### PR TITLE
transcode: Improve asset transcoded profiles

### DIFF
--- a/clients/broadcaster.go
+++ b/clients/broadcaster.go
@@ -52,7 +52,7 @@ type EncodedProfile struct {
 	Width        int64  `json:"width,omitempty"`
 	Height       int64  `json:"height,omitempty"`
 	Bitrate      int64  `json:"bitrate,omitempty"`
-	FPS          int64  `json:"fps,omitempty"`
+	FPS          int64  `json:"fps"`
 	FPSDen       int64  `json:"fpsDen,omitempty"`
 	Profile      string `json:"profile,omitempty"`
 	GOP          string `json:"gop,omitempty"`

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -269,7 +269,7 @@ func getPlaybackProfiles(iv clients.InputVideo) ([]clients.EncodedProfile, error
 	if err != nil {
 		return nil, fmt.Errorf("no video track found in input video: %w", err)
 	}
-	profiles := make([]clients.EncodedProfile, 0, len(defaultTranscodeProfiles))
+	profiles := make([]clients.EncodedProfile, 0, len(defaultTranscodeProfiles)+1)
 	for _, profile := range defaultTranscodeProfiles {
 		// transcoding job will adjust the width to match aspect ratio. no need to
 		// check it here.

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -110,7 +110,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 			transcodeProfiles = append(defaultTranscodeProfiles, clients.EncodedProfile{
 				Name:    "source",
 				Bitrate: videoTrack.Bitrate,
-				FPS:     int64(videoTrack.FPS),
+				FPS:     0,
 				Width:   videoTrack.Width,
 				Height:  videoTrack.Height,
 			})

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -101,13 +101,13 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 
 	// If Profiles haven't been overridden, use the default set
 	if len(transcodeProfiles) == 0 {
-		transcodeProfiles = defaultTranscodeProfiles
+		transcodeProfiles = append([]clients.EncodedProfile(nil), defaultTranscodeProfiles...)
 		if isInputVideoBiggerThanDefaults(inputInfo) {
 			videoTrack, err := inputInfo.GetVideoTrack()
 			if err != nil {
 				return outputs, fmt.Errorf("error finding a video track: %s", err)
 			}
-			transcodeProfiles = append(defaultTranscodeProfiles, clients.EncodedProfile{
+			transcodeProfiles = append(transcodeProfiles, clients.EncodedProfile{
 				Name:    "source",
 				Bitrate: videoTrack.Bitrate,
 				FPS:     0,

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -38,18 +38,32 @@ var MAX_DEFAULT_RENDITION_HEIGHT = int64(720)
 // The default set of encoding profiles to use when none are specified
 var defaultTranscodeProfiles = []clients.EncodedProfile{
 	{
-		Name:    "720p",
-		Bitrate: 2000000,
-		FPS:     30,
-		Width:   MAX_DEFAULT_RENDITION_WIDTH,
-		Height:  MAX_DEFAULT_RENDITION_HEIGHT,
+		Name:    "240p0",
+		FPS:     0,
+		Bitrate: 250_000,
+		Width:   426,
+		Height:  240,
 	},
 	{
-		Name:    "360p",
-		Bitrate: 500000,
-		FPS:     30,
+		Name:    "360p0",
+		FPS:     0,
+		Bitrate: 800_000,
 		Width:   640,
 		Height:  360,
+	},
+	{
+		Name:    "480p0",
+		FPS:     0,
+		Bitrate: 1_600_000,
+		Width:   854,
+		Height:  480,
+	},
+	{
+		Name:    "720p0",
+		FPS:     0,
+		Bitrate: 3_000_000,
+		Width:   1280,
+		Height:  720,
 	},
 }
 

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -121,7 +121,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	if len(transcodeProfiles) == 0 {
 		transcodeProfiles, err = getPlaybackProfiles(inputInfo)
 		if err != nil {
-			return outputs, fmt.Errorf("failed to get playback profiles: %s", err)
+			return outputs, fmt.Errorf("failed to get playback profiles: %w", err)
 		}
 	}
 


### PR DESCRIPTION
This is to make some improvements to the asset profile generation logic, leveraging
from the existing logic in `task-runner` today. 

Main changes: 
 - There's a longer list of default profiles, but those are filtered out depending on the source video
 - With that, changed the logic on including the source profile in the output. It's always added now (since there will be no profile equal or better than it from the above process)