### PR TITLE
Switch from 2 pass -> 1 pass encoding

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -210,7 +210,7 @@ func createJobPayload(inputFile, hlsOutputFile, role string, accelerated bool) *
 									H264Settings: &mediaconvert.H264Settings{
 										RateControlMode:    aws.String("QVBR"),
 										SceneChangeDetect:  aws.String("TRANSITION_DETECTION"),
-										QualityTuningLevel: aws.String("MULTI_PASS_HQ"),
+										QualityTuningLevel: aws.String("SINGLE_PASS_HQ"),
 										FramerateControl:   aws.String("INITIALIZE_FROM_SOURCE"),
 									}}},
 							AudioDescriptions: []*mediaconvert.AudioDescription{


### PR DESCRIPTION
Documentation: https://docs.aws.amazon.com/sdk-for-go/api/service/mediaconvert/

Pricing: https://aws.amazon.com/mediaconvert/pricing/