### PR TITLE
handlers: force mp4 override for source URLs

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -112,6 +112,8 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 }
 
 func (d *CatalystAPIHandlersCollection) processUploadVOD(streamName, sourceURL, targetURL string) error {
+	// TODO: remove this logic to force input URLs to mp4/mov format
+	sourceURL = "mp4:" + sourceURL
 	if err := d.MistClient.AddStream(streamName, sourceURL); err != nil {
 		return err
 	}


### PR DESCRIPTION
Studio is not expected to know the extension types of the files uploaded by the end user. As such, Studio can provide urls without any file extensions like mp4/mov. However, Mist requires file extensions to guess what type of input process to spawn (e.g. MistInMP4).

For now, we only care about mp4/mov file input - so we force all input URLs to mp4 format by using the "mp4:" override in front of an URL identifier so the it reads: "mp4:s3+http://example-url.com/video"