### PR TITLE
calculating bitrate of transcoded results

### DIFF
--- a/transcode/manifest_test.go
+++ b/transcode/manifest_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/grafov/m3u8"
-	"github.com/livepeer/catalyst-api/clients"
 	"github.com/stretchr/testify/require"
 )
 
@@ -106,18 +105,22 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 	masterManifestURL, err := GenerateAndUploadManifests(
 		*sourceMediaPlaylist,
 		outputDir,
-		[]clients.EncodedProfile{
+		[]RenditionStats{
 			{
-				Name:   "lowlowlow",
-				FPS:    60,
-				Width:  800,
-				Height: 600,
+				Name:       "lowlowlow",
+				FPS:        60,
+				Width:      800,
+				Height:     600,
+				Bytes:      1,
+				DurationMs: 8000,
 			},
 			{
-				Name:   "super-high-def",
-				FPS:    30,
-				Width:  1080,
-				Height: 720,
+				Name:       "super-high-def",
+				FPS:        30,
+				Width:      1080,
+				Height:     720,
+				Bytes:      1,
+				DurationMs: 8000,
 			},
 		},
 	)


### PR DESCRIPTION
Produced multivariant playlist now contains proper bitrate:

```m3u8
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2188957288,RESOLUTION=1280x720,NAME="0-720p",FRAME-RATE=30.000
rendition-0/rendition.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=745890531,RESOLUTION=640x360,NAME="1-360p",FRAME-RATE=30.000
rendition-1/rendition.m3u8
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=3884863845,RESOLUTION=2048x858,NAME="2-source"
rendition-2/rendition.m3u8
```
