### PR TITLE
transcode: improve low-bitrate profiles bitrate slightly for better playback

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -261,7 +261,7 @@ func getPlaybackProfiles(iv clients.InputVideo) ([]clients.EncodedProfile, error
 }
 
 func lowBitrateProfile(video clients.InputTrack) clients.EncodedProfile {
-	bitrate := int64(float64(video.Bitrate) * (3.0 / 4.0))
+	bitrate := int64(float64(video.Bitrate) * (1.0 / 2.0))
 	if bitrate < MIN_VIDEO_BITRATE && video.Bitrate > MIN_VIDEO_BITRATE {
 		bitrate = MIN_VIDEO_BITRATE
 	} else if bitrate < ABSOLUTE_MIN_VIDEO_BITRATE {

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -261,7 +261,7 @@ func getPlaybackProfiles(iv clients.InputVideo) ([]clients.EncodedProfile, error
 }
 
 func lowBitrateProfile(video clients.InputTrack) clients.EncodedProfile {
-	bitrate := video.Bitrate / 3
+	bitrate := int64(float64(video.Bitrate) * (3.0 / 4.0))
 	if bitrate < MIN_VIDEO_BITRATE && video.Bitrate > MIN_VIDEO_BITRATE {
 		bitrate = MIN_VIDEO_BITRATE
 	} else if bitrate < ABSOLUTE_MIN_VIDEO_BITRATE {


### PR DESCRIPTION
When the input video's height or bitrate combo is too low to meet the ABR ladder, the low-bitrate profile is used in addition to the input video's profile to have some ABR during playback. The low-bitrate profile 1/3's the input video profile resulting in pretty low quality video. Increase this to be 75% of the input video's resolution so that playback still feels good without experiencing artifacts.

\#fix https://github.com/livepeer/catalyst-api/issues/215