### PR TITLE
Don't send callbacks out of order

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -89,8 +89,16 @@ func recoverer(f func()) {
 func (pcc *PeriodicCallbackClient) SendTranscodeStatus(tsm TranscodeStatusMessage) {
 	if tsm.URL != "" {
 		pcc.mapLock.Lock()
-		pcc.requestIDToLatestMessage[tsm.RequestID] = tsm
-		pcc.mapLock.Unlock()
+		defer pcc.mapLock.Unlock()
+
+		previousMessage, ok := pcc.requestIDToLatestMessage[tsm.RequestID]
+		previousCompletion := OverallCompletionRatio(previousMessage.Status, previousMessage.CompletionRatio)
+		newCompletion := OverallCompletionRatio(tsm.Status, tsm.CompletionRatio)
+
+		// Don't update the current message with one that represents an earlier stage
+		if !ok || tsm.IsTerminal() || newCompletion >= previousCompletion {
+			pcc.requestIDToLatestMessage[tsm.RequestID] = tsm
+		}
 	}
 
 	rawStatus, _ := json.Marshal(tsm)

--- a/clients/callback_client_status_test.go
+++ b/clients/callback_client_status_test.go
@@ -1,0 +1,32 @@
+package clients
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItCanMarshalStatusToAString(t *testing.T) {
+	var statuses = []TranscodeStatus{
+		TranscodeStatusError,
+		TranscodeStatusCompleted,
+	}
+
+	jsonBytes, err := json.Marshal(statuses)
+	require.NoError(t, err)
+
+	require.JSONEq(t, `["error", "success"]`, string(jsonBytes))
+}
+
+func TestItCanUnmarshalStatusJSON(t *testing.T) {
+	var statusList []TranscodeStatus
+	err := json.Unmarshal([]byte(`["preparing", "success"]`), &statusList)
+	require.NoError(t, err)
+
+	require.Equal(
+		t,
+		[]TranscodeStatus{TranscodeStatusPreparing, TranscodeStatusCompleted},
+		statusList,
+	)
+}

--- a/clients/callback_client_test.go
+++ b/clients/callback_client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -26,7 +27,7 @@ func TestItRetriesOnFailedCallbacks(t *testing.T) {
 		// Check we got a valid callback message of the type we'd expect
 		var actualMsg TranscodeStatusMessage
 		require.NoError(t, json.Unmarshal(body, &actualMsg))
-		require.Equal(t, "success", actualMsg.Status)
+		require.Equal(t, TranscodeStatusCompleted, actualMsg.Status)
 
 		// Return HTTP error codes the first two times
 		atomic.AddInt64(&tries, 1)
@@ -66,7 +67,7 @@ func TestItSendsPeriodicHeartbeats(t *testing.T) {
 		// Check we got a valid callback message of the type we'd expect
 		var actualMsg TranscodeStatusMessage
 		require.NoError(t, json.Unmarshal(body, &actualMsg))
-		require.Equal(t, "success", actualMsg.Status)
+		require.Equal(t, TranscodeStatusCompleted, actualMsg.Status)
 
 		atomic.AddInt64(&tries, 1)
 
@@ -95,7 +96,7 @@ func TestTranscodeStatusErrorNotifcation(t *testing.T) {
 		// Check we got a valid callback message of the type we'd expect
 		var actualMsg TranscodeStatusMessage
 		require.NoError(t, json.Unmarshal(body, &actualMsg))
-		require.Equal(t, "error", actualMsg.Status)
+		require.Equal(t, TranscodeStatusError, actualMsg.Status)
 		require.Equal(t, "something went wrong", actualMsg.Error)
 
 		atomic.AddInt64(&requestCount, 1)
@@ -110,6 +111,51 @@ func TestTranscodeStatusErrorNotifcation(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	require.Equal(t, int64(1), atomic.LoadInt64(&requestCount))
+}
+
+// Updates might still theoretically arrive at the callback endpoint out of order,
+// but this test ensures that we don't send one progress callback of X% completion
+// and then repeatedly send one with < X% completion
+// (i.e that our internal state never regresses)
+func TestItDoesntSendOutOfOrderUpdates(t *testing.T) {
+	// Counter for the number of retries we've done
+	var tries int64
+	var latestCompletion float64
+	var latestCompletionMutex sync.Mutex
+
+	// Set up a dummy server to receive the callbacks
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Check that we got the callback we're expecting
+		body, err := io.ReadAll(r.Body)
+		require.NoError(t, err)
+
+		// Check we got a valid callback message of the type we'd expect
+		var actualMsg TranscodeStatusMessage
+		require.NoError(t, json.Unmarshal(body, &actualMsg))
+
+		atomic.AddInt64(&tries, 1)
+		latestCompletionMutex.Lock()
+		latestCompletion = actualMsg.CompletionRatio
+		latestCompletionMutex.Unlock()
+
+		// Return an error code
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer svr.Close()
+
+	// Send the callback and confirm the number of times we retried
+	client := NewPeriodicCallbackClient(100 * time.Millisecond).Start()
+	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusTranscoding, 1))
+	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusPreparing, 1))
+	time.Sleep(400 * time.Millisecond)
+
+	// Sanity check that the client has sent multiple callbacks in this timeframe
+	require.Greater(t, atomic.LoadInt64(&tries), int64(2), "Expected the client to have sent multiple status updates within the timeframe")
+
+	// Check that we're being sent the latest message in terms of progress, rather than order of being sent
+	latestCompletionMutex.Lock()
+	defer latestCompletionMutex.Unlock()
+	require.Equal(t, 0.9, latestCompletion)
 }
 
 func TestItCalculatesTheOverallCompletionRatioCorrectly(t *testing.T) {

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -236,7 +236,7 @@ waitsegmenting:
 		select {
 		case message := <-callbacks:
 			// 0.2 is final progress reported for TranscodeStatusPreparing from UploadVOD()
-			if message.Status == "preparing" && message.CompletionRatio == clients.OverallCompletionRatio(clients.TranscodeStatusPreparing, 0.3) {
+			if message.Status == clients.TranscodeStatusPreparing && message.CompletionRatio == clients.OverallCompletionRatio(clients.TranscodeStatusPreparing, 0.3) {
 				break waitsegmenting
 			}
 			// Fail on any error in callbacks
@@ -275,7 +275,7 @@ waitsegmenting:
 	for {
 		select {
 		case message := <-callbacks:
-			if message.Status == "success" {
+			if message.Status == clients.TranscodeStatusCompleted {
 				return
 			}
 			require.Equal(t, "", message.Error, "received error callback")

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -48,11 +48,11 @@ func TestCoordinatorDoesNotBlock(t *testing.T) {
 
 	require.True(running.Load())
 	msg := requireReceive(t, callbacks, 1*time.Second)
-	require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 	close(barrier)
 	msg = requireReceive(t, callbacks, 1*time.Second)
-	require.Equal(clients.TranscodeStatusError.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusError, msg.Status)
 	require.Contains(msg.Error, "test error")
 
 	require.Zero(len(callbacks))
@@ -105,10 +105,10 @@ func TestCoordinatorResistsPanics(t *testing.T) {
 	coord.StartUploadJob(testJob)
 
 	require.Equal(1, len(callbacks))
-	require.Equal(clients.TranscodeStatusPreparing.String(), (<-callbacks).Status)
+	require.Equal(clients.TranscodeStatusPreparing, (<-callbacks).Status)
 
 	msg := requireReceive(t, callbacks, 1*time.Second)
-	require.Equal(clients.TranscodeStatusError.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusError, msg.Status)
 	require.Contains(msg.Error, "oh no")
 }
 
@@ -160,7 +160,7 @@ func TestCoordinatorBackgroundJobsStrategies(t *testing.T) {
 
 		msg := requireReceive(t, callbacks, 1*time.Second)
 		require.NotZero(msg.URL)
-		require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+		require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 		fgJob := requireReceive(t, foregroundCalls, 1*time.Second)
 		require.Equal("123", fgJob.RequestID)
@@ -171,7 +171,7 @@ func TestCoordinatorBackgroundJobsStrategies(t *testing.T) {
 		// Test that foreground job is the real one: status callbacks ARE reported
 		msg = requireReceive(t, callbacks, 1*time.Second)
 		require.NotZero(msg.URL)
-		require.Equal(clients.TranscodeStatusCompleted.String(), msg.Status)
+		require.Equal(clients.TranscodeStatusCompleted, msg.Status)
 		require.Equal("123", msg.RequestID)
 
 		time.Sleep(1 * time.Second)
@@ -198,14 +198,14 @@ func TestCoordinatorFallbackStrategySuccess(t *testing.T) {
 	coord.StartUploadJob(testJob)
 
 	msg := requireReceive(t, callbacks, 1*time.Second)
-	require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 	mistJob := requireReceive(t, mistCalls, 1*time.Second)
 	require.Equal("123", mistJob.RequestID)
 
 	// Check successful completion of the mist event
 	msg = requireReceive(t, callbacks, 1*time.Second)
-	require.Equal(clients.TranscodeStatusCompleted.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusCompleted, msg.Status)
 
 	time.Sleep(1 * time.Second)
 	require.Zero(len(mistCalls))
@@ -235,7 +235,7 @@ func TestCoordinatorFallbackStrategyFailure(t *testing.T) {
 
 	msg := requireReceive(t, callbacks, 1*time.Second)
 	require.Equal("123", msg.RequestID)
-	require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 	mistJob := requireReceive(t, mistCalls, 1*time.Second)
 	require.Equal("123", mistJob.RequestID)
@@ -243,7 +243,7 @@ func TestCoordinatorFallbackStrategyFailure(t *testing.T) {
 	// External provider pipeline will trigger the initial preparing trigger as well
 	msg = requireReceive(t, callbacks, 1*time.Second)
 	require.Equal("123", msg.RequestID)
-	require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 	meconJob := requireReceive(t, externalCalls, 1*time.Second)
 	require.Equal("123", meconJob.RequestID)
@@ -253,12 +253,12 @@ func TestCoordinatorFallbackStrategyFailure(t *testing.T) {
 	msg = requireReceive(t, callbacks, 1*time.Second)
 	require.NotZero(msg.URL)
 	require.Equal("123", msg.RequestID)
-	require.Equal(clients.TranscodeStatusPreparing.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 	require.Equal(clients.OverallCompletionRatio(clients.TranscodeStatusPreparing, 0.2), msg.CompletionRatio)
 
 	msg = requireReceive(t, callbacks, 1*time.Second)
 	require.Equal("123", msg.RequestID)
-	require.Equal(clients.TranscodeStatusCompleted.String(), msg.Status)
+	require.Equal(clients.TranscodeStatusCompleted, msg.Status)
 
 	time.Sleep(1 * time.Second)
 	require.Zero(len(mistCalls))


### PR DESCRIPTION
This ensures that if we send a message with completion ratio X, we don't then repeatedly send a message with completion ratio < X.

The change itself is quite a small check in the code where we update our internal `Request ID -> Status` mapping, but I also updated our JSON mapping to be strongly typed rather than using a string for the Status Message.