### PR TITLE
Accept ucan key provided by infra

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func main() {
 	metricsDBConnectionString := flag.String("metrics-db-connection-string", "", "Connection string to use for the metrics Postgres DB. Takes the form: host=X port=X user=X password=X dbname=X")
 	URLSliceVarFlag(&config.ImportIPFSGatewayURLs, "import-ipfs-gateway-urls", "https://vod-import-gtw.mypinata.cloud/ipfs/?pinataGatewayToken={{secrets.LP_PINATA_GATEWAY_TOKEN}},https://w3s.link/ipfs/,https://ipfs.io/ipfs/,https://cloudflare-ipfs.com/ipfs/", "Comma delimited ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from")
 	URLSliceVarFlag(&config.ImportArweaveGatewayURLs, "import-arweave-gateway-urls", "https://arweave.net/", "Comma delimited ordered list of arweave gateways")
+	_ = flag.String("ucan-key", "", "base64 UCAN ed25519 secret key")
 	flag.Parse()
 
 	if *mistJson {


### PR DESCRIPTION
This change is needed to not break changes coming from livepeer-infra [1] passing ucan secret key as argument to catalyst-api.

[1] https://github.com/livepeer/catalyst/issues/363