### PR TITLE
Return an HTTP 429 when we're over capacity

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -6,13 +6,19 @@ import (
 
 type Cache[T interface{}] struct {
 	cache map[string]T
-	mutex sync.Mutex
+	mutex sync.RWMutex
 }
 
 func New[T interface{}]() *Cache[T] {
 	return &Cache[T]{
 		cache: make(map[string]T),
 	}
+}
+
+func (c *Cache[T]) Size() int {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	return len(c.cache)
 }
 
 func (c *Cache[T]) Remove(streamName string) {
@@ -22,8 +28,8 @@ func (c *Cache[T]) Remove(streamName string) {
 }
 
 func (c *Cache[T]) Get(streamName string) T {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
 	info, ok := c.cache[streamName]
 	if ok {
 		return info

--- a/middleware/capacity.go
+++ b/middleware/capacity.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/pipeline"
+)
+
+const MAX_JOBS_IN_FLIGHT = 10
+
+func HasCapacity(vodEngine *pipeline.Coordinator, next httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		if vodEngine.Jobs.Size() >= MAX_JOBS_IN_FLIGHT {
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		next(w, r, ps)
+	}
+}

--- a/middleware/capacity_test.go
+++ b/middleware/capacity_test.go
@@ -1,0 +1,58 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/pipeline"
+	"github.com/stretchr/testify/require"
+)
+
+func TestItCallsNextMiddlewareWhenCapacityAvailable(t *testing.T) {
+	// Create a next handler in the middleware chain, to confirm the request was passed onwards
+	var nextCalled bool
+	next := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		nextCalled = true
+	}
+
+	// Set up the HTTP handler
+	handler := HasCapacity(pipeline.NewStubCoordinator(), next)
+
+	// Call the handler
+	responseRecorder := httptest.NewRecorder()
+	handler(responseRecorder, nil, nil)
+
+	// Confirm we got a success reponse and that the handler called the next middleware
+	require.Equal(t, http.StatusOK, responseRecorder.Code)
+	require.True(t, nextCalled)
+}
+
+func TestItErrorsWhenNoCapacityAvailable(t *testing.T) {
+	// Create a next handler in the middleware chain, to confirm the request was passed onwards
+	var nextCalled bool
+	next := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+		nextCalled = true
+	}
+
+	// Create a lot of in-flight jobs
+	coordinator := pipeline.NewStubCoordinator()
+	for x := 0; x < 11; x++ {
+		coordinator.Jobs.Store(fmt.Sprintf("request-%d", x), &pipeline.JobInfo{})
+	}
+
+	// Set up the HTTP handler
+	handler := HasCapacity(coordinator, next)
+
+	// Call the handler
+	responseRecorder := httptest.NewRecorder()
+	handler(responseRecorder, nil, nil)
+
+	// Confirm we got an HTTP 429 response
+	require.Equal(t, http.StatusTooManyRequests, responseRecorder.Code)
+
+	// Confirm the handler didn't call the next middleware
+	require.False(t, nextCalled)
+}

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -194,6 +194,10 @@ func (c *Coordinator) TriggerRecordingEnd(p RecordingEndPayload) {
 	})
 }
 
+func (c *Coordinator) NumJobsInFlight() {
+
+}
+
 // TriggerPushEnd handles PUSH_END trigger from mist.
 func (c *Coordinator) TriggerPushEnd(p PushEndPayload) {
 	si := c.Jobs.Get(p.StreamName)


### PR DESCRIPTION
Currently very crude, but protects us from being DOSed.

Future iterations will probably be 

1) Include job size and current completion % in the calculation
2) Include machine resource availability (CPU, memory, network) in the calculation