### PR TITLE
Populate source stream format info

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -216,15 +216,16 @@ type TranscodeStatusMessage struct {
 }
 
 type VideoTrack struct {
-	Width       int    `json:"width,omitempty"`
-	Height      int    `json:"height,omitempty"`
-	PixelFormat string `json:"pixel_format,omitempty"`
-	FPS         int    `json:"fps,omitempty"`
+	Width       int     `json:"width,omitempty"`
+	Height      int     `json:"height,omitempty"`
+	PixelFormat string  `json:"pixel_format,omitempty"`
+	FPS         float64 `json:"fps,omitempty"`
 }
 
 type AudioTrack struct {
 	Channels   int `json:"channels,omitempty"`
 	SampleRate int `json:"sample_rate,omitempty"`
+	SampleBits int `json:"sample_bits,omitempty"`
 }
 
 type InputTrack struct {

--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -31,16 +31,16 @@ type MistClient struct {
 
 type MistStreamInfoTrack struct {
 	Codec   string `json:"codec,omitempty"`
-	Firstms int    `json:"firstms,omitempty"`
+	Firstms int64  `json:"firstms,omitempty"`
 	Idx     int    `json:"idx,omitempty"`
 	Init    string `json:"init,omitempty"`
 	Lastms  int64  `json:"lastms,omitempty"`
 	Maxbps  int    `json:"maxbps,omitempty"`
 	Trackid int    `json:"trackid,omitempty"`
 	Type    string `json:"type,omitempty"`
+	Bps     int    `json:"bps,omitempty"`
 
 	// Audio Only Fields
-	Bps      int `json:"bps,omitempty"`
 	Channels int `json:"channels,omitempty"`
 	Rate     int `json:"rate,omitempty"`
 	Size     int `json:"size,omitempty"`

--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -112,11 +112,33 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 			}
 		} else {
 			// TODO: Fill in with real values once we have them back from the transcoder
+			inputInfo := clients.InputVideo{
+				Format:    "mp4", // hardcoded as mist stream is in dtsc format.
+				Duration:  float64(p.StreamMediaDurationMillis) / 1000.0,
+				SizeBytes: p.WrittenBytes,
+			}
+			for _, track := range streamInfo.Meta.Tracks {
+				inputInfo.Tracks = append(inputInfo.Tracks, clients.InputTrack{
+					Type:         track.Type,
+					Codec:        track.Codec,
+					Bitrate:      track.Bps * 8,
+					DurationSec:  float64(track.Lastms-track.Firstms) / 1000.0,
+					StartTimeSec: float64(track.Firstms) / 1000.0,
+					VideoTrack: clients.VideoTrack{
+						Width:  track.Width,
+						Height: track.Height,
+						FPS:    float64(track.Fpks) / 1000.0,
+					},
+					AudioTrack: clients.AudioTrack{
+						Channels:   track.Channels,
+						SampleRate: track.Rate,
+						SampleBits: track.Size,
+					},
+				})
+			}
 			err = clients.DefaultCallbackClient.SendTranscodeStatusCompleted(
 				callbackUrl,
-				clients.InputVideo{
-					Format: "unknown",
-				},
+				inputInfo,
 				[]clients.OutputVideo{},
 			)
 

--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -111,7 +111,6 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 				_ = config.Logger.Log("msg", "Failed to send Error callback", "err", err.Error(), "stream_name", p.StreamName)
 			}
 		} else {
-			// TODO: Fill in with real values once we have them back from the transcoder
 			inputInfo := clients.InputVideo{
 				Format:    "mp4", // hardcoded as mist stream is in dtsc format.
 				Duration:  float64(p.StreamMediaDurationMillis) / 1000.0,


### PR DESCRIPTION
```json
  "video_spec": {
    "format": "mp4",
    "tracks": [
      {
        "type": "audio",
        "codec": "AAC",
        "bitrate": 255856,
        "duration": 6.24,
        "size": 0,
        "start_time": 0,
        "channels": 2,
        "sample_rate": 48000,
        "sample_bits": 16
      },
      {
        "type": "video",
        "codec": "H264",
        "bitrate": 10167032,
        "duration": 6.219,
        "size": 0,
        "start_time": 0,
        "width": 2048,
        "height": 858
      }
    ],
    "duration": 6.218,
    "size": 8279708
  }
```