### PR TITLE
mediaconvert: Use retryable HTTP client for download during copying

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -12,9 +12,9 @@ import (
 
 const MAX_COPY_DURATION = 20 * time.Minute
 
-var arweaveIPFSHTTPClient = newArweaveIPFSHTTPClient()
+var defaultRetryableHttpClient = newDefaultRetryableHttpClient()
 
-func newArweaveIPFSHTTPClient() *http.Client {
+func newDefaultRetryableHttpClient() *http.Client {
 	client := retryablehttp.NewClient()
 	client.RetryMax = 2                          // Retry a maximum of this+1 times
 	client.RetryWaitMin = 200 * time.Millisecond // Wait at least this long between retries
@@ -29,7 +29,7 @@ func newArweaveIPFSHTTPClient() *http.Client {
 }
 
 func CopyArweaveToS3(arweaveURL, s3URL string) error {
-	resp, err := arweaveIPFSHTTPClient.Get(arweaveURL)
+	resp, err := defaultRetryableHttpClient.Get(arweaveURL)
 	if err != nil {
 		return fmt.Errorf("error fetching Arweave or IPFS URL: %s", err)
 	}

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -275,7 +275,7 @@ func getFileHTTP(ctx context.Context, url string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, xerrors.Unretriable(fmt.Errorf("error creating http request: %w", err))
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := defaultRetryableHttpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error on import request: %w", err)
 	}


### PR DESCRIPTION
Updates:

- Renamed `arweaveIPFSHttpClient` to `defaultRetryableHttpClient` since the configured retryable HTTP client is not Arweave & IPFS specific (although it happens to be particularly useful for fetching data from Arweave & IPFS because the first request for data with these gateways can fail or be slow)
- Use the `defaultRetryableHttpClient` when downloading a file during the copy operation to the S3 transfer bucket used for MC. The use of this client should ensure that we retry requests (up to 3 times with the current config) which should help (at least sometimes) with the recent 504 Gateway Timeouts that we've received from IPFS gateways. See [this comment](https://github.com/livepeer/task-runner/issues/79#issuecomment-1303709294) for additional context.