### PR TITLE
Add a pprof listener for tracing

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/livepeer/catalyst-api/pipeline"
+	"github.com/livepeer/catalyst-api/pprof"
 	"github.com/livepeer/livepeer-data/pkg/mistconnector"
 )
 
@@ -25,6 +26,7 @@ func main() {
 	apiToken := flag.String("api-token", "IAmAuthorized", "Auth header value for API access")
 	mistJson := flag.Bool("j", false, "Print application info as JSON. Used by Mist to present flags in its UI.")
 	promPort := flag.Int("prom-port", 2112, "Prometheus metrics port")
+	pprofPort := flag.Int("pprof-port", 6061, "Pprof listen port")
 	sourceOutputUrl := flag.String("source-output", "", "URL for the video source segments used if source_segments is not defined in the upload request")
 	externalTranscoderUrl := flag.String("external-transcoder", "", "URL for the external transcoder to be used by the pipeline coordinator. Only 1 implementation today for AWS MediaConvert which should be in the format: mediaconvert://key-id:key-secret@endpoint-host?region=aws-region&role=iam-role&s3_aux_bucket=s3://bucket")
 	vodPipelineStrategy := flag.String("vod-pipeline-strategy", string(pipeline.StrategyCatalystDominance), "Which strategy to use for the VOD pipeline")
@@ -46,6 +48,9 @@ func main() {
 
 	go func() {
 		log.Fatal(metrics.ListenAndServe(*promPort))
+	}()
+	go func() {
+		log.Println(pprof.ListenAndServe(*pprofPort))
 	}()
 
 	mist := &clients.MistClient{

--- a/pprof/pprof.go
+++ b/pprof/pprof.go
@@ -1,0 +1,11 @@
+package pprof
+
+import (
+	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+)
+
+func ListenAndServe(port int) error {
+	return fmt.Errorf("pprof listener stopped: %w", http.ListenAndServe(fmt.Sprintf("0.0.0.0:%d", port), nil))
+}


### PR DESCRIPTION
We're having some errors copying output files to storage so adding a pprof listener to be able to retrieve profiling/tracing data from the pods to investigate.