### PR TITLE
Add HTTP callback client for communicating status to Studio

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -1,0 +1,111 @@
+package clients
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const max_retries = 3
+const backoff_millis = 200
+
+type CallbackClient struct {
+	httpClient *http.Client
+}
+
+func NewCallbackClient() CallbackClient {
+	return CallbackClient{
+		httpClient: &http.Client{},
+	}
+}
+
+func (c CallbackClient) DoWithRetries(r *http.Request) error {
+	var resp *http.Response
+	var err error
+	for x := 0; x < max_retries; x++ {
+		resp, err = c.httpClient.Do(r)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return nil
+		}
+
+		// Back off to give us more chance of succeeding during a network blip
+		time.Sleep(backoff_millis * time.Millisecond)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to send callback to %q. Error: %q", r.URL.String(), err)
+	}
+	return fmt.Errorf("failed to send callback to %q. Response Status Code: %d", r.URL.String(), resp.StatusCode)
+}
+
+func (c CallbackClient) SendTranscodeStatus(url string, status TranscodeStatus, completionRatio float32) error {
+	tsm := TranscodeStatusMessage{
+		CompletionRatio: completionRatio,
+		Status:          status.String(),
+	}
+
+	j, err := json.Marshal(tsm)
+	if err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(j))
+	if err != nil {
+		return err
+	}
+
+	return c.DoWithRetries(r)
+}
+
+func (c CallbackClient) SendTranscodeStatusError(callbackURL, errorMsg string) error {
+	tsm := TranscodeStatusMessage{
+		Error:  errorMsg,
+		Status: TranscodeStatusError.String(),
+	}
+
+	j, err := json.Marshal(tsm)
+	if err != nil {
+		return err
+	}
+
+	r, err := http.NewRequest(http.MethodPost, callbackURL, bytes.NewReader(j))
+	if err != nil {
+		return err
+	}
+
+	return c.DoWithRetries(r)
+}
+
+// An enum of potential statuses a Transcode job can have
+
+type TranscodeStatus int
+
+const (
+	TranscodeStatusPreparing TranscodeStatus = iota
+	TranscodeStatusTranscoding
+	TranscodeStatusCompleted
+	TranscodeStatusError
+)
+
+type TranscodeStatusMessage struct {
+	CompletionRatio float32 `json:"completion_ratio,omitempty"`
+	Error           string  `json:"error,omitempty"`
+	Retriable       bool    `json:"retriable,omitempty"`
+	Status          string  `json:"status,omitempty"`
+}
+
+func (ts TranscodeStatus) String() string {
+	switch ts {
+	case TranscodeStatusPreparing:
+		return "preparing"
+	case TranscodeStatusTranscoding:
+		return "transcoding"
+	case TranscodeStatusCompleted:
+		return "completed"
+	case TranscodeStatusError:
+		return "error"
+	}
+	return "unknown"
+}

--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -19,7 +19,9 @@ type CallbackClient struct {
 
 func NewCallbackClient() CallbackClient {
 	return CallbackClient{
-		httpClient: &http.Client{},
+		httpClient: &http.Client{
+			Timeout: 5 * time.Second,
+		},
 	}
 }
 

--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/livepeer/catalyst-api/config"
 )
 
 const max_retries = 3
@@ -44,6 +46,7 @@ func (c CallbackClient) SendTranscodeStatus(url string, status TranscodeStatus, 
 	tsm := TranscodeStatusMessage{
 		CompletionRatio: completionRatio,
 		Status:          status.String(),
+		Timestamp:       config.Clock.GetTimestampUTC(),
 	}
 
 	j, err := json.Marshal(tsm)
@@ -61,8 +64,9 @@ func (c CallbackClient) SendTranscodeStatus(url string, status TranscodeStatus, 
 
 func (c CallbackClient) SendTranscodeStatusError(callbackURL, errorMsg string) error {
 	tsm := TranscodeStatusMessage{
-		Error:  errorMsg,
-		Status: TranscodeStatusError.String(),
+		Error:     errorMsg,
+		Status:    TranscodeStatusError.String(),
+		Timestamp: config.Clock.GetTimestampUTC(),
 	}
 
 	j, err := json.Marshal(tsm)
@@ -94,6 +98,7 @@ type TranscodeStatusMessage struct {
 	Error           string  `json:"error,omitempty"`
 	Retriable       bool    `json:"retriable,omitempty"`
 	Status          string  `json:"status,omitempty"`
+	Timestamp       int64   `json:"timestamp"`
 }
 
 func (ts TranscodeStatus) String() string {

--- a/clients/callback_client_test.go
+++ b/clients/callback_client_test.go
@@ -49,7 +49,6 @@ func TestItEventuallyStopsRetrying(t *testing.T) {
 		require.NoError(t, err)
 		require.JSONEq(t, `{"completion_ratio":1, "status":"completed"}`, string(body))
 
-		// Return HTTP error codes the first two times
 		tries += 1
 
 		// Return an error code

--- a/clients/callback_client_test.go
+++ b/clients/callback_client_test.go
@@ -1,0 +1,84 @@
+package clients
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItRetriesOnFailedCallbacks(t *testing.T) {
+	// Counter for the number of retries we've done
+	var tries int
+
+	// Set up a dummy server to receive the callbacks
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that we got the callback we're expecting
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"completion_ratio":1, "status":"completed"}`, string(body))
+
+		// Return HTTP error codes the first two times
+		tries += 1
+		if tries <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		// Return a successful response the third time
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	// Send the callback and confirm the number of times we retried
+	client := NewCallbackClient()
+	require.NoError(t, client.SendTranscodeStatus(svr.URL, TranscodeStatusCompleted, 1))
+	require.Equal(t, 3, tries, "Expected the client to retry on failed callbacks")
+}
+
+func TestItEventuallyStopsRetrying(t *testing.T) {
+	// Counter for the number of retries we've done
+	var tries int
+
+	// Set up a dummy server to receive the callbacks
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that we got the callback we're expecting
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"completion_ratio":1, "status":"completed"}`, string(body))
+
+		// Return HTTP error codes the first two times
+		tries += 1
+
+		// Return an error code
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer svr.Close()
+
+	// Send the callback and confirm the number of times we retried
+	client := NewCallbackClient()
+	err := client.SendTranscodeStatus(svr.URL, TranscodeStatusCompleted, 1)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to send callback")
+	require.Contains(t, err.Error(), "Response Status Code: 500")
+	require.Equal(t, 3, tries, "Expected the client to retry on failed callbacks")
+}
+
+func TestTranscodeStatusErrorNotifcation(t *testing.T) {
+	// Set up a dummy server to receive the callbacks
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that we got the callback we're expecting
+		body, err := ioutil.ReadAll(r.Body)
+		require.NoError(t, err)
+		require.JSONEq(t, `{"error": "something went wrong", "status":"error"}`, string(body))
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	// Send the callback and confirm the number of times we retried
+	client := NewCallbackClient()
+	require.NoError(t, client.SendTranscodeStatusError(svr.URL, "something went wrong"))
+}

--- a/config/config.go
+++ b/config/config.go
@@ -1,3 +1,6 @@
 package config
 
 var Version string
+
+// Used so that we can generate fixed timestamps in tests
+var Clock TimestampGenerator = RealTimestampGenerator{}

--- a/config/timestamp.go
+++ b/config/timestamp.go
@@ -1,0 +1,21 @@
+package config
+
+import "time"
+
+type TimestampGenerator interface {
+	GetTimestampUTC() int64
+}
+
+type RealTimestampGenerator struct{}
+
+func (t RealTimestampGenerator) GetTimestampUTC() int64 {
+	return time.Now().Unix()
+}
+
+type FixedTimestampGenerator struct {
+	Timestamp int64
+}
+
+func (t FixedTimestampGenerator) GetTimestampUTC() int64 {
+	return t.Timestamp
+}


### PR DESCRIPTION
Currently implementing Transcode Status success / error based on spec in https://www.notion.so/livepeer/Technical-Design-Studio-Catalyst-API-for-VOD-Recording-bba2b160efff4ad4963dae2d4e9ff1a2

Completion Outputs block (i.e telling Studio where we've put the files) will come in a separate PR