### PR TITLE
introduce auto_mp4 request flag

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -162,7 +162,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) ([
 	}
 
 	// only output MP4s for short videos, with duration less than maxMP4OutDuration
-	if mcArgs.InputFileInfo.Duration <= maxMP4OutDuration.Seconds() {
+	if args.AutoMP4 && mcArgs.InputFileInfo.Duration <= maxMP4OutDuration.Seconds() {
 		// sets the mp4 path to be the same as HLS except for the suffix being "static"
 		// resulting files look something like https://storage.googleapis.com/bucket/25afy0urw3zu2476/static360p0.mp4
 		mcArgs.MP4OutputLocation = mc.s3TransferBucket.JoinPath(path.Join("output", targetDir, mp4OutFilePrefix))

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -356,6 +356,7 @@ func Test_MP4OutDurationCheck(t *testing.T) {
 				InputFile:         mustParseURL(t, "file://"+f.Name()),
 				HLSOutputFile:     mustParseURL(t, "s3+https://endpoint.com/bucket/1234/index.m3u8"),
 				CollectSourceSize: func(size int64) {},
+				AutoMP4:           true,
 			})
 			require.Error(err)
 		})

--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -19,6 +19,7 @@ type TranscodeJobArgs struct {
 	// Input File info used to by transcoder provider(s) to set transcode options
 	InputFileInfo video.InputVideo
 	Profiles      []video.EncodedProfile
+	AutoMP4       bool
 
 	// Collect size of an asset
 	CollectSourceSize        func(size int64)

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -25,6 +25,7 @@ type UploadVODRequestOutputLocationOutputs struct {
 	SourceMp4          bool `json:"source_mp4"`
 	SourceSegments     bool `json:"source_segments"`
 	TranscodedSegments bool `json:"transcoded_segments"`
+	AutoMP4            bool `json:"auto_mp4"`
 }
 
 type UploadVODRequestOutputLocation struct {
@@ -84,6 +85,15 @@ func (r UploadVODRequest) getTargetURL() (*url.URL, error) {
 		}
 	}
 	return nil, fmt.Errorf("no output_location with transcoded_segments")
+}
+
+func (r UploadVODRequest) isAutoMP4() bool {
+	for _, o := range r.OutputLocations {
+		if o.Outputs.AutoMP4 {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
@@ -161,6 +171,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 		RequestID:        requestID,
 		Profiles:         uploadVODRequest.Profiles,
 		PipelineStrategy: uploadVODRequest.PipelineStrategy,
+		AutoMP4:          uploadVODRequest.isAutoMP4(),
 	})
 
 	respBytes, err := json.Marshal(UploadVODResponse{RequestID: requestID})

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -78,22 +78,13 @@ func (r UploadVODRequest) getSourceOutputURL() (*url.URL, error) {
 	return nil, nil
 }
 
-func (r UploadVODRequest) getTargetURL() (*url.URL, error) {
+func (r UploadVODRequest) getTargetOutput() (UploadVODRequestOutputLocation, error) {
 	for _, o := range r.OutputLocations {
 		if o.Outputs.TranscodedSegments {
-			return url.Parse(o.URL)
+			return o, nil
 		}
 	}
-	return nil, fmt.Errorf("no output_location with transcoded_segments")
-}
-
-func (r UploadVODRequest) isAutoMP4() bool {
-	for _, o := range r.OutputLocations {
-		if o.Outputs.AutoMP4 {
-			return true
-		}
-	}
-	return false
+	return UploadVODRequestOutputLocation{}, fmt.Errorf("no output_location with transcoded_segments")
 }
 
 func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
@@ -137,7 +128,11 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 
 	// Create a separate subdirectory for the source segments
 	// Use the output directory specified in request as the output directory of transcoded renditions
-	targetURL, err := uploadVODRequest.getTargetURL()
+	targetOutput, err := uploadVODRequest.getTargetOutput()
+	if err != nil {
+		return false, errors.WriteHTTPBadRequest(w, "Invalid request payload", err)
+	}
+	targetURL, err := url.Parse(targetOutput.URL)
 	if err != nil {
 		return false, errors.WriteHTTPBadRequest(w, "Invalid request payload", err)
 	}
@@ -171,7 +166,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 		RequestID:        requestID,
 		Profiles:         uploadVODRequest.Profiles,
 		PipelineStrategy: uploadVODRequest.PipelineStrategy,
-		AutoMP4:          uploadVODRequest.isAutoMP4(),
+		AutoMP4:          targetOutput.Outputs.AutoMP4,
 	})
 
 	respBytes, err := json.Marshal(UploadVODResponse{RequestID: requestID})

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -65,7 +65,7 @@ func TestGetTargetURL(t *testing.T) {
 	tests := []struct {
 		name        string
 		req         UploadVODRequest
-		expectedURL *url.URL
+		expectedURL string
 		isErr       bool
 	}{
 		{
@@ -76,7 +76,7 @@ func TestGetTargetURL(t *testing.T) {
 					SourceSegments:     true,
 					TranscodedSegments: true,
 				}}}},
-			expectedURL: toUrl("s3+https://user:pass@bucket"),
+			expectedURL: "s3+https://user:pass@bucket",
 		},
 		{
 			name: "multiple output locations",
@@ -95,26 +95,26 @@ func TestGetTargetURL(t *testing.T) {
 					},
 				},
 			}},
-			expectedURL: toUrl("s3+https://first:first@bucket"),
+			expectedURL: "s3+https://first:first@bucket",
 		},
 		{
 			name:        "empty output locations",
 			req:         UploadVODRequest{OutputLocations: []UploadVODRequestOutputLocation{}},
-			expectedURL: nil,
+			expectedURL: "",
 			isErr:       true,
 		},
 		{
 			name:        "nil output locations",
 			req:         UploadVODRequest{},
-			expectedURL: nil,
+			expectedURL: "",
 			isErr:       true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := tt.req.getTargetURL()
-			require.Equal(t, tt.expectedURL, got)
+			got, err := tt.req.getTargetOutput()
+			require.Equal(t, tt.expectedURL, got.URL)
 			if tt.isErr {
 				require.Error(t, err)
 			} else {

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -60,6 +60,7 @@ type UploadJobPayload struct {
 	RequestID             string
 	Profiles              []video.EncodedProfile
 	PipelineStrategy      Strategy
+	AutoMP4               bool
 }
 
 // UploadJobResult is the object returned by the successful execution of an

--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -32,6 +32,7 @@ func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		InputFile:     sourceFileUrl,
 		HLSOutputFile: job.TargetURL,
 		Profiles:      job.Profiles,
+		AutoMP4:       job.AutoMP4,
 		ReportProgress: func(progress float64) {
 			job.ReportProgress(clients.TranscodeStatusTranscoding, progress)
 		},


### PR DESCRIPTION
only generate mp4s if auto_mp4 request flag is set and input duration is less than 2mins

Fixes https://github.com/livepeer/catalyst-api/issues/418