### PR TITLE
handlers/upload: use PUSH_END trigger as configured in Mist config

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -117,9 +117,6 @@ func (d *CatalystAPIHandlersCollection) processUploadVOD(streamName, sourceURL, 
 	if err := d.MistClient.AddStream(streamName, sourceURL); err != nil {
 		return err
 	}
-	if err := d.MistClient.AddTrigger(streamName, "PUSH_END"); err != nil {
-		return err
-	}
 	if err := d.MistClient.PushStart(streamName, targetURL); err != nil {
 		return err
 	}


### PR DESCRIPTION
We don't need to dynamically add PUSH_END trigger in catalyst-api - this results in double the amount of transcode renditions as Mist iterates through the triggers list.

#/Fix https://github.com/livepeer/catalyst/issues/201
#/Fix https://github.com/livepeer/catalyst-api/issues/60