### PR TITLE
mediaconvert: Handle secret acceleration error code

### DIFF
--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -41,7 +41,7 @@ func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 			},
 			Outputs: []clients.OutputVideo{
 				{
-					Type:     "manifest",
+					Type:     "object_store",
 					Manifest: job.TargetURL.String(),
 					Videos:   []clients.OutputVideoFile{
 						// TODO: Figure out what to do here. Studio doesn't use these anyway.


### PR DESCRIPTION
Follow-up on #237. 

The error code is not the documented, it's a secret one 🙄 

Also fix a small issue in the external `pipeline.Handler`, which should have an output with
type `object_store` instead of `manifest` .