### PR TITLE
Return JSON validation errors

### DIFF
--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/livepeer/catalyst-api/clients"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -11,6 +10,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/livepeer/catalyst-api/clients"
 
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/errors"
@@ -102,7 +103,11 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			errors.WriteHTTPInternalServerError(w, "Cannot validate payload", err)
 			return
 		} else if !result.Valid() {
-			errors.WriteHTTPBadRequest(w, "Invalid request payload", nil)
+			var errString string
+			for i, desc := range result.Errors() {
+				errString += fmt.Sprintf("%d - %s, ", i, desc)
+			}
+			errors.WriteHTTPBadRequest(w, "Invalid request payload: "+strings.TrimSuffix(errString, ", "), nil)
 			return
 		} else if err := json.Unmarshal(payload, &uploadVODRequest); err != nil {
 			errors.WriteHTTPBadRequest(w, "Invalid request payload", err)


### PR DESCRIPTION
This is to make testing / integrating easier by returning a list of the reasons validation failed in the HTTP response