### PR TITLE
Use requestID in the transfer bucket path

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout 3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,7 +30,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout 3m
+          # args: --issues-exit-code=0
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -90,7 +90,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) er
 	if path.Base(args.HLSOutputFile.Path) != "index.m3u8" {
 		return fmt.Errorf("target URL must be an `index.m3u8` file, found %s", args.HLSOutputFile)
 	}
-	targetDir := path.Join(args.RequestID, getTargetDir(args.HLSOutputFile))
+	targetDir := getTargetDir(args)
 
 	mcInputRelPath := path.Join("input", targetDir, "video")
 	// AWS MediaConvert adds the .m3u8 to the end of the output file name
@@ -421,7 +421,11 @@ func trimBaseDir(osPath, filePath string) string {
 }
 
 // Returns the directory where the files will be stored given an OS URL
-func getTargetDir(url *url.URL) string {
+func getTargetDir(args TranscodeJobArgs) string {
+	var (
+		url       = args.HLSOutputFile
+		requestID = args.RequestID
+	)
 	// remove the file name
 	dir := path.Dir(url.Path)
 	if url.Scheme == "s3" || strings.HasPrefix(url.Scheme, "s3+") {
@@ -434,7 +438,7 @@ func getTargetDir(url *url.URL) string {
 			dir = ""
 		}
 	}
-	return dir
+	return path.Join(requestID, dir)
 }
 
 func contains[T comparable](v T, list []T) bool {

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/livepeer/catalyst-api/config"
 	"io"
 	"net/http"
 	"net/url"
@@ -90,7 +91,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) er
 	if path.Base(args.HLSOutputFile.Path) != "index.m3u8" {
 		return fmt.Errorf("target URL must be an `index.m3u8` file, found %s", args.HLSOutputFile)
 	}
-	targetDir := path.Join(args.RequestID, getTargetDir(args.HLSOutputFile))
+	targetDir := path.Join(config.RandomTrailer(10), getTargetDir(args.HLSOutputFile))
 
 	mcInputRelPath := path.Join("input", targetDir, "video")
 	// AWS MediaConvert adds the .m3u8 to the end of the output file name

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -90,7 +90,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) er
 	if path.Base(args.HLSOutputFile.Path) != "index.m3u8" {
 		return fmt.Errorf("target URL must be an `index.m3u8` file, found %s", args.HLSOutputFile)
 	}
-	targetDir := getTargetDir(args.HLSOutputFile)
+	targetDir := path.Join(args.RequestID, getTargetDir(args.HLSOutputFile))
 
 	mcInputRelPath := path.Join("input", targetDir, "video")
 	// AWS MediaConvert adds the .m3u8 to the end of the output file name

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/livepeer/catalyst-api/config"
 	"io"
 	"net/http"
 	"net/url"
@@ -91,7 +90,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) er
 	if path.Base(args.HLSOutputFile.Path) != "index.m3u8" {
 		return fmt.Errorf("target URL must be an `index.m3u8` file, found %s", args.HLSOutputFile)
 	}
-	targetDir := path.Join(config.RandomTrailer(10), getTargetDir(args.HLSOutputFile))
+	targetDir := path.Join(args.RequestID, getTargetDir(args.HLSOutputFile))
 
 	mcInputRelPath := path.Join("input", targetDir, "video")
 	// AWS MediaConvert adds the .m3u8 to the end of the output file name


### PR DESCRIPTION
Introduce `requestID` into the transfer bucket path for MediaConvert. 

Before, we didn't use any randomness in the path. That was not an issue while using assets in Studio, because Studio creates a random ID for each asset. However, it became an issue while introducing Transcode API, where users can define their own output directory. Without any randomness, one request could overwrite another requests.

fix https://github.com/livepeer/catalyst/issues/344