### PR TITLE
Define pipeline constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,5 +23,7 @@ func init() {
 
 // Prefixes used in Mist stream names to let us determine whether a given "stream" in Mist is being used
 // for the segmenting or transcoding phase
+const SEGMENTING_PREFIX = "catalyst_vod_"
 const SOURCE_PREFIX = "tr_src_"
 const RENDITION_PREFIX = "tr_rend_+"
+const RECORDING_PREFIX = "video"

--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -35,17 +35,15 @@ func (d *MistCallbackHandlersCollection) TriggerPushEnd(w http.ResponseWriter, r
 	// actualDestination := lines[3]
 	// pushStatus := lines[5]
 
-	// Determine if the PUSH that has finished was happening during the segmenting or transcoding phase
-	if isTranscodeStream(streamName) {
+	switch streamNameToPipeline(streamName) {
+	case Transcoding:
 		// TODO: Left commented for illustration of the alternate code path here as this is the next piece we'll pull out of https://github.com/livepeer/catalyst-api/pull/30
 		// d.TranscodingPushEnd(w, req, streamName, destination, actualDestination, pushStatus)
-	} else {
+	case Segmenting:
 		d.SegmentingPushEnd(w, req, streamName)
+	default:
+		// Not related to API logic
 	}
-}
-
-func isTranscodeStream(streamName string) bool {
-	return strings.HasPrefix(streamName, config.RENDITION_PREFIX)
 }
 
 func (d *MistCallbackHandlersCollection) SegmentingPushEnd(w http.ResponseWriter, req *http.Request, streamName string) {

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
@@ -121,3 +122,25 @@ func stubTranscodingCallbacksForStudio(callbackURL string) {
 		return
 	}
 }
+
+// streamNameToPipeline returns pipeline that given stream belongs to. We use different stream name prefixes for each pipeline.
+func streamNameToPipeline(name string) PipelineId {
+	if strings.HasPrefix(name, config.RENDITION_PREFIX) {
+		// config.SOURCE_PREFIX also belongs to Transcoding. So far no triggers installed for source streams.
+		return Transcoding
+	} else if strings.HasPrefix(name, config.SEGMENTING_PREFIX) {
+		return Segmenting
+	} else if strings.HasPrefix(name, config.RECORDING_PREFIX) {
+		return Recording
+	}
+	return Unrelated
+}
+
+type PipelineId = int
+
+const (
+	Unrelated PipelineId = iota
+	Segmenting
+	Transcoding
+	Recording
+)

--- a/handlers/misttriggers/triggers_test.go
+++ b/handlers/misttriggers/triggers_test.go
@@ -1,0 +1,24 @@
+package misttriggers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPipelineId(t *testing.T) {
+	records := []StreamSample{
+		{"catalyst_vod_110442dc-5b7d-4725-a92f-231677ac6167", Segmenting},
+		{"bigBucksBunny1080p", Unrelated},
+		{"tr_rend_+10a40c88-dcf7-4d77-8ac2-4ef07cb23807", Transcoding},
+		{"video2b1e43cd-f0df-4fc9-be6f-8bd91f9758a9", Recording},
+	}
+	for _, record := range records {
+		require.Equal(t, record.expected, streamNameToPipeline(record.streamName), record.streamName)
+	}
+}
+
+type StreamSample struct {
+	streamName string
+	expected   PipelineId
+}

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -13,6 +13,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/cache"
 	"github.com/livepeer/catalyst-api/clients"
+	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/xeipuuv/gojsonschema"
 )
@@ -87,7 +88,7 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			return
 		}
 
-		streamName := randomStreamName("catalyst_vod_")
+		streamName := randomStreamName(config.SEGMENTING_PREFIX)
 		cache.DefaultStreamCache.Segmenting.Store(streamName, uploadVODRequest.CallbackUrl)
 
 		// process the request


### PR DESCRIPTION
The number of required functions are growing. Preparing for recording pipeline changes, lets define new constants for each pipeline. In trigger handling we can use stream prefix to determine to which function a stream belongs to.

Changes:
- Define pipeline constants
- Triggers: Use switch to branch to proper pipeline logic based on stream name
- Move string constant from UploadVOD() to config