### PR TITLE
Fix 'http: wrote more than the declared Content-Length' error

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,8 +16,6 @@ type apiError struct {
 }
 
 func writeHttpError(w http.ResponseWriter, msg string, status int, err error) apiError {
-	w.WriteHeader(status)
-
 	var errorDetail string
 	if err != nil {
 		errorDetail = err.Error()
@@ -26,6 +24,8 @@ func writeHttpError(w http.ResponseWriter, msg string, status int, err error) ap
 	if err := json.NewEncoder(w).Encode(map[string]string{"error": msg, "error_detail": errorDetail}); err != nil {
 		log.LogNoRequestID("error writing HTTP error", "http_error_msg", msg, "error", err)
 	}
+
+	w.WriteHeader(status)
 	return apiError{msg, status, err}
 }
 

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -16,6 +16,8 @@ type apiError struct {
 }
 
 func writeHttpError(w http.ResponseWriter, msg string, status int, err error) apiError {
+	w.WriteHeader(status)
+
 	var errorDetail string
 	if err != nil {
 		errorDetail = err.Error()
@@ -24,8 +26,6 @@ func writeHttpError(w http.ResponseWriter, msg string, status int, err error) ap
 	if err := json.NewEncoder(w).Encode(map[string]string{"error": msg, "error_detail": errorDetail}); err != nil {
 		log.LogNoRequestID("error writing HTTP error", "http_error_msg", msg, "error", err)
 	}
-
-	w.WriteHeader(status)
 	return apiError{msg, status, err}
 }
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -414,7 +414,7 @@ func TestWrongContentTypeVODUploadHandler(t *testing.T) {
 	router.POST("/api/vod", catalystApiHandlers.UploadVOD())
 	router.ServeHTTP(rr, req)
 
-	require.Equal(rr.Result().StatusCode, 415)
+	require.Equal(415, rr.Result().StatusCode)
 	require.JSONEq(rr.Body.String(), `{"error": "Requires application/json content type", "error_detail":""}`)
 }
 

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -176,7 +176,7 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			})
 
 			if err := clients.DefaultCallbackClient.SendTranscodeStatus(uploadVODRequest.CallbackUrl, clients.TranscodeStatusPreparing, 0); err != nil {
-				errors.WriteHTTPInternalServerError(w, "Cannot send transcode status", err)
+				log.LogError(requestID, "Cannot send transcode status", err)
 			}
 
 			// Attempt an out-of-band call to generate the dtsh headers using MistIn*
@@ -190,7 +190,7 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			}
 
 			if err := clients.DefaultCallbackClient.SendTranscodeStatus(uploadVODRequest.CallbackUrl, clients.TranscodeStatusPreparing, 0.1); err != nil {
-				errors.WriteHTTPInternalServerError(w, "Cannot send transcode status", err)
+				log.LogError(requestID, "Cannot send transcode status", err)
 			}
 
 			log.Log(requestID, "Beginning segmenting")
@@ -201,7 +201,7 @@ func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
 			}
 
 			if err := clients.DefaultCallbackClient.SendTranscodeStatus(uploadVODRequest.CallbackUrl, clients.TranscodeStatusPreparing, 0.2); err != nil {
-				errors.WriteHTTPInternalServerError(w, "Cannot send transcode status", err)
+				log.LogError(requestID, "Cannot send transcode status", err)
 			}
 		}()
 


### PR DESCRIPTION
I thought we'd caught all of these, but looks like we were writing HTTP errors (but not returning) for callback failures