### PR TITLE
probe: add check for jpeg/mpeg type of inputs

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -39,11 +39,16 @@ func (p Probe) ProbeFile(url string) (iv InputVideo, err error) {
 }
 
 func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
-	// parse bitrate
+	// check for a valid video stream
 	videoStream := probeData.FirstVideoStream()
 	if videoStream == nil {
-		return InputVideo{}, errors.New("error probing mp4 input file from s3: no video stream found")
+		return InputVideo{}, errors.New("error checking for video: no video stream found")
 	}
+	// check for unsupported video stream(s)
+	if strings.Contains("mjpeg", videoStream.CodecName) {
+		return InputVideo{}, errors.New("error checking for video: mjpeg is not supported")
+	}
+	// parse bitrate
 	bitRateValue := videoStream.BitRate
 	if bitRateValue == "" {
 		bitRateValue = probeData.Format.BitRate

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -1,0 +1,52 @@
+package video
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/vansante/go-ffprobe.v2"
+)
+
+func TestItRejectsWhenNoVideoTrackPresent(t *testing.T) {
+	_, err := parseProbeOutput(&ffprobe.ProbeData{
+		Streams: []*ffprobe.Stream{
+			{
+				CodecType: "audio",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "no video stream found")
+}
+
+func TestItRejectsWhenMJPEGVideoTrackPresent(t *testing.T) {
+	_, err := parseProbeOutput(&ffprobe.ProbeData{
+		Streams: []*ffprobe.Stream{
+			{
+				CodecType: "video",
+				CodecName: "mjpeg",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "mjpeg is not supported")
+
+	_, err = parseProbeOutput(&ffprobe.ProbeData{
+		Streams: []*ffprobe.Stream{
+			{
+				CodecType: "video",
+				CodecName: "jpeg",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "jpeg is not supported")
+}
+
+func TestItRejectsWhenVideoBitrateMissing(t *testing.T) {
+	_, err := parseProbeOutput(&ffprobe.ProbeData{
+		Streams: []*ffprobe.Stream{
+			{
+				CodecType: "video",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "format information missing")
+}


### PR DESCRIPTION
Any single jpeg input file may get classified as an mjpeg in the probing logic. These inputs are not supported currently. This change adds a check for mjpeg type of inputs and fails the probe check.