### PR TITLE
Remove seg_ prefix from Mist target URL

### DIFF
--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -289,7 +289,7 @@ func inSameDirectory(base url.URL, paths ...string) (*url.URL, error) {
 //	s3+https://xyz:xyz@storage.googleapis.com/a/b/c/seg_$currentMediaTime.ts?m3u8=index.m3u8&split=5
 func targetURLToMistTargetURL(targetURL url.URL) (string, error) {
 	targetManifestFilename := path.Base(targetURL.Path)
-	segmentingTargetURL, err := inSameDirectory(targetURL, MIST_SEGMENTING_SUBDIR, "seg_$currentMediaTime.ts")
+	segmentingTargetURL, err := inSameDirectory(targetURL, MIST_SEGMENTING_SUBDIR, "$currentMediaTime.ts")
 	if err != nil {
 		return "", fmt.Errorf("cannot create segmentingTargetURL: %w", err)
 	}

--- a/pipeline/mist_test.go
+++ b/pipeline/mist_test.go
@@ -107,7 +107,7 @@ func TestItConvertsS3TargetURLToMistTargetURLCorrectly(t *testing.T) {
 
 	require.Equal(
 		t,
-		"s3+https://abc:def@storage.googleapis.com/a/b/c/source/seg_$currentMediaTime.ts?m3u8=index.m3u8&split=5",
+		"s3+https://abc:def@storage.googleapis.com/a/b/c/source/$currentMediaTime.ts?m3u8=index.m3u8&split=5",
 		mistTargetURL,
 	)
 }
@@ -121,7 +121,7 @@ func TestItConvertsLocalPathToMistTargetCorrectly(t *testing.T) {
 
 	require.Equal(
 		t,
-		"/a/b/c/source/seg_$currentMediaTime.ts?m3u8=index.m3u8&split=5",
+		"/a/b/c/source/$currentMediaTime.ts?m3u8=index.m3u8&split=5",
 		mistTargetURL,
 	)
 }


### PR DESCRIPTION
This is just to make it match up with our current implementation