### PR TITLE
fix duplicate profile

### DIFF
--- a/video/profiles.go
+++ b/video/profiles.go
@@ -93,7 +93,7 @@ func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 	for _, profile := range DefaultTranscodeProfiles {
 		// transcoding job will adjust the width to match aspect ratio. no need to
 		// check it here.
-		lowerQualityThanSrc := profile.Height <= video.Height && profile.Bitrate < video.Bitrate
+		lowerQualityThanSrc := profile.Height < video.Height && profile.Bitrate < video.Bitrate
 		if lowerQualityThanSrc {
 			profiles = append(profiles, profile)
 		}

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -13,18 +13,33 @@ func TestGetPlaybackProfiles(t *testing.T) {
 		want  []EncodedProfile
 	}{
 		{
-			name: "low bitrate 720p input",
+			name: "360p input",
 			track: InputTrack{
 				Type:    "video",
-				Bitrate: 1_000_000,
+				Bitrate: 800_001,
 				VideoTrack: VideoTrack{
-					Width:  1200,
-					Height: 720,
+					Width:  640,
+					Height: 360,
 				},
 			},
 			want: []EncodedProfile{
-				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
-				{Name: "720p0", Width: 1200, Height: 720, Bitrate: 1_000_000},
+				{Name: "low-bitrate", Width: 640, Height: 360, Bitrate: 400_000},
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_001},
+			},
+		},
+		{
+			name: "low bitrate 360p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 500_000,
+				VideoTrack: VideoTrack{
+					Width:  640,
+					Height: 360,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "low-bitrate", Width: 640, Height: 360, Bitrate: 250_000},
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 500_000},
 			},
 		},
 		{
@@ -43,6 +58,21 @@ func TestGetPlaybackProfiles(t *testing.T) {
 			},
 		},
 		{
+			name: "low bitrate 720p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 1_000_000,
+				VideoTrack: VideoTrack{
+					Width:  1200,
+					Height: 720,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
+				{Name: "720p0", Width: 1200, Height: 720, Bitrate: 1_000_000},
+			},
+		},
+		{
 			name: "1080p input",
 			track: InputTrack{
 				Type:    "video",
@@ -56,21 +86,6 @@ func TestGetPlaybackProfiles(t *testing.T) {
 				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
 				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 3_000_000},
 				{Name: "1080p0", Width: 1920, Height: 1080, Bitrate: 5_000_000},
-			},
-		},
-		{
-			name: "low bitrate 360p input",
-			track: InputTrack{
-				Type:    "video",
-				Bitrate: 500_000,
-				VideoTrack: VideoTrack{
-					Width:  640,
-					Height: 360,
-				},
-			},
-			want: []EncodedProfile{
-				{Name: "low-bitrate", Width: 640, Height: 360, Bitrate: 250_000},
-				{Name: "360p0", Width: 640, Height: 360, Bitrate: 500_000},
 			},
 		},
 	}

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -1,0 +1,86 @@
+package video
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlaybackProfiles(t *testing.T) {
+	tests := []struct {
+		name  string
+		track InputTrack
+		want  []EncodedProfile
+	}{
+		{
+			name: "low bitrate 720p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 1_000_000,
+				VideoTrack: VideoTrack{
+					Width:  1200,
+					Height: 720,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
+				{Name: "720p0", Width: 1200, Height: 720, Bitrate: 1_000_000},
+			},
+		},
+		{
+			name: "720p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 3_000_001,
+				VideoTrack: VideoTrack{
+					Width:  1280,
+					Height: 720,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
+				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 3_000_001},
+			},
+		},
+		{
+			name: "1080p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 5_000_000,
+				VideoTrack: VideoTrack{
+					Width:  1920,
+					Height: 1080,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
+				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 3_000_000},
+				{Name: "1080p0", Width: 1920, Height: 1080, Bitrate: 5_000_000},
+			},
+		},
+		{
+			name: "low bitrate 360p input",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 500_000,
+				VideoTrack: VideoTrack{
+					Width:  640,
+					Height: 360,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "low-bitrate", Width: 640, Height: 360, Bitrate: 250_000},
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 500_000},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GetPlaybackProfiles(InputVideo{
+				Tracks: []InputTrack{tt.track},
+			})
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Previously the `lowerQualityThanSrc` condition would match if the heights were equal, which would result in a duplicate profile because we are then adding a profile with height equal to the input [lower down in the function](https://github.com/livepeer/catalyst-api/compare/mh/fix-duplicate-profile?expand=1#diff-7bbc069c84bd3dadf5c408f6c62b025837d72035cd18c8cea4b70a4d12efd1c1R104)

E.g. you'd end up with a set of profiles like:
```
				{Name: "360p0", Width: 640, Height: 360, Bitrate: 800_000},
				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 3_000_000},
				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 3_000_001},
```
MediaConvert errors on this because the output paths clash (due to the duplicate profile name). 