### PR TITLE
Update timeout param name to reflect go-livepeer change

### DIFF
--- a/clients/broadcaster.go
+++ b/clients/broadcaster.go
@@ -33,8 +33,8 @@ type createStreamPayload struct {
 }
 
 type LivepeerTranscodeConfiguration struct {
-	Profiles                   []EncodedProfile `json:"profiles"`
-	SegUploadTimeoutMultiplier int              `json:"segUploadTimeoutMultiplier"`
+	Profiles          []EncodedProfile `json:"profiles"`
+	TimeoutMultiplier int              `json:"timeoutMultiplier"`
 }
 
 type Credentials struct {

--- a/clients/broadcaster_local.go
+++ b/clients/broadcaster_local.go
@@ -31,7 +31,7 @@ func NewLocalBroadcasterClient(broadcasterURL string) (LocalBroadcasterClient, e
 
 func (c LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error) {
 	conf := LivepeerTranscodeConfiguration{
-		SegUploadTimeoutMultiplier: 10,
+		TimeoutMultiplier: 10,
 	}
 	conf.Profiles = append(conf.Profiles, profiles...)
 	transcodeConfig, err := json.Marshal(&conf)


### PR DESCRIPTION
This is the other half of https://github.com/livepeer/go-livepeer/pull/2667