### PR TITLE
Transcoding stage: use SourceFile instead of UploadURL

### DIFF
--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -88,12 +88,12 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 
 	si := cache.DefaultStreamCache.Segmenting.Get(p.StreamName)
 	transcodeRequest := transcode.TranscodeSegmentRequest{
-		SourceFile:       si.SourceFile,
+		SourceFile:       si.UploadURL, // Source of transcoding stage is output from segmenting stage
+		UploadURL:        si.UploadURL, // Store transcoded renditions in the same dir as segmented playlist
 		CallbackURL:      si.CallbackURL,
 		AccessToken:      si.AccessToken,
 		TranscodeAPIUrl:  si.TranscodeAPIUrl,
 		SourceStreamInfo: streamInfo,
-		UploadURL:        si.UploadURL,
 	}
 
 	go func() {

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -91,7 +91,7 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 		cache.DefaultStreamCache.Segmenting.Store(streamName, cache.StreamInfo{
 			SourceFile:      uploadVODRequest.Url,
 			CallbackURL:     uploadVODRequest.CallbackUrl,
-			UploadURL:       uploadVODRequest.OutputLocations[0].URL,
+			UploadURL:       tURL,
 			AccessToken:     uploadVODRequest.AccessToken,
 			TranscodeAPIUrl: uploadVODRequest.TranscodeAPIUrl,
 		})

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -59,18 +59,18 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	_ = config.Logger.Log("msg", "RunTranscodeProcess (v2) Beginning", "source", transcodeRequest.SourceFile, "target", transcodeRequest.UploadURL)
 
 	// Create a separate subdirectory for the transcoded renditions
-	segmentedUploadURL, err := url.Parse(transcodeRequest.UploadURL)
+	renditionsUploadURL, err := url.Parse(transcodeRequest.UploadURL)
 	if err != nil {
-		return fmt.Errorf("failed to parse transcodeRequest.UploadURL: %s", err)
+		return fmt.Errorf("failed to parse UploadURL: %s", err)
 	}
 	relativeTranscodeURL, err := url.Parse("transcoded/")
 	if err != nil {
 		return fmt.Errorf("failed to parse relativeTranscodeURL: %s", err)
 	}
 
-	targetOSURL := segmentedUploadURL.ResolveReference(relativeTranscodeURL)
+	targetOSURL := renditionsUploadURL.ResolveReference(relativeTranscodeURL)
 	// Grab some useful parameters to be used later from the TranscodeSegmentRequest
-	sourceManifestOSURL := transcodeRequest.UploadURL
+	sourceManifestOSURL := transcodeRequest.SourceFile
 	transcodeProfiles := transcodeRequest.Profiles
 	callbackURL := transcodeRequest.CallbackURL
 

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -105,6 +105,7 @@ func TestItCanTranscode(t *testing.T) {
 				},
 			},
 			CallbackURL: callbackServer.URL,
+			SourceFile:  manifestFile.Name(),
 			UploadURL:   manifestFile.Name(),
 		},
 		"streamName",


### PR DESCRIPTION
Segmenting stage SourceFile is mp4, produces m3u8 that is SourceFile of transcoding stage.
We want to place transcoding paths in same dir as mp4 file so we should set UploadURL of transcoding stage to same value as SourceFile.