### PR TITLE
handlers,pipeline: Move segmenting target URL logic to mist pipeline

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -46,7 +46,6 @@ type UploadJobPayload struct {
 	SourceFile            string
 	CallbackURL           string
 	TargetURL             *url.URL
-	SegmentingTargetURL   string
 	AccessToken           string
 	TranscodeAPIUrl       string
 	HardcodedBroadcasters string
@@ -80,6 +79,8 @@ type JobInfo struct {
 	mu sync.Mutex
 	UploadJobPayload
 	StreamName string
+	// this is only set&used internally in the mist pipeline
+	SegmentingTargetURL string
 
 	handler      Handler
 	hasFallback  bool

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -25,7 +25,7 @@ func (m *mist) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		return nil, fmt.Errorf("target output file should have .m3u8 extension, found %q", targetExtension)
 	}
 
-	segmentingTargetURL, err := InSameDirectory(job.TargetURL, "source", targetManifestFilename)
+	segmentingTargetURL, err := inSameDirectory(job.TargetURL, "source", targetManifestFilename)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create targetSegmentedOutputURL: %w", err)
 	}
@@ -35,7 +35,7 @@ func (m *mist) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	// Arweave URLs don't support HTTP Range requests and so Mist can't natively handle them for segmenting
 	// This workaround copies the file from Arweave to S3 and then tells Mist to use the S3 URL
 	if clients.IsArweaveOrIPFSURL(job.SourceFile) {
-		newSourceURL, err := InSameDirectory(job.TargetURL, "source", "arweave-source.mp4")
+		newSourceURL, err := inSameDirectory(job.TargetURL, "source", "arweave-source.mp4")
 		if err != nil {
 			return nil, fmt.Errorf("cannot create location for arweave source copy: %w", err)
 		}
@@ -195,7 +195,7 @@ func (m *mist) HandlePushEndTrigger(job *JobInfo, p PushEndPayload) (*HandlerOut
 	return ContinuePipeline, nil
 }
 
-func InSameDirectory(base *url.URL, paths ...string) (*url.URL, error) {
+func inSameDirectory(base *url.URL, paths ...string) (*url.URL, error) {
 	baseDir := path.Dir(base.Path)
 	paths = append([]string{baseDir}, paths...)
 	fullPath := path.Join(paths...)


### PR DESCRIPTION
Found a bug on the background mist job: Since the coordinator only changes the TargetURL when the job is in background (line 206), the mist job will actually not pick up that change since it uses the segmenting URL instead.

Fix this the right way, by moving the creation of the segmeting URL to the mist pipeline. It is only used there.

The only small issue is that it is still a "global" field in the job info, so I added a comment that it's only used in mist for now. We can do something more sophisticated is this grows (like a "handler data" inside the job info struct that can be of any type)