### PR TITLE
clients/mediaconvert: Auto-rotate input video based on metadata

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -238,6 +238,7 @@ func createJobPayload(inputFile, hlsOutputFile, role string, accelerated bool) *
 					AutomatedEncodingSettings: &mediaconvert.AutomatedEncodingSettings{
 						AbrSettings: &mediaconvert.AutomatedAbrSettings{
 							MaxAbrBitrate: aws.Int64(8000000),
+							MaxRenditions: aws.Int64(3),
 						},
 					},
 				},

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -186,7 +186,9 @@ func createJobPayload(inputFile, hlsOutputFile, role string, accelerated bool) *
 					},
 					FileInput:      aws.String(inputFile),
 					TimecodeSource: aws.String("ZEROBASED"),
-					VideoSelector:  &mediaconvert.VideoSelector{},
+					VideoSelector: &mediaconvert.VideoSelector{
+						Rotate: aws.String(mediaconvert.InputRotateAuto),
+					},
 				},
 			},
 			OutputGroups: []*mediaconvert.OutputGroup{


### PR DESCRIPTION
FTR: We have this same issue in the old task-runner and the new catalyst pipelines. We need to implement the same auto-rotate logic based on video metadata on the Catalyst pipeline.