### PR TITLE
add new postgres metrics fields

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -380,8 +380,43 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo) {
 	if job.TargetURL != nil {
 		targetURL = job.TargetURL.String()
 	}
-	insertDynStmt := `insert into "vod_completed"("finished_at", "started_at", "request_id", "source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "state", "profiles_count", "job_duration", "source_segment_count", "transcoded_segment_count", "source_bytes_count", "source_duration", "source_url", "target_url") values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
-	_, err := c.MetricsDB.Exec(insertDynStmt, time.Now().Unix(), job.startTime.Unix(), job.RequestID, job.sourceCodecVideo, job.sourceCodecAudio, job.pipeline, job.catalystRegion, job.state, job.numProfiles, time.Since(job.startTime).Milliseconds(), job.sourceSegments, job.transcodedSegments, job.sourceBytes, job.sourceDurationMs, job.SourceFile, targetURL)
+	insertDynStmt := `insert into "vod_completed"(
+                            "finished_at",
+                            "started_at",
+                            "request_id",
+                            "source_codec_video",
+                            "source_codec_audio",
+                            "pipeline",
+                            "catalyst_region",
+                            "state",
+                            "profiles_count",
+                            "job_duration",
+                            "source_segment_count",
+                            "transcoded_segment_count",
+                            "source_bytes_count",
+                            "source_duration",
+                            "source_url",
+                            "target_url"
+                            ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+	_, err := c.MetricsDB.Exec(
+		insertDynStmt,
+		time.Now().Unix(),
+		job.startTime.Unix(),
+		job.RequestID,
+		job.sourceCodecVideo,
+		job.sourceCodecAudio,
+		job.pipeline,
+		job.catalystRegion,
+		job.state,
+		job.numProfiles,
+		time.Since(job.startTime).Milliseconds(),
+		job.sourceSegments,
+		job.transcodedSegments,
+		job.sourceBytes,
+		job.sourceDurationMs,
+		job.SourceFile,
+		targetURL,
+	)
 	if err != nil {
 		log.LogError(job.RequestID, "error writing postgres metrics", err)
 		return

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -376,8 +376,12 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo) {
 		return
 	}
 
-	insertDynStmt := `insert into "vod_completed"("timestamp", "request_id", "source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "state", "profiles_count", "job_duration", "source_segment_count", "transcoded_segment_count", "source_bytes_count", "source_duration") values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
-	_, err := c.MetricsDB.Exec(insertDynStmt, time.Now().Unix(), job.RequestID, job.sourceCodecVideo, job.sourceCodecAudio, job.pipeline, job.catalystRegion, job.state, job.numProfiles, time.Since(job.startTime).Milliseconds(), job.sourceSegments, job.transcodedSegments, job.sourceBytes, job.sourceDurationMs)
+	targetURL := ""
+	if job.TargetURL != nil {
+		targetURL = job.TargetURL.String()
+	}
+	insertDynStmt := `insert into "vod_completed"("finished_at", "started_at", "request_id", "source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "state", "profiles_count", "job_duration", "source_segment_count", "transcoded_segment_count", "source_bytes_count", "source_duration", "source_url", "target_url") values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`
+	_, err := c.MetricsDB.Exec(insertDynStmt, time.Now().Unix(), job.startTime.Unix(), job.RequestID, job.sourceCodecVideo, job.sourceCodecAudio, job.pipeline, job.catalystRegion, job.state, job.numProfiles, time.Since(job.startTime).Milliseconds(), job.sourceSegments, job.transcodedSegments, job.sourceBytes, job.sourceDurationMs, job.SourceFile, targetURL)
 	if err != nil {
 		log.LogError(job.RequestID, "error writing postgres metrics", err)
 		return

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -302,6 +302,7 @@ func setJobInfoFields(job *JobInfo) {
 	job.transcodedSegments = 3
 	job.sourceBytes = 4
 	job.sourceDurationMs = 5
+	job.startTime = time.Unix(0, 0)
 }
 
 func TestPipelineCollectedMetrics(t *testing.T) {
@@ -327,7 +328,7 @@ func TestPipelineCollectedMetrics(t *testing.T) {
 	require.NoError(err)
 	dbMock.
 		ExpectExec("insert into \"vod_completed\".*").
-		WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5).
+		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, "source-file", "s3+https://storage.google.com/bucket/key").
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	coord := NewStubCoordinatorOpts(StrategyBackgroundMist, nil, mist, external)


### PR DESCRIPTION
To address https://github.com/livepeer/catalyst-api/issues/278

Column changes:
- renaming `timestamp` to `finished_at`
- adding `started_at`, `source_url` and `target_url`