### PR TITLE
clients: Create some tests for the mediaconvert client

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -54,9 +54,14 @@ type MediaConvertOptions struct {
 	S3AuxBucket *url.URL
 }
 
+type AWSMediaConvertClient interface {
+	CreateJob(*mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error)
+	GetJob(*mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error)
+}
+
 type MediaConvert struct {
 	opts                MediaConvertOptions
-	client              *mediaconvert.MediaConvert
+	client              AWSMediaConvertClient
 	osTransferBucketURL *url.URL
 }
 

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -208,7 +208,7 @@ func createJobPayload(inputFile, hlsOutputFile, role string, accelerated bool) *
 	var acceleration *mediaconvert.AccelerationSettings
 	if accelerated {
 		acceleration = &mediaconvert.AccelerationSettings{
-			Mode: aws.String("ENABLED"),
+			Mode: aws.String(mediaconvert.AccelerationModePreferred),
 		}
 	}
 

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -21,7 +21,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const pollDelay = 10 * time.Second
+var pollDelay = 10 * time.Second
+
 const rateLimitedPollDelay = 15 * time.Second
 
 // https://docs.aws.amazon.com/mediaconvert/latest/ug/mediaconvert_error_codes.html
@@ -442,6 +443,8 @@ func getTargetDir(url *url.URL) string {
 			// only bucket name and file in URL
 			dir = ""
 		}
+	} else if url.Scheme == "file" {
+		dir = path.Join("/", url.Host, dir)
 	}
 	return dir
 }

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -1,0 +1,26 @@
+package clients
+
+import (
+	"errors"
+
+	"github.com/aws/aws-sdk-go/service/mediaconvert"
+)
+
+type stubMediaConvertClient struct {
+	createJob func(*mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error)
+	getJob    func(*mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error)
+}
+
+func (s stubMediaConvertClient) CreateJob(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+	if s.createJob == nil {
+		return nil, errors.New("not implemented")
+	}
+	return s.createJob(input)
+}
+
+func (s stubMediaConvertClient) GetJob(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
+	if s.getJob == nil {
+		return nil, errors.New("not implemented")
+	}
+	return s.getJob(input)
+}

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -7,38 +7,32 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediaconvert"
+	"github.com/cenkalti/backoff/v4"
+	"github.com/livepeer/catalyst-api/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestOnlyS3URLsToAWSClient(t *testing.T) {
 	require := require.New(t)
-	f, err := os.CreateTemp(os.TempDir(), "user-input-*")
-	require.NoError(err)
-	defer os.Remove(f.Name())
-	_, err = f.WriteString(exampleFileContents)
-	require.NoError(err)
-
-	// use the random file name as the dir name for the transfer file
-	mcInputDir := path.Join(os.TempDir(), "out", f.Name())
-	transferredFile := path.Join(mcInputDir, "input/1234/video")
-	defer os.Remove(transferredFile)
-
-	mc := &MediaConvert{
-		s3TransferBucket:    mustParseURL("s3://thebucket"),
-		osTransferBucketURL: mustParseURL("file://" + mcInputDir),
-		client: stubMediaConvertClient{
-			createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
-				// check that only an s3:// URL is sent to AWS client
-				require.Equal("s3://thebucket/input/1234/video", *input.Settings.Inputs[0].FileInput)
-				require.Equal("s3://thebucket/output/1234/index", *input.Settings.OutputGroups[0].OutputGroupSettings.HlsGroupSettings.Destination)
-				return nil, errors.New("secret error")
-			},
+	awsStub := &stubMediaConvertClient{
+		createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+			// check that only an s3:// URL is sent to AWS client
+			require.Equal("s3://thebucket/input/1234/video", *input.Settings.Inputs[0].FileInput)
+			require.Equal("s3://thebucket/output/1234/index", *input.Settings.OutputGroups[0].OutputGroupSettings.HlsGroupSettings.Destination)
+			return nil, errors.New("secret error")
 		},
 	}
-	err = mc.Transcode(context.Background(), TranscodeJobArgs{
+	mc, f, transferDir, cleanup := setupTestMediaConvert(t, awsStub)
+	defer cleanup()
+
+	transferredFile := path.Join(transferDir, "input/1234/video")
+	defer os.Remove(transferredFile)
+
+	err := mc.Transcode(context.Background(), TranscodeJobArgs{
 		InputFile:     mustParseURL("file://" + f.Name()),
 		HLSOutputFile: mustParseURL("s3+https://endpoint.com/bucket/1234/index.m3u8"),
 		CollectSourceSize: func(size int64) {
@@ -48,15 +42,58 @@ func TestOnlyS3URLsToAWSClient(t *testing.T) {
 	require.ErrorContains(err, "secret error")
 
 	// Check that the file was copied to the osTransferBucketURL folder
-	_, err = os.Stat(transferredFile)
+	content, err := os.ReadFile(transferredFile)
 	require.NoError(err)
+	require.Equal(exampleFileContents, string(content))
+}
+
+func TestReportsMediaConvertProgress(t *testing.T) {
+	require := require.New(t)
+
+	createJobCalls, getJobCalls := 0, 0
+	awsStub := &stubMediaConvertClient{
+		createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+			createJobCalls++
+			return &mediaconvert.CreateJobOutput{Job: &mediaconvert.Job{Id: aws.String("10")}}, nil
+		},
+		getJob: func(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
+			getJobCalls++
+			switch getJobCalls {
+			case 1:
+				return &mediaconvert.GetJobOutput{Job: &mediaconvert.Job{
+					Status:             aws.String(mediaconvert.JobStatusProgressing),
+					JobPercentComplete: aws.Int64(50),
+				}}, nil
+			case 2:
+				return nil, errors.New("done with this test")
+			default:
+				require.Fail("unexpected call")
+				return nil, errors.New("unreachable")
+			}
+		},
+	}
+	mc, f, transferDir, cleanup := setupTestMediaConvert(t, awsStub)
+	defer cleanup()
+	defer os.Remove(path.Join(transferDir, "input/1234/video"))
+
+	reportProgressCalls := 0
+	err := mc.Transcode(context.Background(), TranscodeJobArgs{
+		InputFile:         mustParseURL("file://" + f.Name()),
+		HLSOutputFile:     mustParseURL("s3+https://endpoint.com/bucket/1234/index.m3u8"),
+		CollectSourceSize: func(size int64) {},
+		ReportProgress: func(progress float64) {
+			reportProgressCalls++
+			require.InEpsilon(0.5, progress, 1e-9)
+		},
+	})
+	require.ErrorContains(err, "done with this test")
+	require.Equal(1, createJobCalls)
+	require.Equal(2, getJobCalls)
+	require.Equal(1, reportProgressCalls)
 }
 
 func TestSendsOriginalURLToS3OnCopyError(t *testing.T) {
 	require := require.New(t)
-	mcInputDir := path.Join(os.TempDir(), "out")
-	transferredFile := path.Join(mcInputDir, "input/1234/video")
-	defer os.Remove(transferredFile)
 
 	awsStub := &stubMediaConvertClient{
 		createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
@@ -66,11 +103,9 @@ func TestSendsOriginalURLToS3OnCopyError(t *testing.T) {
 			return nil, errors.New("secret error")
 		},
 	}
-	mc := &MediaConvert{
-		s3TransferBucket:    mustParseURL("s3://thebucket"),
-		osTransferBucketURL: mustParseURL("file://" + mcInputDir),
-		client:              awsStub,
-	}
+	mc, _, transferDir, cleanup := setupTestMediaConvert(t, awsStub)
+	defer cleanup()
+
 	err := mc.Transcode(context.Background(), TranscodeJobArgs{
 		// use a non existing HTTP endpoint for the file
 		InputFile:         mustParseURL("http://localhost:3000/not-here.mp4"),
@@ -85,7 +120,7 @@ func TestSendsOriginalURLToS3OnCopyError(t *testing.T) {
 		return nil, errors.New("unreachable")
 	}
 	err = mc.Transcode(context.Background(), TranscodeJobArgs{
-		// use a non existing an OS URL
+		// use a non existing OS URL
 		InputFile:         mustParseURL("s3+https://user:pwd@localhost:4321/bucket/no-minio-here.mp4"),
 		HLSOutputFile:     mustParseURL("s3+https://endpoint.com/bucket/1234/index.m3u8"),
 		CollectSourceSize: func(size int64) {},
@@ -93,62 +128,86 @@ func TestSendsOriginalURLToS3OnCopyError(t *testing.T) {
 	require.ErrorContains(err, "download error")
 
 	// Check that no file was created to the osTransferBucketURL folder
-	_, err = os.Stat(transferredFile)
+	_, err = os.Stat(path.Join(transferDir, "input/1234/video"))
 	require.ErrorContains(err, "no such file")
 }
 
 func TestRetriesOnAccelerationError(t *testing.T) {
 	require := require.New(t)
-	mcInputDir := path.Join(os.TempDir(), "out")
-	transferredFile := path.Join(mcInputDir, "input/1234/video")
-	defer os.Remove(transferredFile)
 
 	createdJobs := 0
-	mc := &MediaConvert{
-		s3TransferBucket:    mustParseURL("s3://thebucket"),
-		osTransferBucketURL: mustParseURL("file://" + mcInputDir),
-		client: stubMediaConvertClient{
-			createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
-				createdJobs++
-				switch createdJobs {
-				case 1:
-					require.Equal(*input.AccelerationSettings.Mode, mediaconvert.AccelerationModePreferred)
-					return &mediaconvert.CreateJobOutput{Job: &mediaconvert.Job{Id: aws.String("420")}}, nil
-				case 2:
-					require.Nil(input.AccelerationSettings)
-					return nil, errors.New("we are done with this test")
-				default:
-					require.Fail("should not have been called")
-					return nil, errors.New("unreachable")
-				}
-			},
-			getJob: func(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
-				switch *input.Id {
-				case "420":
-					return &mediaconvert.GetJobOutput{Job: &mediaconvert.Job{
-						Status:       aws.String(mediaconvert.JobStatusError),
-						ErrorMessage: aws.String("enhance your calm"),
-						ErrorCode:    aws.Int64(1550),
-					}}, nil
-				default:
-					require.Fail("unknown job id " + *input.Id)
-					return nil, errors.New("unreachable")
-				}
-			},
+	awsStub := &stubMediaConvertClient{
+		createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+			createdJobs++
+			switch createdJobs {
+			case 1:
+				require.Equal(*input.AccelerationSettings.Mode, mediaconvert.AccelerationModePreferred)
+				return &mediaconvert.CreateJobOutput{Job: &mediaconvert.Job{Id: aws.String("420")}}, nil
+			case 2:
+				require.Nil(input.AccelerationSettings)
+				return nil, errors.New("we are done with this test")
+			default:
+				require.Fail("should not have been called")
+				return nil, errors.New("unreachable")
+			}
+		},
+		getJob: func(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
+			switch *input.Id {
+			case "420":
+				return &mediaconvert.GetJobOutput{Job: &mediaconvert.Job{
+					Status:       aws.String(mediaconvert.JobStatusError),
+					ErrorMessage: aws.String("enhance your calm"),
+					ErrorCode:    aws.Int64(1550),
+				}}, nil
+			default:
+				require.Fail("unknown job id " + *input.Id)
+				return nil, errors.New("unreachable")
+			}
 		},
 	}
+	mc, inputFile, transferDir, cleanup := setupTestMediaConvert(t, awsStub)
+	defer cleanup()
+	defer os.Remove(path.Join(transferDir, "input/1234/video"))
+
 	err := mc.Transcode(context.Background(), TranscodeJobArgs{
 		// use a non existing HTTP endpoint for the file
-		InputFile:         mustParseURL("http://localhost:3000/not-here.mp4"),
+		InputFile:         mustParseURL("file://" + inputFile.Name()),
 		HLSOutputFile:     mustParseURL("s3+https://endpoint.com/bucket/1234/index.m3u8"),
 		CollectSourceSize: func(size int64) {},
 	})
 	require.ErrorContains(err, "done with this test")
 	require.Equal(2, createdJobs)
+}
 
-	// Check that no file was created to the osTransferBucketURL folder
-	_, err = os.Stat(transferredFile)
-	require.ErrorContains(err, "no such file")
+func setupTestMediaConvert(t *testing.T, awsStub AWSMediaConvertClient) (mc *MediaConvert, inputFile *os.File, transferDir string, cleanup func()) {
+	oldConstantBackoff, oldExponentialBackoff, oldRetries := constantBackOff, exponentialBackOff, config.DownloadOSURLRetries
+	constantBackOff = backoff.NewConstantBackOff(1 * time.Millisecond)
+	exponentialBackOff = backoff.NewExponentialBackOff()
+	exponentialBackOff.InitialInterval = 1 * time.Millisecond
+	exponentialBackOff.MaxInterval = 1 * time.Millisecond
+	config.DownloadOSURLRetries = 1
+
+	var err error
+	inputFile, err = os.CreateTemp(os.TempDir(), "user-input-*")
+	require.NoError(t, err)
+	_, err = inputFile.WriteString(exampleFileContents)
+	require.NoError(t, err)
+	require.NoError(t, inputFile.Close())
+
+	// use the random file name as the dir name for the transfer file
+	transferDir = path.Join(inputFile.Name()+"_dir", "transfer")
+
+	cleanup = func() {
+		constantBackOff, exponentialBackOff, config.DownloadOSURLRetries = oldConstantBackoff, oldExponentialBackoff, oldRetries
+		require.NoError(t, os.Remove(inputFile.Name()))
+	}
+
+	mc = &MediaConvert{
+		s3TransferBucket:    mustParseURL("s3://thebucket"),
+		osTransferBucketURL: mustParseURL("file://" + transferDir),
+		client:              awsStub,
+	}
+	return
 }
 
 func mustParseURL(str string) *url.URL {
@@ -164,14 +223,14 @@ type stubMediaConvertClient struct {
 	getJob    func(*mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error)
 }
 
-func (s stubMediaConvertClient) CreateJob(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+func (s *stubMediaConvertClient) CreateJob(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
 	if s.createJob == nil {
 		return nil, errors.New("not implemented")
 	}
 	return s.createJob(input)
 }
 
-func (s stubMediaConvertClient) GetJob(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
+func (s *stubMediaConvertClient) GetJob(input *mediaconvert.GetJobInput) (*mediaconvert.GetJobOutput, error) {
 	if s.getJob == nil {
 		return nil, errors.New("not implemented")
 	}

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -1,10 +1,59 @@
 package clients
 
 import (
+	"context"
 	"errors"
+	"net/url"
+	"os"
+	"path"
+	"testing"
 
 	"github.com/aws/aws-sdk-go/service/mediaconvert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestOnlyS3URLsToAWSClient(t *testing.T) {
+	f, err := os.CreateTemp(os.TempDir(), "user-input-*")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, err = f.WriteString(exampleFileContents)
+	require.NoError(t, err)
+
+	// use the random file name as the dir name for the transfer file
+	mcInputDir := path.Join(os.TempDir(), path.Ext(f.Name()))
+	transferredFile := path.Join(mcInputDir, "input/1234/video")
+	defer os.Remove(transferredFile)
+
+	mc := &MediaConvert{
+		s3TransferBucket:    mustParseURL("s3://thebucket"),
+		osTransferBucketURL: mustParseURL("file://" + mcInputDir),
+		client: stubMediaConvertClient{
+			createJob: func(input *mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error) {
+				// check that only an s3:// URL is sent to AWS client
+				require.Equal(t, "s3://thebucket/input/1234/video", *input.Settings.Inputs[0].FileInput)
+				require.Equal(t, "s3://thebucket/output/1234/index", *input.Settings.OutputGroups[0].OutputGroupSettings.HlsGroupSettings.Destination)
+				return nil, errors.New("secret error")
+			},
+		},
+	}
+	err = mc.Transcode(context.Background(), TranscodeJobArgs{
+		InputFile:     mustParseURL("file://" + f.Name()),
+		HLSOutputFile: mustParseURL("s3+https://endpoint.com/bucket/1234/index.m3u8"),
+	})
+	require.ErrorContains(t, err, "secret error")
+
+	// Check that the file was copied to the osTransferBucketURL folder
+	_, err = os.Stat(transferredFile)
+	require.NoError(t, err)
+}
+
+func mustParseURL(str string) *url.URL {
+	u, err := url.Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
 
 type stubMediaConvertClient struct {
 	createJob func(*mediaconvert.CreateJobInput) (*mediaconvert.CreateJobOutput, error)

--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -61,12 +61,12 @@ func ParseTranscodeProviderURL(input string) (TranscodeProvider, error) {
 		}
 
 		return NewMediaConvertClient(MediaConvertOptions{
-			Endpoint:        endpoint,
-			Region:          region,
-			Role:            role,
-			AccessKeyID:     accessKeyId,
-			AccessKeySecret: accessKeySecret,
-			S3AuxBucket:     s3AuxBucket,
+			Endpoint:         endpoint,
+			Region:           region,
+			Role:             role,
+			AccessKeyID:      accessKeyId,
+			AccessKeySecret:  accessKeySecret,
+			S3TransferBucket: s3AuxBucket,
 		})
 	}
 	return nil, fmt.Errorf("unrecognized OS scheme: %s", u.Scheme)

--- a/clients/transcode_provider_test.go
+++ b/clients/transcode_provider_test.go
@@ -1,0 +1,52 @@
+package clients
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseURLRequiresMandatoryFields(t *testing.T) {
+	testCases := []struct {
+		url string
+		err string
+	}{
+		{"https://wrong.scheme", "unrecognized OS scheme"},
+		{"mediaconvert://", "missing endpoint"},
+		{"mediaconvert://test.com", "missing credentials"},
+		{"mediaconvert://user@test.com", "missing credentials"},
+		{"mediaconvert://user:pwd@test.com", "missing region"},
+		{"mediaconvert://user:pwd@test.com?region=reg", "missing role"},
+		{"mediaconvert://user:pwd@test.com?region=reg&role=me", "invalid s3_aux_bucket"},
+		{"mediaconvert://user:pwd@test.com?region=reg&role=me&s3_aux_bucket=not_an_s3_url", "invalid s3_aux_bucket"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.err, func(t *testing.T) {
+			_, err := ParseTranscodeProviderURL(tc.url)
+			require.ErrorContains(t, err, tc.err)
+		})
+	}
+}
+
+func TestParseURLSendsAllTheRightOptionsToClient(t *testing.T) {
+	require := require.New(t)
+	oldMediaConvertClientFunc := newMediaConvertClientFunc
+	defer func() { newMediaConvertClientFunc = oldMediaConvertClientFunc }()
+
+	callCount := 0
+	newMediaConvertClientFunc = func(opts MediaConvertOptions) (TranscodeProvider, error) {
+		callCount++
+		require.Equal("https://test.com", opts.Endpoint)
+		require.Equal("reg", opts.Region)
+		require.Equal("me", opts.Role)
+		require.Equal("user", opts.AccessKeyID)
+		require.Equal("pwd", opts.AccessKeySecret)
+		require.Equal("s3://bucket", opts.S3TransferBucket.String())
+		return nil, nil
+	}
+
+	_, err := ParseTranscodeProviderURL("mediaconvert://user:pwd@test.com/?region=reg&role=me&s3_aux_bucket=s3://bucket")
+	require.NoError(err)
+	require.Equal(1, callCount)
+}


### PR DESCRIPTION
As part of tech debt week, I'm adding some unit tests to the MediaConvert client here.

Only some minimal changes to the actual core code, from some things I needed to change
to make the tests work to some minor issues I found on the code and could fix as well.

Added tests for some basic error cases as well as full successful run, using only temp local
files for the tests.