### PR TITLE
Generate source segment URLs

### DIFF
--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -1,0 +1,47 @@
+package transcode
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/grafov/m3u8"
+)
+
+func GetSourceSegmentURLs(sourceManifestURL string, manifest io.Reader) ([]string, error) {
+	// Parse the source manifest
+	playlist, playlistType, err := m3u8.DecodeFrom(manifest, true)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding manifest: %s", err)
+	}
+
+	// We shouldn't ever receive Master playlists from the previous section
+	if playlistType != m3u8.MEDIA {
+		return nil, fmt.Errorf("received non-Media manifest, but currently only Media playlists are supported")
+	}
+
+	// The check above means we should be able to cast to the correct type
+	mediaPlaylist, ok := playlist.(*m3u8.MediaPlaylist)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse playlist as MediaPlaylist: %s", err)
+	}
+
+	// Loop over each segment and convert it from a relative to a full ObjectStore-compatible URL
+	var urls []string
+	for _, segment := range mediaPlaylist.Segments {
+		// The segments list is a ring buffer - see https://github.com/grafov/m3u8/issues/140
+		// and so we only know we've hit the end of the list when we find a nil element
+		if segment == nil {
+			break
+		}
+
+		urls = append(urls, manifestURLToSegmentURL(sourceManifestURL, segment.URI))
+	}
+
+	return urls, nil
+}
+
+func manifestURLToSegmentURL(manifestURL, segmentFilename string) string {
+	i := strings.LastIndex(manifestURL, "/")
+	return manifestURL[:i] + "/" + segmentFilename
+}

--- a/transcode/manifest_test.go
+++ b/transcode/manifest_test.go
@@ -1,0 +1,23 @@
+package transcode
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSourceSegmentsURLsFailsWhenItCantParseTheManifest(t *testing.T) {
+	// Check it fails with a parsing error
+	_, err := GetSourceSegmentURLs("/tmp/something/x.m3u8", strings.NewReader("This isn't a manifest file!"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error decoding manifest")
+}
+
+func TestItCanConvertRelativeURLsToOSURLs(t *testing.T) {
+	u := manifestURLToSegmentURL("/tmp/file/something.m3u8", "001.ts")
+	require.Equal(t, "/tmp/file/001.ts", u)
+
+	u = manifestURLToSegmentURL("s3+https://REDACTED:REDACTED@storage.googleapis.com/something/output.m3u8", "001.ts")
+	require.Equal(t, "s3+https://REDACTED:REDACTED@storage.googleapis.com/something/001.ts", u)
+}

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -1,7 +1,9 @@
 package transcode
 
 import (
+	"bytes"
 	"fmt"
+	"io"
 
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
@@ -24,9 +26,21 @@ func RunTranscodeProcess(sourceManifestOSURL, targetManifestOSURL string) error 
 
 	// TODO: Generate the master + rendition output manifests
 
-	// TODO: Push the segments through the transcoder
+	// Iterate through the segment URLs and transcode them
 	for _, u := range urls {
-		_ = config.Logger.Log("msg", "TODO: Downloading source segment", "url", u)
+		rc, err := clients.DownloadOSURL(u)
+		if err != nil {
+			return fmt.Errorf("failed to download source segment %q: %s", u, err)
+		}
+
+		// Download and read the segment, log the size in bytes and discard for now
+		// TODO: Push the segments through the transcoder
+		buf := &bytes.Buffer{}
+		nRead, err := io.Copy(buf, rc)
+		if err != nil {
+			return fmt.Errorf("failed to read source segment data %q: %s", u, err)
+		}
+		_ = config.Logger.Log("msg", "downloaded source segment", "url", u, "size_bytes", nRead, "error", err)
 	}
 
 	// TODO: Upload the output segments

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -3,7 +3,6 @@ package transcode
 import (
 	"fmt"
 
-	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 )
@@ -14,16 +13,23 @@ func RunTranscodeProcess(sourceManifestOSURL, targetManifestOSURL string) error 
 	// Download the source manifest
 	rc, err := clients.DownloadOSURL(sourceManifestOSURL)
 	if err != nil {
-		return fmt.Errorf("error downloading manifest from %q: %s", sourceManifestOSURL, err)
+		return fmt.Errorf("error downloading manifest: %s", err)
 	}
 
-	// Parse the source manifest
-	playlist, _, err := m3u8.DecodeFrom(rc, false)
+	// Generate the full segment URLs from the manifest
+	urls, err := GetSourceSegmentURLs(sourceManifestOSURL, rc)
 	if err != nil {
-		return fmt.Errorf("error decoding manifest from %q: %s", sourceManifestOSURL, err)
+		return fmt.Errorf("error generating source segment URLs: %s", err)
 	}
 
-	// For now, just log out the manifest
-	_ = config.Logger.Log("msg", "Parsed source manifest", "manifest", playlist.String())
+	// TODO: Generate the master + rendition output manifests
+
+	// TODO: Push the segments through the transcoder
+	for _, u := range urls {
+		_ = config.Logger.Log("msg", "TODO: Downloading source segment", "url", u)
+	}
+
+	// TODO: Upload the output segments
+
 	return nil
 }

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -19,15 +19,27 @@ const exampleManifest = `#EXTM3U
 #EXT-X-ENDLIST`
 
 func TestItCanParseAValidManifest(t *testing.T) {
-	// Create a temporary file on the local filesystem
-	f, err := os.CreateTemp(os.TempDir(), "manifest*.m3u8")
+	dir := os.TempDir()
+
+	// Create temporary manifest + segment files on the local filesystem
+	manifestFile, err := os.CreateTemp(dir, "manifest-*.m3u8")
+	require.NoError(t, err)
+
+	segment0, err := os.Create(dir + "/0.ts")
+	require.NoError(t, err)
+
+	segment1, err := os.Create(dir + "/5000.ts")
 	require.NoError(t, err)
 
 	// Write some data to it
-	_, err = f.WriteString(exampleManifest)
+	_, err = manifestFile.WriteString(exampleManifest)
+	require.NoError(t, err)
+	_, err = segment0.WriteString("segment data")
+	require.NoError(t, err)
+	_, err = segment1.WriteString("lots of segment data")
 	require.NoError(t, err)
 
 	// Check we don't get an error downloading or parsing it
-	err = RunTranscodeProcess(f.Name(), "/tmp/target.m3u8")
+	err = RunTranscodeProcess(manifestFile.Name(), "/tmp/target.m3u8")
 	require.NoError(t, err)
 }

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -15,31 +15,8 @@ const exampleManifest = `#EXTM3U
 #EXTINF:10.4160000000,
 0.ts
 #EXTINF:5.3340000000,
-5000.ts`
-
-func TestItFailsWhenTheURLDoesntExist(t *testing.T) {
-	err := RunTranscodeProcess("/some/fake/url.m3u8", "/tmp/target.m3u8")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error downloading manifest")
-	require.Contains(t, err.Error(), "failed to read from OS URL")
-	require.Contains(t, err.Error(), "/some/fake/url.m3u8")
-}
-
-func TestItFailsWhenItCantParseTheManifest(t *testing.T) {
-	// Create a temporary file on the local filesystem
-	f, err := os.CreateTemp(os.TempDir(), "manifest*.m3u8")
-	require.NoError(t, err)
-
-	// Write some data to it
-	_, err = f.WriteString("This isn't a manifest file!")
-	require.NoError(t, err)
-
-	// Check it fails with a parsing error
-	err = RunTranscodeProcess(f.Name(), "/tmp/target.m3u8")
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "error decoding manifest")
-	require.Contains(t, err.Error(), f.Name())
-}
+5000.ts
+#EXT-X-ENDLIST`
 
 func TestItCanParseAValidManifest(t *testing.T) {
 	// Create a temporary file on the local filesystem


### PR DESCRIPTION
Small change to split the manifest code out into its own file and iterate through the segment list, generating ObjectStore URLs that can be used by the transcoder and downloading those files into memory