### PR TITLE
Increase linting timeout from 1m (default) -> 3m

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout 3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true


### PR DESCRIPTION
I've been seeing this step failing because of the timeout. Looks from https://github.com/golangci/golangci-lint-action/issues/297 like the default has just become a bit too short for the number of linters it runs.