### PR TITLE
handlers: allow hardcoded B to be used by MistProcLivepeer

### DIFF
--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -169,13 +169,12 @@ func (d *MistCallbackHandlersCollection) SegmentingPushEnd(w http.ResponseWriter
 
 	si := cache.DefaultStreamCache.Segmenting.Get(p.StreamName)
 	transcodeRequest := handlers.TranscodeSegmentRequest{
-		SourceFile:            si.SourceFile,
-		CallbackURL:           si.CallbackURL,
-		AccessToken:           si.AccessToken,
-		TranscodeAPIUrl:       si.TranscodeAPIUrl,
-		HardcodedBroadcasters: si.HardcodedBroadcasters,
-		SourceStreamInfo:      infoJson,
-		UploadURL:             si.UploadURL,
+		SourceFile:       si.SourceFile,
+		CallbackURL:      si.CallbackURL,
+		AccessToken:      si.AccessToken,
+		TranscodeAPIUrl:  si.TranscodeAPIUrl,
+		SourceStreamInfo: infoJson,
+		UploadURL:        si.UploadURL,
 	}
 	go func() {
 		err := handlers.RunTranscodeProcess(d.MistClient, transcodeRequest)

--- a/handlers/transcode.go
+++ b/handlers/transcode.go
@@ -21,15 +21,14 @@ import (
 )
 
 type TranscodeSegmentRequest struct {
-	SourceFile            string                 `json:"source_location"`
-	CallbackURL           string                 `json:"callback_url"`
-	UploadURL             string                 `json:"upload_url"`
-	StreamKey             string                 `json:"streamKey"`
-	AccessToken           string                 `json:"accessToken"`
-	TranscodeAPIUrl       string                 `json:"transcodeAPIUrl"`
-	HardcodedBroadcasters string                 `json:"hardcodedBroadcasters"`
-	Profiles              []cache.EncodedProfile `json:"profiles"`
-	Detection             struct {
+	SourceFile      string                 `json:"source_location"`
+	CallbackURL     string                 `json:"callback_url"`
+	UploadURL       string                 `json:"upload_url"`
+	StreamKey       string                 `json:"streamKey"`
+	AccessToken     string                 `json:"accessToken"`
+	TranscodeAPIUrl string                 `json:"transcodeAPIUrl"`
+	Profiles        []cache.EncodedProfile `json:"profiles"`
+	Detection       struct {
 		Freq                uint `json:"freq"`
 		SampleRate          uint `json:"sampleRate"`
 		SceneClassification []struct {
@@ -195,10 +194,8 @@ func configForSubprocess(req TranscodeSegmentRequest, inputStreamName, outputStr
 		} else {
 			apiUrl = config.DefaultCustomAPIUrl
 		}
-	} else if req.HardcodedBroadcasters != "" {
-		hardcodedBroadcasters = req.HardcodedBroadcasters
 	} else {
-		hardcodedBroadcasters = ""
+		hardcodedBroadcasters = fmt.Sprintf(`[{"address":"http://127.0.0.1:%d"}]`, config.DefaultBroadcasterPort)
 	}
 	conf := ProcLivepeerConfig{
 		AccessToken:           req.AccessToken,

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -29,9 +29,8 @@ type UploadVODRequest struct {
 			TranscodedSegments bool `json:"transcoded_segments"`
 		} `json:"outputs,omitempty"`
 	} `json:"output_locations,omitempty"`
-	AccessToken           string `json:"accessToken"`
-	TranscodeAPIUrl       string `json:"transcodeAPIUrl"`
-	HardcodedBroadcasters string `json:"hardcodedBroadcasters"`
+	AccessToken     string `json:"accessToken"`
+	TranscodeAPIUrl string `json:"transcodeAPIUrl"`
 }
 
 func HasContentType(r *http.Request, mimetype string) bool {
@@ -90,12 +89,11 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 		}
 		streamName := config.RandomStreamName(config.SEGMENTING_PREFIX)
 		cache.DefaultStreamCache.Segmenting.Store(streamName, cache.StreamInfo{
-			SourceFile:            uploadVODRequest.Url,
-			CallbackURL:           uploadVODRequest.CallbackUrl,
-			UploadURL:             uploadVODRequest.OutputLocations[0].URL,
-			AccessToken:           uploadVODRequest.AccessToken,
-			TranscodeAPIUrl:       uploadVODRequest.TranscodeAPIUrl,
-			HardcodedBroadcasters: uploadVODRequest.HardcodedBroadcasters,
+			SourceFile:      uploadVODRequest.Url,
+			CallbackURL:     uploadVODRequest.CallbackUrl,
+			UploadURL:       uploadVODRequest.OutputLocations[0].URL,
+			AccessToken:     uploadVODRequest.AccessToken,
+			TranscodeAPIUrl: uploadVODRequest.TranscodeAPIUrl,
 		})
 
 		// process the request


### PR DESCRIPTION
* remove harcoded-broadcaster fields in the incoming request as it is not an option that will be used
* add hardcoded-broadcaster as the fallback option if access-token is not provided in the incoming request