### PR TITLE
Define new API endpoint + test

### DIFF
--- a/cmd/http-server/http-server.go
+++ b/cmd/http-server/http-server.go
@@ -36,6 +36,7 @@ func StartCatalystAPIRouter() *httprouter.Router {
 	router := httprouter.New()
 
 	router.GET("/ok", middleware.IsAuthorized(handlers.CatalystAPIHandlers.Ok()))
+	router.POST("/api/transcode/file", middleware.IsAuthorized(handlers.CatalystAPIHandlers.TranscodeSegment()))
 	router.POST("/api/vod", middleware.IsAuthorized(handlers.CatalystAPIHandlers.UploadVOD()))
 
 	return router

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -4,6 +4,9 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"strings"
+
+	"github.com/xeipuuv/gojsonschema"
 )
 
 type apiError struct {
@@ -36,4 +39,16 @@ func WriteHTTPUnsupportedMediaType(w http.ResponseWriter, msg string, err error)
 
 func WriteHTTPInternalServerError(w http.ResponseWriter, msg string, err error) apiError {
 	return writeHttpError(w, msg, http.StatusInternalServerError, err)
+}
+
+func WriteHTTPBadBodySchema(where string, w http.ResponseWriter, errors []gojsonschema.ResultError) apiError {
+	sb := strings.Builder{}
+	sb.WriteString("Body validation error in ")
+	sb.WriteString(where)
+	sb.WriteString(" ")
+	for i := 0; i < len(errors); i++ {
+		sb.WriteString(errors[i].String())
+		sb.WriteString(" ")
+	}
+	return writeHttpError(w, sb.String(), http.StatusBadRequest, nil)
 }

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -24,6 +24,44 @@ func (d *CatalystAPIHandlersCollection) Ok() httprouter.Handle {
 	}
 }
 
+func (d *CatalystAPIHandlersCollection) TranscodeSegment() httprouter.Handle {
+	schemaLoader := gojsonschema.NewStringLoader(TranscodeSegmentRequestSchemaDefinition)
+
+	schema, err := gojsonschema.NewSchema(schemaLoader)
+	if err != nil {
+		panic(err)
+	}
+	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		var transcodeRequest TranscodeSegmentRequest
+		payload, err := ioutil.ReadAll(req.Body)
+		if err != nil {
+			errors.WriteHTTPInternalServerError(w, "Cannot read body", err)
+			return
+		}
+		result, err := schema.Validate(gojsonschema.NewBytesLoader(payload))
+		if err != nil {
+			errors.WriteHTTPInternalServerError(w, "body schema validation failed", err)
+			return
+		}
+		if !result.Valid() {
+			errors.WriteHTTPBadBodySchema("TranscodeSegment", w, result.Errors())
+			return
+		}
+		if err := json.Unmarshal(payload, &transcodeRequest); err != nil {
+			errors.WriteHTTPBadRequest(w, "Invalid request payload", err)
+			return
+		}
+		if len(transcodeRequest.Profiles) == 0 {
+			// TODO: Check if this is correct. What if we only do detection?
+			errors.WriteHTTPBadRequest(w, "profiles array must contain at least one encoding profile", nil)
+			return
+		}
+
+		go invokeTestCallback(&transcodeRequest)
+		io.WriteString(w, "OK") // TODO later
+	}
+}
+
 func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 	schemaLoader := gojsonschema.NewStringLoader(`{
 		"type": "object",

--- a/handlers/segment.go
+++ b/handlers/segment.go
@@ -1,0 +1,161 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type EncodedProfile struct {
+	Name         string `json:"name"`
+	Width        int    `json:"width"`
+	Height       int    `json:"height"`
+	Bitrate      int    `json:"bitrate"`
+	FPS          uint   `json:"fps"`
+	FPSDen       uint   `json:"fpsDen"`
+	Profile      string `json:"profile"`
+	GOP          string `json:"gop"`
+	Encoder      string `json:"encoder"`
+	ColorDepth   int    `json:"colorDepth"`
+	ChromaFormat int    `json:"chromaFormat"`
+}
+
+type TranscodeSegmentRequest struct {
+	SourceFile           string           `json:"source_location"`
+	CallbackUrl          string           `json:"callback_url"`
+	ManifestID           string           `json:"manifestID"`
+	StreamID             string           `json:"streamID"`
+	SessionID            string           `json:"sessionID"`
+	StreamKey            string           `json:"streamKey"`
+	Presets              []string         `json:"presets"`
+	ObjectStore          string           `json:"objectStore"`
+	RecordObjectStore    string           `json:"recordObjectStore"`
+	RecordObjectStoreURL string           `json:"recordObjectStoreUrl"`
+	Profiles             []EncodedProfile `json:"profiles"`
+	PreviousSessions     []string         `json:"previousSessions"`
+	Detection            struct {
+		Freq                uint `json:"freq"`
+		SampleRate          uint `json:"sampleRate"`
+		SceneClassification []struct {
+			Name string `json:"name"`
+		} `json:"sceneClassification"`
+	} `json:"detection"`
+	VerificationFreq uint `json:"verificationFreq"`
+}
+
+var TranscodeSegmentRequestSchemaDefinition string = `{
+	"type": "object",
+	"properties": {
+		"source_location": {"type": "string"},
+		"callback_url": {"type": "string"},
+		"manifestID": {"type": "string"},
+		"streamID": {"type": "string"},
+		"sessionID": {"type": "string"},
+		"streamKey": {"type": "string"},
+		"presets": {
+			"items": {"type": "string"},
+			"type": "array"
+		},
+		"objectStore": {"type": "string"},
+		"recordObjectStore": {"type": "string"},
+		"recordObjectStoreUrl": {"type": "string"},
+		"profiles": {
+			"items": {
+				"properties": {
+					"name": {"type": "string"},
+					"width": {"type": "integer"},
+					"height": {"type": "integer"},
+					"bitrate": {"type": "integer"},
+					"fps": {"type": "integer"},
+					"fpsDen": {"type": "integer"},
+					"profile": {"type": "string"},
+					"gop": {"type": "string"},
+					"encoder": {"type": "string"},
+					"colorDepth": {"type": "integer"},
+					"chromaFormat": {"type": "integer"}
+				},
+				"additionalProperties": false,
+				"type": "object",
+				"required": [
+					"name",
+					"width",
+					"height",
+					"bitrate"
+				]
+			},
+			"type": "array"
+		},
+		"previousSessions": {
+			"items": {"type": "string"},
+			"type": "array"
+		},
+		"detection": {
+			"properties": {
+				"freq": {"type": "integer"},
+				"sampleRate": {"type": "integer"},
+				"sceneClassification": {
+					"items": {
+						"properties": {
+							"name": {"type": "string"}
+						},
+						"additionalProperties": false,
+						"type": "object",
+						"required": [
+							"name"
+						]
+					},
+					"type": "array"
+				}
+			},
+			"additionalProperties": false,
+			"type": "object",
+			"required": [
+				"freq",
+				"sampleRate"
+			]
+		},
+		"verificationFreq": {"type": "integer"}
+	},
+	"additionalProperties": false,
+	"required": [
+		"source_location",
+		"callback_url",
+		"manifestID",
+		"profiles",
+		"verificationFreq"
+	]
+}`
+
+type TranscodeSegmentResult struct {
+	SourceFile      string  `json:"source_location"`
+	Status          string  `json:"status"`
+	CompletionRatio float32 `json:"completion_ratio,omitempty"`
+	ErrorMessage    string  `json:"error_message,omitempty"`
+}
+
+func invokeTestCallback(transcodeRequest *TranscodeSegmentRequest) {
+	time.Sleep(30 * time.Millisecond) // takes some time to transcode
+	// invoke callback
+	resultEncoded, err := json.Marshal(&TranscodeSegmentResult{
+		SourceFile:      transcodeRequest.SourceFile,
+		Status:          "error",
+		CompletionRatio: 0.0,
+		ErrorMessage:    "NYI - not yet implemented",
+	})
+	if err != nil {
+		fmt.Printf("ERROR TranscodeSegmentResult to json SourceFile=%s\n", transcodeRequest.SourceFile)
+		return
+	}
+	req, err := http.NewRequest("POST", transcodeRequest.CallbackUrl, bytes.NewBuffer(resultEncoded))
+	req.Header.Set("Content-Type", "application/json")
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		fmt.Printf("ERROR invoking callback %v\n", err)
+		return
+	}
+	resp.Body.Close()
+	// What to do with status of callback?
+}

--- a/handlers/webhook.go
+++ b/handlers/webhook.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/assert"
+)
+
+type WebhookReceiver struct {
+	handler  func(w http.ResponseWriter, req *http.Request, _ httprouter.Params)
+	port     int
+	requests chan []byte
+	router   *httprouter.Router
+	server   *http.Server
+}
+
+func (s *WebhookReceiver) Init() {
+	s.requests = make(chan []byte, 1000)
+	s.router = httprouter.New()
+	if s.handler == nil {
+		s.handler = func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+			payload, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				fmt.Printf("WebhookReceiver error reading req body\n")
+				w.WriteHeader(451)
+				return
+			}
+			w.WriteHeader(200)
+			s.requests <- payload
+		}
+	}
+	s.router.POST("/callback", s.handler)
+	s.server = &http.Server{Addr: fmt.Sprintf("127.0.0.1:%d", s.port), Handler: s.router}
+	go func() {
+		if err := s.server.ListenAndServe(); err != nil {
+			if err.Error() == "http: Server closed" {
+				return // normal exit
+			}
+			fmt.Printf("server.ListenAndServe() %v\n", err)
+		}
+	}()
+}
+
+func (s *WebhookReceiver) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	if err := s.server.Shutdown(ctx); err != nil {
+		fmt.Printf("server.Shutdown() %v\n", err)
+	}
+}
+
+func (s *WebhookReceiver) WaitForCallback(t *testing.T, timeout time.Duration) []byte {
+	select {
+	case data := <-s.requests:
+		return data
+	case <-time.After(timeout):
+		assert.FailNow(t, "WaitForCallback timedout")
+	}
+	return nil
+}
+
+func NewWebhookReceiver(port int) *WebhookReceiver {
+	server := &WebhookReceiver{port: port}
+	server.Init()
+	return server
+}


### PR DESCRIPTION
- New handler `/api/transcode/file` added to `func StartCatalystAPIRouter()`
- Use `gojsonschema` to check input json.
- Just return `OK` for now and invoke callback.
- Testing request json format and required fields.
- Testing is callback invoked by handler.
