### PR TITLE
Implement VOD pipeline metrics

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -32,6 +32,15 @@ var errCodesAcceleration = []int64{
 }
 var ErrJobAcceleration = errors.New("job should not have acceleration")
 
+type ByteAccumulatorWriter struct {
+	count int64
+}
+
+func (acc *ByteAccumulatorWriter) Write(p []byte) (int, error) {
+	acc.count += int64(len(p))
+	return 0, nil
+}
+
 type MediaConvertOptions struct {
 	Endpoint, Region, Role       string
 	AccessKeyID, AccessKeySecret string
@@ -425,13 +434,4 @@ func contains[T comparable](v T, list []T) bool {
 		}
 	}
 	return false
-}
-
-type ByteAccumulatorWriter struct {
-	count int64
-}
-
-func (acc *ByteAccumulatorWriter) Write(p []byte) (int, error) {
-	acc.count += int64(len(p))
-	return 0, nil
 }

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -87,7 +87,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) er
 	mcOutputRelPath := path.Join("output", targetDir, "index")
 
 	log.Log(args.RequestID, "Copying input file to S3", "source", args.InputFile, "dest", mc.opts.S3AuxBucket.JoinPath(mcInputRelPath), "destOSBaseURL", mc.osTransferBucketURL.String(), "filename", mcInputRelPath)
-	err := copyFile(ctx, args.InputFile.String(), mc.osTransferBucketURL.String(), mcInputRelPath)
+	size, err := copyFile(ctx, args.InputFile.String(), mc.osTransferBucketURL.String(), mcInputRelPath)
 	if err != nil {
 		return fmt.Errorf("error copying input file to S3: %w", err)
 	}
@@ -428,13 +428,10 @@ func contains[T comparable](v T, list []T) bool {
 }
 
 type ByteAccumulatorWriter struct {
-	w     io.Writer
 	count int64
 }
 
 func (acc *ByteAccumulatorWriter) Write(p []byte) (int, error) {
-	n, err := acc.w.Write(p)
-	acc.count += int64(n)
-
-	return n, err
+	acc.count += int64(len(p))
+	return 0, nil
 }

--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -14,6 +14,10 @@ type TranscodeJobArgs struct {
 	RequestID string
 	// Function that should be called every so often with the progress of the job.
 	ReportProgress func(completionRatio float64)
+
+	// Collect size of an asset
+	CollectSourceSize        func(size *int64)
+	CollectTranscodedSegment func()
 }
 
 // TranscodProviders is the interface to an external video processing service

--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -16,7 +16,7 @@ type TranscodeJobArgs struct {
 	ReportProgress func(completionRatio float64)
 
 	// Collect size of an asset
-	CollectSourceSize        func(size *int64)
+	CollectSourceSize        func(size int64)
 	CollectTranscodedSegment func()
 }
 

--- a/handlers/transcode.go
+++ b/handlers/transcode.go
@@ -38,7 +38,7 @@ func (d *CatalystAPIHandlersCollection) TranscodeSegment() httprouter.Handle {
 
 		// Note: This is no longer used pipeline stage
 		// TODO: Revisit later with better mistserver integration
-		_, err = transcode.RunTranscodeProcess(transcodeRequest, "", clients.InputVideo{}, func() {})
+		_, _, err = transcode.RunTranscodeProcess(transcodeRequest, "", clients.InputVideo{})
 		if err != nil {
 			errors.WriteHTTPInternalServerError(w, "Error running Transcode process", err)
 		}

--- a/handlers/transcode.go
+++ b/handlers/transcode.go
@@ -38,7 +38,7 @@ func (d *CatalystAPIHandlersCollection) TranscodeSegment() httprouter.Handle {
 
 		// Note: This is no longer used pipeline stage
 		// TODO: Revisit later with better mistserver integration
-		_, err = transcode.RunTranscodeProcess(transcodeRequest, "", clients.InputVideo{})
+		_, err = transcode.RunTranscodeProcess(transcodeRequest, "", clients.InputVideo{}, func() {})
 		if err != nil {
 			errors.WriteHTTPInternalServerError(w, "Error running Transcode process", err)
 		}

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -3,8 +3,8 @@ package pipeline
 import (
 	"fmt"
 	"net/url"
+	"os"
 	"path"
-	"strconv"
 	"sync"
 	"time"
 
@@ -91,6 +91,17 @@ type JobInfo struct {
 	statusClient clients.TranscodeStatusClient
 	startTime    time.Time
 	result       chan bool
+
+	sourceBytes        int64
+	sourceSegments     int
+	sourceDurationMs   int64
+	sourceCodecVideo   string
+	sourceCodecAudio   string
+	transcodedSegments int
+	pipeline           string
+	catalystRegion     string
+	numProfiles        int
+	state              string
 }
 
 func (j *JobInfo) ReportProgress(stage clients.TranscodeStatus, completionRatio float64) {
@@ -224,6 +235,12 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		statusClient:     c.statusClient,
 		startTime:        time.Now(),
 		result:           make(chan bool, 1),
+
+		pipeline:           handler.Name(),
+		numProfiles:        len(p.Profiles),
+		state:              "segmenting",
+		transcodedSegments: 0,
+		catalystRegion:     os.Getenv("REGION"),
 	}
 	si.ReportProgress(clients.TranscodeStatusPreparing, 0)
 
@@ -300,8 +317,10 @@ func (c *Coordinator) finishJob(job *JobInfo, out *HandlerOutput, err error) {
 			callbackURL = ""
 		}
 		tsm = clients.NewTranscodeStatusError(callbackURL, job.RequestID, err.Error(), errors.IsUnretriable(err))
+		job.state = "failed"
 	} else {
 		tsm = clients.NewTranscodeStatusCompleted(job.CallbackURL, job.RequestID, out.Result.InputVideo, out.Result.Outputs)
+		job.state = "completed"
 	}
 	job.statusClient.SendTranscodeStatus(tsm)
 
@@ -310,9 +329,32 @@ func (c *Coordinator) finishJob(job *JobInfo, out *HandlerOutput, err error) {
 	c.Jobs.Remove(job.StreamName)
 
 	log.Log(job.RequestID, "Finished job and deleted from job cache", "success", success)
-	metrics.Metrics.UploadVODPipelineDurationSec.
-		WithLabelValues(job.handler.Name(), strconv.FormatBool(success)).
+
+	var labels = []string{job.sourceCodecVideo, job.sourceCodecAudio, job.pipeline, job.catalystRegion, fmt.Sprint(job.numProfiles), job.state}
+
+	metrics.Metrics.VODPipelineMetrics.Count.
+		WithLabelValues(labels...).
+		Inc()
+
+	metrics.Metrics.VODPipelineMetrics.Duration.
+		WithLabelValues(labels...).
 		Observe(time.Since(job.startTime).Seconds())
+
+	metrics.Metrics.VODPipelineMetrics.SourceSegments.
+		WithLabelValues(labels...).
+		Observe(float64(job.sourceSegments))
+
+	metrics.Metrics.VODPipelineMetrics.SourceBytes.
+		WithLabelValues(labels...).
+		Observe(float64(job.sourceBytes))
+
+	metrics.Metrics.VODPipelineMetrics.SourceDuration.
+		WithLabelValues(labels...).
+		Observe(float64(job.sourceDurationMs))
+
+	metrics.Metrics.VODPipelineMetrics.SourceSegments.
+		WithLabelValues(labels...).
+		Observe(float64(job.sourceSegments))
 
 	job.result <- success
 }

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -240,7 +240,7 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		numProfiles:        len(p.Profiles),
 		state:              "segmenting",
 		transcodedSegments: 0,
-		catalystRegion:     os.Getenv("REGION"),
+		catalystRegion:     os.Getenv("MY_REGION"),
 	}
 	si.ReportProgress(clients.TranscodeStatusPreparing, 0)
 
@@ -352,9 +352,9 @@ func (c *Coordinator) finishJob(job *JobInfo, out *HandlerOutput, err error) {
 		WithLabelValues(labels...).
 		Observe(float64(job.sourceDurationMs))
 
-	metrics.Metrics.VODPipelineMetrics.SourceSegments.
+	metrics.Metrics.VODPipelineMetrics.TranscodedSegments.
 		WithLabelValues(labels...).
-		Observe(float64(job.sourceSegments))
+		Observe(float64(job.transcodedSegments))
 
 	job.result <- success
 }

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -239,8 +239,8 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		pipeline:           handler.Name(),
 		numProfiles:        len(p.Profiles),
 		state:              "segmenting",
-		transcodedSegments: 0,
 		catalystRegion:     os.Getenv("MY_REGION"),
+		transcodedSegments: 0,
 	}
 	si.ReportProgress(clients.TranscodeStatusPreparing, 0)
 

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -239,8 +239,8 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		pipeline:           handler.Name(),
 		numProfiles:        len(p.Profiles),
 		state:              "segmenting",
-		catalystRegion:     os.Getenv("MY_REGION"),
 		transcodedSegments: 0,
+		catalystRegion:     os.Getenv("MY_REGION"),
 	}
 	si.ReportProgress(clients.TranscodeStatusPreparing, 0)
 

--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -33,6 +33,12 @@ func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		ReportProgress: func(progress float64) {
 			job.ReportProgress(clients.TranscodeStatusTranscoding, progress)
 		},
+		CollectSourceSize: func(size *int64) {
+			job.sourceBytes = *size
+		},
+		CollectTranscodedSegment: func() {
+			job.transcodedSegments++
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("external transcoder error: %w", err)

--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -33,8 +33,8 @@ func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		ReportProgress: func(progress float64) {
 			job.ReportProgress(clients.TranscodeStatusTranscoding, progress)
 		},
-		CollectSourceSize: func(size *int64) {
-			job.sourceBytes = *size
+		CollectSourceSize: func(size int64) {
+			job.sourceBytes = size
 		},
 		CollectTranscodedSegment: func() {
 			job.transcodedSegments++

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -180,16 +180,13 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 
 	job.sourceSegments = len(sourceManifest.Segments)
 
-	job.transcodedSegments = 0
-	segmentsCounter := func() {
-		job.transcodedSegments++
-	}
-
-	outputs, err := transcode.RunTranscodeProcess(transcodeRequest, p.StreamName, inputInfo, segmentsCounter)
+	outputs, transcodedSegments, err := transcode.RunTranscodeProcess(transcodeRequest, p.StreamName, inputInfo)
 	if err != nil {
 		log.LogError(requestID, "RunTranscodeProcess returned an error", err)
 		return nil, fmt.Errorf("transcoding failed: %w", err)
 	}
+
+	job.transcodedSegments = transcodedSegments
 
 	// TODO: CreateDTSH is hardcoded to call MistInMP4 - the call below requires a call to MistInHLS instead.
 	//	 Update this logic later as it's required for Mist playback.

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -141,6 +141,9 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 		ReportProgress:    job.ReportProgress,
 	}
 
+	var audioCodec = ""
+	var videoCodec = ""
+
 	inputInfo := clients.InputVideo{
 		Format:    "mp4", // hardcoded as mist stream is in dtsc format.
 		Duration:  float64(p.StreamMediaDurationMillis) / 1000.0,
@@ -164,10 +167,24 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 				SampleBits: track.Size,
 			},
 		})
+
+		if track.Type == "video" {
+			if videoCodec != "" {
+				videoCodec = "multiple"
+			} else {
+				videoCodec = track.Codec
+			}
+		} else if track.Type == "audio" {
+			if audioCodec != "" {
+				audioCodec = "multiple"
+			} else {
+				audioCodec = track.Codec
+			}
+		}
 	}
 
-	// this is the only info available about codecs, we take the first track but there may be a better way to represent the codecs
-	job.sourceCodecVideo = inputInfo.Tracks[0].Codec
+	job.sourceCodecVideo = videoCodec
+	job.sourceCodecVideo = audioCodec
 
 	job.state = "transcoding"
 	job.sourceBytes = int64(p.WrittenBytes)

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -85,7 +85,7 @@ func init() {
 	LocalBroadcasterClient = b
 }
 
-func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName string, inputInfo clients.InputVideo) ([]clients.OutputVideo, error) {
+func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName string, inputInfo clients.InputVideo, segmentsCounter func()) ([]clients.OutputVideo, error) {
 	log.AddContext(transcodeRequest.RequestID, "source", transcodeRequest.SourceFile, "source_manifest", transcodeRequest.SourceManifestURL, "stream_name", streamName)
 	log.Log(transcodeRequest.RequestID, "RunTranscodeProcess (v2) Beginning")
 
@@ -139,6 +139,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	var jobs *ParallelTranscoding
 	jobs = NewParallelTranscoding(sourceSegmentURLs, func(segment segmentInfo) error {
 		err := transcodeSegment(segment, streamName, manifestID, transcodeRequest, transcodeProfiles, targetTranscodedRenditionOutputURL, transcodedStats)
+		segmentsCounter()
 		if err != nil {
 			return err
 		}

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -129,6 +129,7 @@ func TestItCanTranscode(t *testing.T) {
 				},
 			},
 		},
+		func() {},
 	)
 	require.NoError(t, err)
 

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -109,7 +109,7 @@ func TestItCanTranscode(t *testing.T) {
 
 	statusClient := clients.NewPeriodicCallbackClient(100 * time.Minute)
 	// Check we don't get an error downloading or parsing it
-	outputs, err := RunTranscodeProcess(
+	outputs, segmentsCount, err := RunTranscodeProcess(
 		TranscodeSegmentRequest{
 			CallbackURL:       callbackServer.URL,
 			SourceManifestURL: manifestFile.Name(),
@@ -129,7 +129,6 @@ func TestItCanTranscode(t *testing.T) {
 				},
 			},
 		},
-		func() {},
 	)
 	require.NoError(t, err)
 
@@ -146,6 +145,7 @@ low-bitrate/index.m3u8
 
 	require.NoError(t, err)
 	require.Greater(t, len(masterManifestBytes), 0)
+	require.Equal(t, segmentsCount, 2)
 	require.Equal(t, expectedMasterManifest, string(masterManifestBytes))
 
 	// Start the callback client, to let it run for one iteration


### PR DESCRIPTION
Initial implementation of VOD pipeline metrics

Not all metrics are collected for MediaConvert strategy. `vod_source_segments` and `vod_source_duration` are unavailable for that flow, same for the labels `source_codec_video` and `source_codec_audio`. We could use some ffprobe or mediainfo go library to populate them.

Please, make sure to review the metrics types https://github.com/livepeer/catalyst-api/pull/288/files#diff-d715f391f2ffa038c3167bfea1adf741c1f5e39f08349fbbacab780a594146a4R120, not sure if these are the right types to use.
