### PR TITLE
clients: add logging to dstorage download flow

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -91,6 +91,7 @@ func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser,
 
 func downloadDStorageResourceFromSingleGateway(gateway *url.URL, resourceId, requestID string) io.ReadCloser {
 	fullURL := gateway.JoinPath(resourceId).String()
+	log.Log(requestID, "downloading from gateway", "resourceID", resourceId, "url", fullURL)
 	resp, err := http.DefaultClient.Get(fullURL)
 
 	if err != nil {

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -33,6 +33,7 @@ func (s *InputCopy) CopyInputToS3(args TranscodeJobArgs, s3HTTPTransferURL *url.
 	if size <= 0 {
 		return TranscodeJobArgs{}, fmt.Errorf("zero bytes found for source: %s", args.InputFile)
 	}
+	log.Log(args.RequestID, "Copied", "bytes", size, "source", args.InputFile, "dest", s3URL)
 	args.CollectSourceSize(size)
 
 	presignedInputFileURL, err := s.S3.PresignS3(s3URL.Host, s3URL.Path)


### PR DESCRIPTION
Some ipfs URLs can be downloaded successfully but closer inspection of the files on S3 reveals only a few kB as being downloaded and uploaded. Add logging to try and root-cause this issue of incomplete uploads.