### PR TITLE
Don't fail codecov if nothing significant has changed

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.1%
+        base: auto 


### PR DESCRIPTION
Trying to avoid this: 
<img width="782" alt="image" src="https://user-images.githubusercontent.com/907370/196652784-5308d7c7-4b0d-4172-bcca-7bf8fd4d5d14.png">

(seen on most recent commit to `main` https://github.com/livepeer/catalyst-api/commit/a637409b81b9342a4246694e1e7048d18c57368f)