### PR TITLE
Bump concurrent capacity from 5 -> 8

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,11 @@ const DefaultCustomAPIUrl = "https://origin.livepeer.com/api/"
 
 var RecordingCallback string = "http://127.0.0.1:8008/recording/status"
 
+// Somewhat arbitrary and conservative number of maximum Catalyst VOD jobs in the system
+// at one time. We can look at more sophisticated strategies for calculating capacity in
+// the future.
+const MAX_JOBS_IN_FLIGHT = 8
+
 var TranscodingParallelJobs int = 2
 
 var TranscodingParallelSleep time.Duration = 713 * time.Millisecond

--- a/middleware/capacity.go
+++ b/middleware/capacity.go
@@ -4,17 +4,13 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/pipeline"
 )
 
-// Somewhat arbitrary and conservative number of maximum Catalyst VOD jobs in the system
-// at one time. We can look at more sophisticated strategies for calculating capacity in
-// the future.
-const MAX_JOBS_IN_FLIGHT = 5
-
 func HasCapacity(vodEngine *pipeline.Coordinator, next httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-		if vodEngine.InFlightMistPipelineJobs() >= MAX_JOBS_IN_FLIGHT {
+		if vodEngine.InFlightMistPipelineJobs() >= config.MAX_JOBS_IN_FLIGHT {
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}

--- a/middleware/capacity_test.go
+++ b/middleware/capacity_test.go
@@ -42,7 +42,7 @@ func TestItErrorsWhenNoCapacityAvailable(t *testing.T) {
 	coordinator := pipeline.NewStubCoordinatorOpts(pipeline.StrategyCatalystDominance, nil, pipeMist, nil)
 
 	// Create a lot of in-flight jobs
-	for x := 0; x < 5; x++ {
+	for x := 0; x < 8; x++ {
 		coordinator.StartUploadJob(pipeline.UploadJobPayload{
 			RequestID: fmt.Sprintf("request-%d", x),
 		})


### PR DESCRIPTION
Now that we're more confident in the system, we'll bump this and monitor error rates. 5 -> 8 should still be conservative given the CPU + Memory headroom we have.