### PR TITLE
Upload transcodes to output target location rather than input location

### DIFF
--- a/cache/segmenting.go
+++ b/cache/segmenting.go
@@ -11,8 +11,8 @@ type SegmentingCache struct {
 
 type StreamInfo struct {
 	SourceFile            string
-	CallbackUrl           string
-	UploadDir             string
+	CallbackURL           string
+	UploadURL             string
 	AccessToken           string
 	TranscodeAPIUrl       string
 	HardcodedBroadcasters string
@@ -29,7 +29,7 @@ func (c *SegmentingCache) GetCallbackUrl(streamName string) string {
 	defer c.mutex.Unlock()
 	info, ok := c.cache[streamName]
 	if ok {
-		return info.CallbackUrl
+		return info.CallbackURL
 	}
 	return ""
 }
@@ -48,8 +48,8 @@ func (c *SegmentingCache) Store(streamName string, streamInfo StreamInfo) {
 	c.mutex.Lock()
 	c.cache[streamName] = StreamInfo{
 		SourceFile:            streamInfo.SourceFile,
-		CallbackUrl:           streamInfo.CallbackUrl,
-		UploadDir:             streamInfo.UploadDir,
+		CallbackURL:           streamInfo.CallbackURL,
+		UploadURL:             streamInfo.UploadURL,
 		AccessToken:           streamInfo.AccessToken,
 		TranscodeAPIUrl:       streamInfo.TranscodeAPIUrl,
 		HardcodedBroadcasters: streamInfo.HardcodedBroadcasters,

--- a/cache/segmenting_test.go
+++ b/cache/segmenting_test.go
@@ -11,7 +11,7 @@ func TestStoreAndRetrieveSegmenting(t *testing.T) {
 	c.Segmenting.Store(
 		"some-stream-name",
 		StreamInfo{
-			CallbackUrl: "http://some-callback-url.com",
+			CallbackURL: "http://some-callback-url.com",
 		},
 	)
 	require.Equal(t, "http://some-callback-url.com", c.Segmenting.GetCallbackUrl("some-stream-name"))
@@ -22,7 +22,7 @@ func TestStoreAndRemoveSegmenting(t *testing.T) {
 	c.Segmenting.Store(
 		"some-stream-name",
 		StreamInfo{
-			CallbackUrl: "http://some-callback-url.com",
+			CallbackURL: "http://some-callback-url.com",
 		},
 	)
 	require.Equal(t, "http://some-callback-url.com", c.Segmenting.GetCallbackUrl("some-stream-name"))

--- a/handlers/misttriggers/live_tracklist.go
+++ b/handlers/misttriggers/live_tracklist.go
@@ -178,6 +178,7 @@ func (d *MistCallbackHandlersCollection) TriggerLiveTrackList(w http.ResponseWri
 	sort.Sort(sort.Reverse(ByBitrate(trackList)))
 	manifest := createPlaylist(multivariantPlaylist, trackList)
 	path := fmt.Sprintf("%s/%s-master.m3u8", rootPathUrl.String(), uniqueName)
+
 	err = uploadPlaylist(path, manifest)
 	if err != nil {
 		errors.WriteHTTPInternalServerError(w, "Failed to upload multivariant master playlist: "+streamName, err)

--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -43,7 +43,6 @@ func (d *MistCallbackHandlersCollection) TriggerPushEnd(w http.ResponseWriter, r
 
 	switch streamNameToPipeline(streamName) {
 	case Transcoding:
-		// TODO: Left commented for illustration of the alternate code path here as this is the next piece we'll pull out of https://github.com/livepeer/catalyst-api/pull/30
 		d.TranscodingPushEnd(w, req, streamName, destination, actualDestination, pushStatus)
 	case Segmenting:
 		d.SegmentingPushEnd(w, req, streamName)
@@ -87,7 +86,6 @@ func (d *MistCallbackHandlersCollection) TranscodingPushEnd(w http.ResponseWrite
 	// We do not delete triggers as source stream is wildcard stream: RENDITION_PREFIX
 	cache.DefaultStreamCache.Transcoding.RemovePushDestination(streamName, destination)
 	if cache.DefaultStreamCache.Transcoding.AreDestinationsEmpty(streamName) {
-		// TODO: Fill this in properly
 		if err := clients.DefaultCallbackClient.SendTranscodeStatusCompleted(info.CallbackUrl, clients.InputVideo{}, []clients.OutputVideo{}); err != nil {
 			_ = config.Logger.Log("msg", "Error sending transcode completed status in TranscodingPushEnd", "err", err)
 		}
@@ -145,11 +143,12 @@ func (d *MistCallbackHandlersCollection) SegmentingPushEnd(w http.ResponseWriter
 	si := cache.DefaultStreamCache.Segmenting.Get(streamName)
 	transcodeRequest := handlers.TranscodeSegmentRequest{
 		SourceFile:            si.SourceFile,
-		CallbackUrl:           si.CallbackUrl,
+		CallbackURL:           si.CallbackURL,
 		AccessToken:           si.AccessToken,
 		TranscodeAPIUrl:       si.TranscodeAPIUrl,
 		HardcodedBroadcasters: si.HardcodedBroadcasters,
 		SourceStreamInfo:      infoJson,
+		UploadURL:             si.UploadURL,
 	}
 	go func() {
 		err := handlers.RunTranscodeProcess(d.MistClient, transcodeRequest)

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -36,6 +36,7 @@ func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
 		_ = config.Logger.Log(
 			"msg", "Received Mist Trigger",
 			"trigger_name", triggerName,
+			"payload", string(payload),
 		)
 
 		switch triggerName {

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -91,8 +91,8 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 		streamName := config.RandomStreamName(config.SEGMENTING_PREFIX)
 		cache.DefaultStreamCache.Segmenting.Store(streamName, cache.StreamInfo{
 			SourceFile:            uploadVODRequest.Url,
-			CallbackUrl:           uploadVODRequest.CallbackUrl,
-			UploadDir:             uploadVODRequest.OutputLocations[0].URL,
+			CallbackURL:           uploadVODRequest.CallbackUrl,
+			UploadURL:             uploadVODRequest.OutputLocations[0].URL,
 			AccessToken:           uploadVODRequest.AccessToken,
 			TranscodeAPIUrl:       uploadVODRequest.TranscodeAPIUrl,
 			HardcodedBroadcasters: uploadVODRequest.HardcodedBroadcasters,


### PR DESCRIPTION
Puts all transcoded segments + manifests under a `transcoded/` dir, rather than alongside the source MP4.

Doesn't account for multiple output locations yet, but is enough for us to test with.

![image](https://user-images.githubusercontent.com/907370/195720084-51ba116c-2c31-41de-9ec6-0e8b673e8c89.png)
