### PR TITLE
Fix contextual logging

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -132,6 +132,8 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			RequestID:       requestID,
 		})
 
+		log.Log(requestID, "Beginning segmenting")
+
 		// process the request
 		if err := d.processUploadVOD(streamName, uploadVODRequest.Url, targetSegmentedOutputURL.String()); err != nil {
 			errors.WriteHTTPInternalServerError(w, "Cannot process upload VOD request", err)


### PR DESCRIPTION
I'd missed that the cache has an "Add" and a "Replace" method and fails if you're using the first when the object exists / the second when it doesn't.
