### PR TITLE
config: MistProcLivepeer in /usr/local/bin/

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ var Version string
 var Clock TimestampGenerator = RealTimestampGenerator{}
 
 // Path to Mist's "Livepeer" process that we shell out to for the transcoding
-const PathMistProcLivepeer = "/usr/bin/MistProcLivepeer"
+const PathMistProcLivepeer = "/usr/local/bin/MistProcLivepeer"
 
 // Port that the local Broadcaster runs on
 const DefaultBroadcasterPort = 8935


### PR DESCRIPTION
See livepeer/catalyst@83d3bcd4d8aa52795cb27883605bcf7e5a0d3dcc

MistProcLivepeer needs to be invoked in /usr/local/bin after the above commit that changes where MistController is invoked from.