### PR TITLE
revert studio message change

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -215,16 +215,8 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) ([
 		{
 			Type:     "object_store",
 			Manifest: args.HLSOutputFile.String(),
-			Videos:   mc.outputVideoFiles(mcArgs, ourOutputBaseDir, "index", "m3u8"),
+			Videos:   []OutputVideoFile{},
 		},
-	}
-	if mcArgs.MP4OutputLocation != nil {
-		mp4OutVid := OutputVideo{
-			Type:     "object_store",
-			Manifest: "",
-		}
-		mp4OutVid.Videos = mc.outputVideoFiles(mcArgs, ourOutputBaseDir, mp4OutFilePrefix, "mp4")
-		outputVideos = append(outputVideos, mp4OutVid)
 	}
 	return outputVideos, nil
 }

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -218,6 +218,19 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) ([
 			Videos:   []OutputVideoFile{},
 		},
 	}
+
+	if mcArgs.MP4OutputLocation != nil {
+		// mp4OutVid := OutputVideo{
+		// Type:     "object_store",
+		// Manifest: "",
+		// }
+
+		// Temporary commenting until we fix task-runner panic
+		_ = mc.outputVideoFiles(mcArgs, ourOutputBaseDir, mp4OutFilePrefix, "mp4")
+		// mp4OutVid.Videos = mc.outputVideoFiles(mcArgs, ourOutputBaseDir, mp4OutFilePrefix, "mp4")
+		// outputVideos = append(outputVideos, mp4OutVid)
+	}
+
 	return outputVideos, nil
 }
 


### PR DESCRIPTION
the extra mp4 outputs in the message were causing a nil panic in task-runner