### PR TITLE
round to an even height and width to fix MC errors

### DIFF
--- a/video/profiles.go
+++ b/video/profiles.go
@@ -93,11 +93,11 @@ func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 		profiles = []EncodedProfile{lowBitrateProfile(video)}
 	}
 	profiles = append(profiles, EncodedProfile{
-		Name:    strconv.FormatInt(video.Height, 10) + "p0",
+		Name:    strconv.FormatInt(nearestEven(video.Height), 10) + "p0",
 		Bitrate: video.Bitrate,
 		FPS:     0,
-		Width:   video.Width,
-		Height:  video.Height,
+		Width:   nearestEven(video.Width),
+		Height:  nearestEven(video.Height),
 	})
 	return profiles, nil
 }
@@ -113,9 +113,13 @@ func lowBitrateProfile(video InputTrack) EncodedProfile {
 		Name:    "low-bitrate",
 		FPS:     0,
 		Bitrate: bitrate,
-		Width:   video.Width,
-		Height:  video.Height,
+		Width:   nearestEven(video.Width),
+		Height:  nearestEven(video.Height),
 	}
+}
+
+func nearestEven(input int64) int64 {
+	return input + (input & 1)
 }
 
 type EncodedProfile struct {

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -88,6 +88,21 @@ func TestGetPlaybackProfiles(t *testing.T) {
 				{Name: "1080p0", Width: 1920, Height: 1080, Bitrate: 5_000_000},
 			},
 		},
+		{
+			name: "240p input with odd number resolution",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 517_099,
+				VideoTrack: VideoTrack{
+					Width:  400,
+					Height: 239,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "low-bitrate", Width: 400, Height: 240, Bitrate: 258549},
+				{Name: "240p0", Width: 400, Height: 240, Bitrate: 517099},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Mediaconvert only accepts even values for width and height so we have to round these values.

We were seeing the following errors in the logs:
`Invalid resolution [400 x 239], only even values are supported. video_description [1]`

