### PR TITLE
Send a Segment Upload Multiplier of 3 to local broadcaster

### DIFF
--- a/clients/broadcaster.go
+++ b/clients/broadcaster.go
@@ -31,7 +31,8 @@ type createStreamPayload struct {
 }
 
 type LivepeerTranscodeConfiguration struct {
-	Profiles []EncodedProfile `json:"profiles"`
+	Profiles                   []EncodedProfile `json:"profiles"`
+	SegUploadTimeoutMultiplier int              `json:"segUploadTimeoutMultiplier"`
 }
 
 type Credentials struct {

--- a/clients/broadcaster_local.go
+++ b/clients/broadcaster_local.go
@@ -30,7 +30,9 @@ func NewLocalBroadcasterClient(broadcasterURL string) (LocalBroadcasterClient, e
 }
 
 func (c LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error) {
-	conf := LivepeerTranscodeConfiguration{}
+	conf := LivepeerTranscodeConfiguration{
+		SegUploadTimeoutMultiplier: 3,
+	}
 	conf.Profiles = append(conf.Profiles, profiles...)
 	transcodeConfig, err := json.Marshal(&conf)
 	if err != nil {


### PR DESCRIPTION
This is to be more lenient than the Live workflow when waiting for transcoders.

Broadcaster change in https://github.com/livepeer/go-livepeer/pull/2650