### PR TITLE
Bump maximum bitrate for default profiles

### DIFF
--- a/clients/fixtures/mediaconvert_payloads/happy.txt
+++ b/clients/fixtures/mediaconvert_payloads/happy.txt
@@ -45,7 +45,7 @@
                 H264Settings: {
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
-                  MaxBitrate: 800000,
+                  MaxBitrate: 1000000,
                   QualityTuningLevel: "MULTI_PASS_HQ",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
@@ -74,7 +74,7 @@
                 H264Settings: {
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
-                  MaxBitrate: 3000000,
+                  MaxBitrate: 4000000,
                   QualityTuningLevel: "MULTI_PASS_HQ",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
@@ -118,7 +118,7 @@
                 H264Settings: {
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
-                  MaxBitrate: 800000,
+                  MaxBitrate: 1000000,
                   QualityTuningLevel: "MULTI_PASS_HQ",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
@@ -147,7 +147,7 @@
                 H264Settings: {
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
-                  MaxBitrate: 3000000,
+                  MaxBitrate: 4000000,
                   QualityTuningLevel: "MULTI_PASS_HQ",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -54,31 +54,17 @@ type InputTrack struct {
 
 // DefaultTranscodeProfiles defines the default set of encoding profiles to use when none are specified
 var DefaultTranscodeProfiles = []EncodedProfile{
-	// {
-	// 	Name:    "240p0",
-	// 	FPS:     0,
-	// 	Bitrate: 250_000,
-	// 	Width:   426,
-	// 	Height:  240,
-	// },
 	{
 		Name:    "360p0",
 		FPS:     0,
-		Bitrate: 800_000,
+		Bitrate: 1_000_000,
 		Width:   640,
 		Height:  360,
 	},
-	// {
-	// 	Name:    "480p0",
-	// 	FPS:     0,
-	// 	Bitrate: 1_600_000,
-	// 	Width:   854,
-	// 	Height:  480,
-	// },
 	{
 		Name:    "720p0",
 		FPS:     0,
-		Bitrate: 3_000_000,
+		Bitrate: 4_000_000,
 		Width:   1280,
 		Height:  720,
 	},


### PR DESCRIPTION
Trying this out to see if we can improve our Livepeer pipeline transcodes