### PR TITLE
Expire objects from cache after 1hr

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func main() {
 
 	// Send "keepalive" heartbeats while transcodes are ongoing
 	heartbeatStop := make(chan bool)
-	go cache.DefaultStreamCache.Transcoding.SendTranscodingHeartbeats(15*time.Second, heartbeatStop)
+	go cache.DefaultStreamCache.Transcoding.SendTranscodingHeartbeats(15*time.Second, time.Hour, heartbeatStop)
 	defer func() { heartbeatStop <- true }()
 
 	if err := api.ListenAndServe(*port, *mistPort, *mistHttpPort, *apiToken); err != nil {


### PR DESCRIPTION
This should stop us from hammering Studio with useless callbacks if there are cases where we're not correctly removing completed / errored jobs from the cache.

We can also monitor the logs for the logged message to figure out if this is happening.