### PR TITLE
clients/mediaconvert: Some final fixes to the mediaconvert pipeline

### DIFF
--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -55,7 +55,6 @@ func ParseTranscodeProviderURL(input string) (TranscodeProvider, error) {
 		if err != nil || s3AuxBucket.Scheme != "s3" {
 			return nil, fmt.Errorf("invalid s3_aux_bucket %s: %w", s3AuxBucketStr, err)
 		}
-		s3AuxBucket.User = u.User
 
 		return NewMediaConvertClient(MediaConvertOptions{
 			Endpoint:        endpoint,


### PR DESCRIPTION
 - Handle S3 vs S3 OS URLs properly. Turns out that it was not only the credentials that had to be removed. Created a helper in the struct with the already translated URL to make things simpler.
 - Handle the 1042 error from MediaConvert and retry without acceleration
 - Fixed OS hell as the list returns the full path of the file but the gets and writes interpret it as a relative path 