### PR TITLE
Parse Mist auth response correctly

### DIFF
--- a/handlers/client.go
+++ b/handlers/client.go
@@ -325,12 +325,15 @@ func validateAuth(resp string, err error) error {
 		return err
 	}
 	r := struct {
-		Authorize map[string]string `json:"authorize"`
+		Authorize struct {
+			Status string `json:"status"`
+		} `json:"authorize"`
 	}{}
+
 	if err := json.Unmarshal([]byte(resp), &r); err != nil {
 		return err
 	}
-	if r.Authorize["status"] != "OK" {
+	if r.Authorize.Status != "OK" {
 		return errors.New("authorization to Mist API failed")
 	}
 	return nil


### PR DESCRIPTION
This was failing because one of the fields isn't a string but we were trying to parse it as one. 

Switched to only parsing the field we care about, which should be safer if other fields appear here in the future.
```json
{
  "local": true,
  "status": "OK"
}
```