### PR TITLE
extract s3 upload and probe into a function

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -10,12 +10,13 @@ import (
 	"github.com/livepeer/catalyst-api/video"
 )
 
-type SourceUpload struct {
+type InputCopy struct {
 	S3    S3
 	Probe video.Prober
 }
 
-func (s *SourceUpload) Upload(args TranscodeJobArgs, s3HTTPTransferURL *url.URL) (TranscodeJobArgs, error) {
+// CopyInputToS3 copies the input video to our S3 transfer bucket and probes the file.
+func (s *InputCopy) CopyInputToS3(args TranscodeJobArgs, s3HTTPTransferURL *url.URL) (TranscodeJobArgs, error) {
 	if s3HTTPTransferURL == nil {
 		return TranscodeJobArgs{}, errors.New("s3HTTPTransferURL was nil")
 	}

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -75,7 +75,7 @@ type MediaConvert struct {
 	client                                AWSMediaConvertClient
 	s3                                    S3
 	probe                                 video.Prober
-	sourceUpload                          *SourceUpload
+	inputCopy                             *InputCopy
 }
 
 func NewMediaConvertClient(opts MediaConvertOptions) (TranscodeProvider, error) {
@@ -112,7 +112,7 @@ func NewMediaConvertClient(opts MediaConvertOptions) (TranscodeProvider, error) 
 		client:              client,
 		s3:                  s3Client,
 		probe:               probe,
-		sourceUpload:        &SourceUpload{s3Client, probe},
+		inputCopy:           &InputCopy{s3Client, probe},
 	}, nil
 }
 
@@ -132,7 +132,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) ([
 	// AWS MediaConvert adds the .m3u8 to the end of the output file name
 	mcOutputRelPath := path.Join("output", targetDir, "index")
 
-	mcArgs, err := mc.sourceUpload.Upload(args, mc.osTransferBucketURL.JoinPath(mcInputRelPath))
+	mcArgs, err := mc.inputCopy.CopyInputToS3(args, mc.osTransferBucketURL.JoinPath(mcInputRelPath))
 	if err != nil {
 		return nil, err
 	}

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -343,7 +343,7 @@ func Test_FramerateCheck(t *testing.T) {
 			}
 			mc, f, _, cleanup := setupTestMediaConvert(t, awsStub)
 			defer cleanup()
-			mc.sourceUpload.Probe = stubFFprobe{
+			mc.inputCopy.Probe = stubFFprobe{
 				Bitrate:  1000000,
 				Duration: 60,
 				FPS:      tt.fps,
@@ -411,7 +411,7 @@ func Test_MP4OutDurationCheck(t *testing.T) {
 			}
 			mc, f, _, cleanup := setupTestMediaConvert(t, awsStub)
 			defer cleanup()
-			mc.sourceUpload.Probe = stubFFprobe{
+			mc.inputCopy.Probe = stubFFprobe{
 				Bitrate:  1000000,
 				Duration: tt.duration,
 				FPS:      30,
@@ -500,7 +500,7 @@ func setupTestMediaConvert(t *testing.T, awsStub AWSMediaConvertClient) (mc *Med
 		client:              awsStub,
 		s3:                  s3Client,
 		probe:               probe,
-		sourceUpload:        &SourceUpload{s3Client, probe},
+		inputCopy:           &InputCopy{s3Client, probe},
 	}
 	return
 }

--- a/clients/upload.go
+++ b/clients/upload.go
@@ -1,0 +1,64 @@
+package clients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/livepeer/catalyst-api/log"
+	"github.com/livepeer/catalyst-api/video"
+)
+
+type SourceUpload struct {
+	S3    S3
+	Probe video.Prober
+}
+
+func (s *SourceUpload) Upload(args TranscodeJobArgs, s3HTTPTransferURL *url.URL) (TranscodeJobArgs, error) {
+	if s3HTTPTransferURL == nil {
+		return TranscodeJobArgs{}, errors.New("s3HTTPTransferURL was nil")
+	}
+	s3URL, err := url.Parse("s3://" + s3HTTPTransferURL.Path)
+	if err != nil {
+		return TranscodeJobArgs{}, fmt.Errorf("failed to parse s3 url: %w", err)
+	}
+
+	log.Log(args.RequestID, "Copying input file to S3", "source", args.InputFile, "dest", s3URL)
+	size, err := CopyFile(context.Background(), args.InputFile.String(), s3HTTPTransferURL.String(), "", args.RequestID)
+	if err != nil {
+		return TranscodeJobArgs{}, fmt.Errorf("error copying input file to S3: %w", err)
+	}
+	if size <= 0 {
+		return TranscodeJobArgs{}, fmt.Errorf("zero bytes found for source: %s", args.InputFile)
+	}
+	args.CollectSourceSize(size)
+
+	presignedInputFileURL, err := s.S3.PresignS3(s3URL.Host, s3URL.Path)
+	if err != nil {
+		return TranscodeJobArgs{}, fmt.Errorf("error creating s3 url: %w", err)
+	}
+
+	log.Log(args.RequestID, "starting probe", "s3url", s3URL)
+	inputVideoProbe, err := s.Probe.ProbeFile(presignedInputFileURL)
+	if err != nil {
+		log.Log(args.RequestID, "probe failed", "s3url", s3URL, "err", err)
+		return TranscodeJobArgs{}, fmt.Errorf("error probing MP4 input file from S3: %w", err)
+	}
+	log.Log(args.RequestID, "probe succeeded", "s3url", s3URL)
+	videoTrack, err := inputVideoProbe.GetVideoTrack()
+	if err != nil {
+		return TranscodeJobArgs{}, fmt.Errorf("no video track found in input video: %w", err)
+	}
+	if videoTrack.FPS <= 0 {
+		// unsupported, includes things like motion jpegs
+		return TranscodeJobArgs{}, fmt.Errorf("invalid framerate: %f", videoTrack.FPS)
+	}
+
+	if inputVideoProbe.SizeBytes > maxInputFileSizeBytes {
+		return TranscodeJobArgs{}, fmt.Errorf("input file %d bytes was greater than %d bytes", inputVideoProbe.SizeBytes, maxInputFileSizeBytes)
+	}
+	args.InputFileInfo = inputVideoProbe
+	args.InputFile = s3URL
+	return args, nil
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -69,10 +69,16 @@ func redactKeyvals(keyvals ...interface{}) []interface{} {
 		if i%2 == 1 {
 			k, v := keyvals[i-1], keyvals[i]
 			res = append(res, k)
-			s, ok := v.(string)
-			if ok {
+			switch s := v.(type) {
+			case string:
 				res = append(res, RedactURL(s))
-			} else {
+			case url.URL:
+				res = append(res, s.Redacted())
+			case *url.URL:
+				if s != nil {
+					res = append(res, s.Redacted())
+				}
+			default:
 				res = append(res, v)
 			}
 		}
@@ -82,7 +88,7 @@ func redactKeyvals(keyvals ...interface{}) []interface{} {
 
 func RedactURL(str string) string {
 	strLower := strings.ToLower(str)
-	if !strings.HasPrefix(strLower, "s3+http") && !strings.HasPrefix(strLower, "http") {
+	if !strings.HasPrefix(strLower, "s3+http") && !strings.HasPrefix(strLower, "http") && !strings.HasPrefix(strLower, "s3") {
 		return str
 	}
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -88,7 +88,7 @@ func redactKeyvals(keyvals ...interface{}) []interface{} {
 
 func RedactURL(str string) string {
 	strLower := strings.ToLower(str)
-	if !strings.HasPrefix(strLower, "s3+http") && !strings.HasPrefix(strLower, "http") && !strings.HasPrefix(strLower, "s3") {
+	if !strings.HasPrefix(strLower, "http") && !strings.HasPrefix(strLower, "s3") {
 		return str
 	}
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -22,6 +22,10 @@ func TestRedactURL(t *testing.T) {
 		RedactURL("s3+https://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/inbucket/source.mp4"),
 	)
 	require.Equal(t,
+		"s3://jv4s7zwfugeb7uccnnl2bwigikka:xxxxx@gateway.storjshare.io/inbucket/source.mp4",
+		RedactURL("s3://jv4s7zwfugeb7uccnnl2bwigikka:j3axkol3vqndxy4vs6mgmv4tzs47kaxazj3uesegybny2q7n74jwq@gateway.storjshare.io/inbucket/source.mp4"),
+	)
+	require.Equal(t,
 		"REDACTED",
 		RedactURL("s3+https://username:username:username/1234@incorrect.url"),
 	)


### PR DESCRIPTION
Moving the logic which copies the input to s3 and probes it into a separate file. We'll then be able to use this for the mist pipeline too.