### PR TITLE
Increase the timeout for mediaconvert to support big mp4 files

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -15,6 +15,8 @@ import (
 	"github.com/livepeer/go-tools/drivers"
 )
 
+const MAX_COPY_FILE_DURATION = 30 * time.Minute
+
 type InputCopy struct {
 	S3    S3
 	Probe video.Prober
@@ -82,7 +84,7 @@ func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID
 
 	content := io.TeeReader(c, &writtenBytes)
 
-	err = UploadToOSURL(destOSBaseURL, filename, content, 5*time.Minute)
+	err = UploadToOSURL(destOSBaseURL, filename, content, MAX_COPY_FILE_DURATION)
 	if err != nil {
 		return writtenBytes.count, fmt.Errorf("upload error: %w", err)
 	}


### PR DESCRIPTION
When we start supporting mp4 output, then the current timeout for saving data (`5 min`) may not be high enough. This PR increases this timeout.

However, I think we could think about an approach in which the timeout actually depends on the file size. @emranemran @victorges wdyt?

Also a comment from @emranemran 
> Will this cause issues with Studio timeouts?
https://github.com/livepeer/studio/blob/23b1aa453bbef83981ad2547169c7149f0436e35/packages/api/src/store/task-table.ts#L7-L9
If we're stuck in UploadToOSURL, is our callback to Studio ReportProgress called concurrently?
cc @victorges