### PR TITLE
mist: check content-type header for video tag for arweave/ipfs urls only

### DIFF
--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -38,12 +38,12 @@ func (m *mist) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	job.SegmentingTargetURL = segmentingTargetURL.String()
 	log.AddContext(job.RequestID, "segmented_url", job.SegmentingTargetURL)
 
-	if !isVideo(job.RequestID, job.SourceFile) {
-		return nil, fmt.Errorf("source was not a video: %s", job.SourceFile)
-	}
 	// Arweave URLs don't support HTTP Range requests and so Mist can't natively handle them for segmenting
 	// This workaround copies the file from Arweave to S3 and then tells Mist to use the S3 URL
 	if clients.IsArweaveOrIPFSURL(job.SourceFile) {
+		if !isVideo(job.RequestID, job.SourceFile) {
+			return nil, fmt.Errorf("source was not a video: %s", job.SourceFile)
+		}
 		sourceURL, err := url.Parse(job.SourceFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse source as URL: %w", err)


### PR DESCRIPTION
Google S3 source URLs have content-type as follows:
	`content-type: application/octet-stream`
Only check content-type for video tags when arweave/ipfs URLs are detected.

#\fix 369