### PR TITLE
Use big.Int to store timestamps that are potentially very big

### DIFF
--- a/handlers/misttriggers/recording_end.go
+++ b/handlers/misttriggers/recording_end.go
@@ -3,6 +3,7 @@ package misttriggers
 import (
 	"fmt"
 	"math"
+	"math/big"
 	"net/http"
 	"strconv"
 	"strings"
@@ -180,8 +181,8 @@ type RecordingEndPayload struct {
 	ConnectionStartTimeUnix   int
 	ConnectionEndTimeUnix     int
 	StreamMediaDurationMillis int64
-	FirstMediaTimestampMillis int64
-	LastMediaTimestampMillis  int64
+	FirstMediaTimestampMillis big.Int
+	LastMediaTimestampMillis  big.Int
 }
 
 func ParseRecordingEndPayload(payload string) (RecordingEndPayload, error) {
@@ -215,13 +216,13 @@ func ParseRecordingEndPayload(payload string) (RecordingEndPayload, error) {
 		return RecordingEndPayload{}, fmt.Errorf("error parsing line %d of RECORDING_END payload as an int. Line contents: %s. Error: %s", 7, lines[7], err)
 	}
 
-	FirstMediaTimestampMillis, err := strconv.ParseInt(lines[8], 10, 64)
-	if err != nil {
+	var FirstMediaTimestampMillis big.Int
+	if _, ok := FirstMediaTimestampMillis.SetString(lines[8], 10); !ok {
 		return RecordingEndPayload{}, fmt.Errorf("error parsing line %d of RECORDING_END payload as an int. Line contents: %s. Error: %s", 8, lines[8], err)
 	}
 
-	LastMediaTimestampMillis, err := strconv.ParseInt(lines[9], 10, 64)
-	if err != nil {
+	var LastMediaTimestampMillis big.Int
+	if _, ok := LastMediaTimestampMillis.SetString(lines[9], 10); !ok {
 		return RecordingEndPayload{}, fmt.Errorf("error parsing line %d of RECORDING_END payload as an int. Line contents: %s. Error: %s", 9, lines[9], err)
 	}
 

--- a/handlers/misttriggers/recording_end_test.go
+++ b/handlers/misttriggers/recording_end_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestItCanParseAValidRecordingEndPayload(t *testing.T) {
-	var payload = "1\n2\n3\n4\n5\n6\n7\n8\n9\n10"
+	var payload = "1\n2\n3\n4\n5\n6\n7\n8\n18446744073709551615\n18446744073709551615"
 	p, err := ParseRecordingEndPayload(payload)
 	require.NoError(t, err)
 	require.Equal(t, p.StreamName, "1")
@@ -18,8 +18,8 @@ func TestItCanParseAValidRecordingEndPayload(t *testing.T) {
 	require.Equal(t, p.ConnectionStartTimeUnix, 6)
 	require.Equal(t, p.ConnectionEndTimeUnix, 7)
 	require.Equal(t, p.StreamMediaDurationMillis, int64(8))
-	require.Equal(t, p.FirstMediaTimestampMillis, int64(9))
-	require.Equal(t, p.LastMediaTimestampMillis, int64(10))
+	require.Equal(t, p.FirstMediaTimestampMillis.String(), "18446744073709551615")
+	require.Equal(t, p.LastMediaTimestampMillis.String(), "18446744073709551615")
 }
 
 func TestItFailsToParseAnInvalidRecordingEndPayload(t *testing.T) {


### PR DESCRIPTION
This was the error we were seeing:

```error parsing line 8 of RECORDING_END payload as an int. Line contents: 18446744073709551615. Error: strconv.ParseInt: parsing \"18446744073709551615\": value out of range"```