### PR TITLE
Run MistInHLS mist binary on push end for each rendition

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,7 +12,7 @@ var Version string
 var Clock TimestampGenerator = RealTimestampGenerator{}
 
 // Path to Mist's binaries that we shell out to for transcoding and header file creation
-const PathMistDir = "/usr/local/bin"
+var PathMistDir = "/usr/local/bin"
 
 // Port that the local Broadcaster runs on
 const DefaultBroadcasterPort = 8935

--- a/config/config.go
+++ b/config/config.go
@@ -11,8 +11,8 @@ var Version string
 // Used so that we can generate fixed timestamps in tests
 var Clock TimestampGenerator = RealTimestampGenerator{}
 
-// Path to Mist's "Livepeer" process that we shell out to for the transcoding
-const PathMistProcLivepeer = "/usr/local/bin/MistProcLivepeer"
+// Path to Mist's binaries that we shell out to for transcoding and header file creation
+const PathMistDir = "/usr/local/bin"
 
 // Port that the local Broadcaster runs on
 const DefaultBroadcasterPort = 8935

--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -80,7 +80,7 @@ func (d *MistCallbackHandlersCollection) TranscodingPushEnd(w http.ResponseWrite
 	}
 
 	if err := createDtsh(actualDestination); err != nil {
-		_ = config.Logger.Log("msg", "createDtsh failed", "err", err)
+		_ = config.Logger.Log("msg", "createDtsh failed", "err", err, "destination", actualDestination)
 	}
 
 	// We do not delete triggers as source stream is wildcard stream: RENDITION_PREFIX
@@ -166,8 +166,9 @@ func createDtsh(destination string) error {
 		return err
 	}
 	go func() {
-		err := headerPrepare.Wait()
-		fmt.Println("exec headerPrepare:", err)
+		if err := headerPrepare.Wait(); err != nil {
+			_ = config.Logger.Log("msg", "createDtsh return code", "code", err, "destination", destination)
+		}
 	}()
 	return nil
 }

--- a/handlers/misttriggers/triggers_test.go
+++ b/handlers/misttriggers/triggers_test.go
@@ -121,7 +121,7 @@ func TestMistInHLSStart(t *testing.T) {
 	require.IsType(t, &fs.PathError{}, err)
 
 	script := path.Join(dir, "MistInHLS")
-	os.WriteFile(script, []byte("#!/bin/sh\necho livepeer\n"), 0744)
+	_ = os.WriteFile(script, []byte("#!/bin/sh\necho livepeer\n"), 0744)
 
 	err = createDtsh(destination)
 	require.NoError(t, err)

--- a/handlers/misttriggers/triggers_test.go
+++ b/handlers/misttriggers/triggers_test.go
@@ -4,8 +4,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"io"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -105,6 +109,23 @@ func TestRecordingCompleted(t *testing.T) {
 	case <-time.After(1 * time.Second):
 		require.FailNow(t, "no callback happened")
 	}
+}
+
+func TestMistInHLSStart(t *testing.T) {
+	dir := t.TempDir()
+	config.PathMistDir = dir
+	destination := "unused"
+	err := createDtsh("invalid://user:abc{DEf1=lp@example.com:5432/db?sslmode=require")
+	require.IsType(t, &url.Error{}, err)
+	err = createDtsh(destination)
+	require.IsType(t, &fs.PathError{}, err)
+
+	script := path.Join(dir, "MistInHLS")
+	os.WriteFile(script, []byte("#!/bin/sh\necho livepeer\n"), 0744)
+
+	err = createDtsh(destination)
+	require.NoError(t, err)
+	time.Sleep(50 * time.Millisecond)
 }
 
 type StreamSample struct {

--- a/subprocess/logging.go
+++ b/subprocess/logging.go
@@ -1,0 +1,50 @@
+package subprocess
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+
+	"github.com/livepeer/catalyst-api/config"
+)
+
+func streamOutput(src io.Reader, out io.Writer) {
+	s := bufio.NewReader(src)
+	for {
+		var line []byte
+		line, err := s.ReadSlice('\n')
+		if err == io.EOF && len(line) == 0 {
+			break
+		}
+		if err == io.EOF {
+			_ = config.Logger.Log("msg", "streamOutput() improper termination", "line", line)
+			return
+		}
+		if err != nil {
+			_ = config.Logger.Log("msg", "streamOutput ReadSlice error", "err", err)
+			return
+		}
+		_, err = out.Write(line)
+		if err != nil {
+			_ = config.Logger.Log("msg", "streamOutput out.Write error", "err", err)
+			return
+		}
+	}
+}
+
+// LogOutputs starts new goroutines to print cmd's stdout & stderr to our stdout & stderr
+func LogOutputs(cmd *exec.Cmd) error {
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("Failed to open stderr pipe: %s", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("Failed to open stdout pipe: %s", err)
+	}
+	go streamOutput(stderrPipe, os.Stderr)
+	go streamOutput(stdoutPipe, os.Stdout)
+	return nil
+}


### PR DESCRIPTION
Config `config.PathMistDir` now contains path to MistServer binaries directory. We use this info to construct absolute path to `MistProcLivepeer` and `MistInHLS`.

`MistInHLS` is used to create `.dtsh` headers file alongside playlist and segments created on s3.

https://github.com/DDVTECH/mistserver/issues/117 is created for tracking MistServer issue that will obsolete this extra step of running `MistInHLS`.

Add subprocess/logging.go