### PR TITLE
Switch probe log level to error

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -23,7 +23,7 @@ func (p Probe) ProbeFile(url string) (iv InputVideo, err error) {
 	operation := func() error {
 		probeCtx, probeCancel := context.WithTimeout(context.Background(), 60*time.Second)
 		defer probeCancel()
-		data, err = ffprobe.ProbeURL(probeCtx, url)
+		data, err = ffprobe.ProbeURL(probeCtx, url, "-loglevel", "error")
 		return err
 	}
 


### PR DESCRIPTION
By default the log level through the ffprobe library we're using is set to "fatal", this seems to be too high since we have never seen an error message printed when we get a probe failure, just a generic message like:
`error running ffprobe [] exit status 1`
if we switch to level "error" we will start to see more detail like:
`error running ffprobe [/Users/max/Downloads/video: Invalid data found when processing input] exit status 1`