### PR TITLE
remove rendition .dtsh files

### DIFF
--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -152,14 +152,6 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 				// should not block the ingestion flow or make it fail on error.
 				log.LogError(requestID, "master createDtsh() failed", err, "destination", output.Manifest)
 			}
-			for _, rendition := range output.Videos {
-				// we create dtsh for all rendition playlists
-				err := createDtsh(requestID, rendition.Location)
-				if err != nil {
-					// should not block the ingestion flow or make it fail on error.
-					log.LogError(requestID, "createDtsh() failed", err, "destination", rendition.Location)
-				}
-			}
 		}
 
 	}()


### PR DESCRIPTION
Only multivariant playlist .dtsh file is used in playback. Removing creation of renditions .dtsh files.