### PR TITLE
Send the success callback after dtsh upload

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -136,22 +136,6 @@ func (c CallbackClient) SendTranscodeStatusCompleted(url string, iv InputVideo, 
 
 }
 
-func (c CallbackClient) SendTranscodeStatusPlaybackReady(callbackURL string) error {
-	tsm := TranscodeStatusMessage{
-		Status:    TranscodeStatusPlaybackReady.String(),
-		Timestamp: config.Clock.GetTimestampUTC(),
-	}
-	j, err := json.Marshal(tsm)
-	if err != nil {
-		return err
-	}
-	r, err := http.NewRequest(http.MethodPost, callbackURL, bytes.NewReader(j))
-	if err != nil {
-		return err
-	}
-	return c.DoWithRetries(r)
-}
-
 // Calculate the overall completion ratio based on the completion ratio of the current stage.
 // The weighting will need to be tweaked as we understand better the relative time spent in the
 // segmenting vs. transcoding stages.
@@ -193,7 +177,6 @@ const (
 	TranscodeStatusPreparingCompleted
 	TranscodeStatusTranscoding
 	TranscodeStatusCompleted
-	TranscodeStatusPlaybackReady
 	TranscodeStatusError
 )
 
@@ -207,8 +190,6 @@ func (ts TranscodeStatus) String() string {
 		return "transcoding"
 	case TranscodeStatusCompleted:
 		return "success"
-	case TranscodeStatusPlaybackReady:
-		return "playback-ready"
 	case TranscodeStatusError:
 		return "error"
 	}

--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -136,6 +136,22 @@ func (c CallbackClient) SendTranscodeStatusCompleted(url string, iv InputVideo, 
 
 }
 
+func (c CallbackClient) SendTranscodeStatusPlaybackReady(callbackURL string) error {
+	tsm := TranscodeStatusMessage{
+		Status:    TranscodeStatusPlaybackReady.String(),
+		Timestamp: config.Clock.GetTimestampUTC(),
+	}
+	j, err := json.Marshal(tsm)
+	if err != nil {
+		return err
+	}
+	r, err := http.NewRequest(http.MethodPost, callbackURL, bytes.NewReader(j))
+	if err != nil {
+		return err
+	}
+	return c.DoWithRetries(r)
+}
+
 // Calculate the overall completion ratio based on the completion ratio of the current stage.
 // The weighting will need to be tweaked as we understand better the relative time spent in the
 // segmenting vs. transcoding stages.
@@ -177,6 +193,7 @@ const (
 	TranscodeStatusPreparingCompleted
 	TranscodeStatusTranscoding
 	TranscodeStatusCompleted
+	TranscodeStatusPlaybackReady
 	TranscodeStatusError
 )
 
@@ -190,6 +207,8 @@ func (ts TranscodeStatus) String() string {
 		return "transcoding"
 	case TranscodeStatusCompleted:
 		return "success"
+	case TranscodeStatusPlaybackReady:
+		return "playback-ready"
 	case TranscodeStatusError:
 		return "error"
 	}

--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -144,6 +144,13 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 			return
 		}
 
+		// When createDtsh() completes issue another callback signaling to studio playback is ready
+		defer func() {
+			if err := clients.DefaultCallbackClient.SendTranscodeStatusPlaybackReady(callbackUrl); err != nil {
+				log.LogError(requestID, "Failed to send playbackready callback", err)
+			}
+		}()
+
 		// prepare .dtsh headers for all rendition playlists
 		for _, output := range outputs {
 			// output is multivariant playlist

--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -146,8 +146,10 @@ func (d *MistCallbackHandlersCollection) triggerRecordingEndSegmenting(w http.Re
 
 		// When createDtsh() completes issue another callback signaling to studio playback is ready
 		defer func() {
-			if err := clients.DefaultCallbackClient.SendTranscodeStatusPlaybackReady(callbackUrl); err != nil {
-				log.LogError(requestID, "Failed to send playbackready callback", err)
+			// Send the success callback
+			err = clients.DefaultCallbackClient.SendTranscodeStatusCompleted(transcodeRequest.CallbackURL, inputInfo, outputs)
+			if err != nil {
+				log.LogError(transcodeRequest.RequestID, "Failed to send TranscodeStatusCompleted callback", err, "url", transcodeRequest.CallbackURL)
 			}
 		}()
 

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -181,11 +181,6 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 		output.Videos = append(output.Videos, clients.OutputVideoFile{Location: rendition.ManifestLocation})
 	}
 	outputs = []clients.OutputVideo{output}
-	// Send the success callback
-	err = clients.DefaultCallbackClient.SendTranscodeStatusCompleted(transcodeRequest.CallbackURL, inputInfo, outputs)
-	if err != nil {
-		log.LogError(transcodeRequest.RequestID, "Failed to send TranscodeStatusCompleted callback", err, "url", transcodeRequest.CallbackURL)
-	}
 	// Return outputs for .dtsh file creation
 	return outputs, nil
 }

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"testing"
@@ -103,7 +104,7 @@ func TestItCanTranscode(t *testing.T) {
 	}
 
 	// Check we don't get an error downloading or parsing it
-	_, err = RunTranscodeProcess(
+	outputs, err := RunTranscodeProcess(
 		TranscodeSegmentRequest{
 			CallbackURL: callbackServer.URL,
 			UploadURL:   manifestFile.Name(),
@@ -139,13 +140,14 @@ low-bitrate/index.m3u8
 	require.Equal(t, expectedMasterManifest, string(masterManifestBytes))
 
 	// Check we received a progress callback for each segment
-	require.Equal(t, 3, len(callbacks))
+	require.Equal(t, 2, len(callbacks))
 	require.Equal(t, 0.7, callbacks[0]["completion_ratio"])
 	require.Equal(t, 1.0, callbacks[1]["completion_ratio"])
 
 	// Check we received a final Transcode Completed callback
-	require.Equal(t, 1.0, callbacks[2]["completion_ratio"])
-	require.Equal(t, "success", callbacks[2]["status"])
+	require.Equal(t, 1, len(outputs))
+	require.Equal(t, path.Join(topLevelDir, "index.m3u8"), outputs[0].Manifest)
+	require.Equal(t, 2, len(outputs[0].Videos))
 }
 
 func TestItCalculatesTheTranscodeCompletionPercentageCorrectly(t *testing.T) {


### PR DESCRIPTION
First playback will fail via mistserver if .dtsh file is not present on S3.

Introducing `playback-ready` status callback when .dtsh file is created.

If studio is using mist playback then this additional callback signals ready state, if not then `success` (TranscodeStatusCompleted) signals ready state.
