### PR TITLE
Fix retry mechanism

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -16,7 +16,7 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-var dstorageRetryBackoff = backoff.NewConstantBackOff(1 * time.Second)
+var dstorageRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2)
 
 func CopyDStorageToS3(url, s3URL string, requestID string) error {
 	return backoff.Retry(func() error {

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -2,13 +2,13 @@ package clients
 
 import (
 	"fmt"
-	"github.com/cenkalti/backoff/v4"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/log"
 )
@@ -16,9 +16,7 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-const DSTORAGE_MAX_COPY_DURATION = 20 * time.Minute
-
-var DSTORAGE_RETRY_BACKOFF = backoff.NewConstantBackOff(1 * time.Second)
+var dstorageRetryBackoff = backoff.NewConstantBackOff(1 * time.Second)
 
 func CopyDStorageToS3(url, s3URL string, requestID string) error {
 	return backoff.Retry(func() error {
@@ -27,13 +25,13 @@ func CopyDStorageToS3(url, s3URL string, requestID string) error {
 			return err
 		}
 
-		err = UploadToOSURL(s3URL, "", content, DSTORAGE_MAX_COPY_DURATION)
+		err = UploadToOSURL(s3URL, "", content, MAX_COPY_FILE_DURATION)
 		if err != nil {
 			return err
 		}
 
 		return nil
-	}, DSTORAGE_RETRY_BACKOFF)
+	}, dstorageRetryBackoff)
 }
 
 func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser, error) {

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -2,13 +2,13 @@ package clients
 
 import (
 	"fmt"
+	"github.com/cenkalti/backoff/v4"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/log"
 )
@@ -16,20 +16,24 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-const MAX_COPY_DURATION = 20 * time.Minute
+const DSTORAGE_MAX_COPY_DURATION = 20 * time.Minute
+
+var DSTORAGE_RETRY_BACKOFF = backoff.NewConstantBackOff(1 * time.Second)
 
 func CopyDStorageToS3(url, s3URL string, requestID string) error {
-	content, err := DownloadDStorageFromGatewayList(url, requestID)
-	if err != nil {
-		return err
-	}
+	return backoff.Retry(func() error {
+		content, err := DownloadDStorageFromGatewayList(url, requestID)
+		if err != nil {
+			return err
+		}
 
-	err = UploadToOSURL(s3URL, "", content, MAX_COPY_DURATION)
-	if err != nil {
-		return err
-	}
+		err = UploadToOSURL(s3URL, "", content, DSTORAGE_MAX_COPY_DURATION)
+		if err != nil {
+			return err
+		}
 
-	return nil
+		return nil
+	}, DSTORAGE_RETRY_BACKOFF)
 }
 
 func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser, error) {
@@ -68,25 +72,14 @@ func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser,
 		}
 	}
 
-	var opContent io.ReadCloser
-	downloadOperation := func() error {
-		for _, gateway := range gateways {
-			opContent = downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
-			if opContent != nil {
-				return nil
-			}
+	for _, gateway := range gateways {
+		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
+		if opContent != nil {
+			return opContent, nil
 		}
-
-		return fmt.Errorf("failed to fetch %s from any of the gateways", u)
 	}
 
-	retryStrategy := backoff.NewConstantBackOff(1 * time.Second)
-	err = backoff.Retry(downloadOperation, backoff.WithMaxRetries(retryStrategy, 2))
-	if err != nil {
-		return nil, err
-	} else {
-		return opContent, nil
-	}
+	return nil, fmt.Errorf("failed to fetch %s from any of the gateways", u)
 }
 
 func downloadDStorageResourceFromSingleGateway(gateway *url.URL, resourceId, requestID string) io.ReadCloser {

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -16,7 +16,7 @@ import (
 	"github.com/livepeer/go-tools/drivers"
 )
 
-const MAX_COPY_FILE_DURATION = 1 * time.Minute
+const MAX_COPY_FILE_DURATION = 30 * time.Minute
 
 var RETRY_BACKOFF = backoff.WithMaxRetries(newExponentialBackOffExecutor(), 5)
 

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -9,13 +9,16 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	xerrors "github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 	"github.com/livepeer/catalyst-api/video"
 	"github.com/livepeer/go-tools/drivers"
 )
 
-const MAX_COPY_FILE_DURATION = 30 * time.Minute
+const MAX_COPY_FILE_DURATION = 1 * time.Minute
+
+var RETRY_BACKOFF = backoff.WithMaxRetries(newExponentialBackOffExecutor(), 5)
 
 type InputCopy struct {
 	S3    S3
@@ -72,24 +75,30 @@ func (s *InputCopy) CopyInputToS3(args TranscodeJobArgs, s3HTTPTransferURL *url.
 	return args, nil
 }
 
-func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string) (int64, error) {
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
-	defer cancel()
-	writtenBytes := ByteAccumulatorWriter{count: 0}
-	c, err := getFile(ctx, sourceURL, requestID)
-	if err != nil {
-		return writtenBytes.count, fmt.Errorf("download error: %w", err)
-	}
-	defer c.Close()
+func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string) (writtenBytes int64, err error) {
+	err = backoff.Retry(func() error {
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 
-	content := io.TeeReader(c, &writtenBytes)
+		byteAccWriter := ByteAccumulatorWriter{count: 0}
+		defer func() { writtenBytes = byteAccWriter.count }()
 
-	err = UploadToOSURL(destOSBaseURL, filename, content, MAX_COPY_FILE_DURATION)
-	if err != nil {
-		return writtenBytes.count, fmt.Errorf("upload error: %w", err)
-	}
+		c, err := getFile(ctx, sourceURL, requestID)
+		if err != nil {
+			return fmt.Errorf("download error: %w", err)
+		}
+		defer c.Close()
 
-	return writtenBytes.count, nil
+		content := io.TeeReader(c, &byteAccWriter)
+
+		return UploadToOSURL(destOSBaseURL, filename, content, MAX_COPY_FILE_DURATION)
+		if err != nil {
+			return fmt.Errorf("upload error: %w", err)
+		}
+
+		return nil
+	}, RETRY_BACKOFF)
+	return
 }
 
 func getFile(ctx context.Context, url, requestID string) (io.ReadCloser, error) {

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -92,11 +92,6 @@ func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID
 		content := io.TeeReader(c, &byteAccWriter)
 
 		return UploadToOSURL(destOSBaseURL, filename, content, MAX_COPY_FILE_DURATION)
-		if err != nil {
-			return fmt.Errorf("upload error: %w", err)
-		}
-
-		return nil
 	}, RETRY_BACKOFF)
 	return
 }

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -518,7 +518,7 @@ func newRetryableHttpClient() *http.Client {
 	client.HTTPClient = &http.Client{
 		// Give up on requests that take more than this long - the file is probably too big for us to process locally if it takes this long
 		// or something else has gone wrong and the request is hanging
-		Timeout: MAX_COPY_DURATION,
+		Timeout: DSTORAGE_MAX_COPY_DURATION,
 	}
 
 	return client.StandardClient()

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -518,7 +518,7 @@ func newRetryableHttpClient() *http.Client {
 	client.HTTPClient = &http.Client{
 		// Give up on requests that take more than this long - the file is probably too big for us to process locally if it takes this long
 		// or something else has gone wrong and the request is hanging
-		Timeout: DSTORAGE_MAX_COPY_DURATION,
+		Timeout: MAX_COPY_FILE_DURATION,
 	}
 
 	return client.StandardClient()

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -21,6 +21,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const MAX_COPY_DIR_DURATION = 2 * time.Hour
+
 var pollDelay = 10 * time.Second
 var retryableHttpClient = newRetryableHttpClient()
 
@@ -406,7 +408,7 @@ func output(container, name string, height, maxBitrate int64) *mediaconvert.Outp
 }
 
 func copyDir(source, dest *url.URL, args TranscodeJobArgs) error {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), MAX_COPY_DIR_DURATION)
 	defer cancel()
 	eg, ctx := errgroup.WithContext(ctx)
 

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/mediaconvert"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/video"
 	"github.com/stretchr/testify/require"
 )
@@ -465,8 +464,8 @@ func loadFixture(t *testing.T, expectedPath, actual string) string {
 }
 
 func setupTestMediaConvert(t *testing.T, awsStub AWSMediaConvertClient) (mc *MediaConvert, inputFile *os.File, transferDir string, cleanup func()) {
-	oldMaxRetryInterval, oldRetries, oldPollDelay := maxRetryInterval, config.DownloadOSURLRetries, pollDelay
-	maxRetryInterval, config.DownloadOSURLRetries, pollDelay = 1*time.Millisecond, 1, 1*time.Millisecond
+	oldMaxRetryInterval, oldPollDelay := maxRetryInterval, pollDelay
+	maxRetryInterval, pollDelay = 1*time.Millisecond, 1*time.Millisecond
 
 	var err error
 	inputFile, err = os.CreateTemp(os.TempDir(), "user-input-*")
@@ -484,7 +483,7 @@ func setupTestMediaConvert(t *testing.T, awsStub AWSMediaConvertClient) (mc *Med
 	require.NoError(t, os.MkdirAll(transferDir, 0777))
 
 	cleanup = func() {
-		maxRetryInterval, config.DownloadOSURLRetries, pollDelay = oldMaxRetryInterval, oldRetries, oldPollDelay
+		maxRetryInterval, pollDelay = oldMaxRetryInterval, oldPollDelay
 		inErr := os.Remove(inputFile.Name())
 		dirErr := os.RemoveAll(transferDir)
 		require.NoError(t, inErr)

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -10,14 +10,11 @@ import (
 	"github.com/livepeer/catalyst-api/log"
 
 	"github.com/cenkalti/backoff/v4"
-	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/livepeer/go-tools/drivers"
 )
 
 var maxRetryInterval = 5 * time.Second
-
-var DOWNLOAD_RETRY_BACKOFF = backoff.WithMaxRetries(newConstantBackOffExecutor(), config.DownloadOSURLRetries)
 
 func DownloadOSURL(osURL string) (io.ReadCloser, error) {
 	storageDriver, err := drivers.ParseOSURL(osURL, true)
@@ -133,10 +130,6 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 	backOff.MaxInterval = maxRetryInterval
 
 	return backOff
-}
-
-func newConstantBackOffExecutor() *backoff.ConstantBackOff {
-	return backoff.NewConstantBackOff(maxRetryInterval)
 }
 
 var makeOperation = func(fn func() error) func() error {

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -131,7 +131,3 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 
 	return backOff
 }
-
-var makeOperation = func(fn func() error) func() error {
-	return fn
-}

--- a/clients/object_store_client_test.go
+++ b/clients/object_store_client_test.go
@@ -1,38 +1,31 @@
 package clients
 
 import (
-	"bytes"
-	"errors"
+	"github.com/stretchr/testify/require"
 	"io"
-	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
-
-	"github.com/livepeer/catalyst-api/config"
-	"github.com/stretchr/testify/require"
 )
 
-const exampleFileContents = "زن, زندگی, آزادی "
+const (
+	exampleFileContents = "زن, زندگی, آزادی "
+	exampleFilename     = "manifest.m3u8"
+)
 
-func TestItCanDownloadAnOSURL(t *testing.T) {
-	// Create a temporary file on the local filesystem
-	f, err := os.CreateTemp(os.TempDir(), "manifest*.m3u8")
+func TestItCanUploadAndDownloadWithOSURL(t *testing.T) {
+	dir := t.TempDir()
+
+	err := UploadToOSURL(dir, exampleFilename, strings.NewReader(exampleFileContents), 5*time.Minute)
 	require.NoError(t, err)
 
-	// Write some data to it
-	_, err = f.WriteString(exampleFileContents)
-	require.NoError(t, err)
-
-	// Try to "download" it using the OS URL format for local filesystem files
-	rc, err := DownloadOSURL(f.Name())
+	rc, err := DownloadOSURL(path.Join(dir, exampleFilename))
 	require.NoError(t, err)
 
 	buf := new(strings.Builder)
 	_, err = io.Copy(buf, rc)
 	require.NoError(t, err)
-
-	// Check that the file we downloaded matches the one we created
 	require.Equal(t, exampleFileContents, buf.String())
 }
 
@@ -48,107 +41,6 @@ func TestItFailsWithMissingFile(t *testing.T) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to read from OS URL")
 	require.Contains(t, err.Error(), "no such file or directory")
-}
-
-func TestItRetriesReadingData(t *testing.T) {
-	var retries = 0
-	var original = makeOperation
-	makeOperation = func(fn func() error) func() error {
-		return func() error {
-			if retries <= 1 {
-				retries++
-				return errors.New("some-error")
-			} else {
-				return fn()
-			}
-		}
-	}
-	defer func() { makeOperation = original }()
-
-	// Create a temporary file on the local filesystem
-	f, err := os.CreateTemp(os.TempDir(), "manifest*.m3u8")
-	require.NoError(t, err)
-
-	// Write some data to it
-	_, err = f.WriteString(exampleFileContents)
-	require.NoError(t, err)
-
-	// Try to "download" it using the OS URL format for local filesystem files
-	_, err = DownloadOSURL(f.Name())
-
-	require.NoError(t, err)
-	require.Equal(t, 2, retries)
-}
-
-func TestItFailsAfterMaxReadsReached(t *testing.T) {
-	var retries uint64 = 0
-	var original = makeOperation
-
-	var originalRetries = config.DownloadOSURLRetries
-	config.DownloadOSURLRetries = 3
-	defer func() {
-		config.DownloadOSURLRetries = originalRetries
-	}()
-
-	makeOperation = func(fn func() error) func() error {
-		return func() error {
-			retries++
-			return errors.New("some-error")
-		}
-	}
-	defer func() { makeOperation = original }()
-
-	// Create a temporary file on the local filesystem
-	f, err := os.CreateTemp(os.TempDir(), "manifest*.m3u8")
-	require.NoError(t, err)
-
-	// Write some data to it
-	_, err = f.WriteString(exampleFileContents)
-	require.NoError(t, err)
-
-	// Try to "download" it using the OS URL format for local filesystem files
-	_, err = DownloadOSURL(f.Name())
-
-	require.Error(t, err)
-	require.Equal(t, config.DownloadOSURLRetries+1, retries)
-}
-
-func TestItRetriesSavingData(t *testing.T) {
-	var retries = 0
-	var original = makeOperation
-	makeOperation = func(fn func() error) func() error {
-		return func() error {
-			if retries <= 1 {
-				retries++
-				return errors.New("some-error")
-			} else {
-				return fn()
-			}
-		}
-	}
-	defer func() { makeOperation = original }()
-
-	err := UploadToOSURL(os.TempDir(), "name", bytes.NewReader([]byte("foo")), 1*time.Second)
-
-	require.NoError(t, err)
-	require.Equal(t, 2, retries)
-}
-
-func TestItFailsAfterMaxSavesRetriesReached(t *testing.T) {
-	var retries = 0
-	var original = makeOperation
-	makeOperation = func(fn func() error) func() error {
-		return func() error {
-			retries++
-			return errors.New("some-error")
-		}
-	}
-	defer func() { makeOperation = original }()
-
-	err := UploadToOSURL(os.TempDir(), "name", bytes.NewReader([]byte("foo")), 1*time.Second)
-
-	require.Error(t, err)
-	require.Equal(t, 6, retries)
 }
 
 func TestPublishDriverSession(t *testing.T) {

--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/clients"
 )
@@ -129,7 +130,9 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 
 		manifestFilename := "index.m3u8"
 		renditionManifestBaseURL := fmt.Sprintf("%s/%s", targetOSURL, profile.Name)
-		err = clients.UploadToOSURL(renditionManifestBaseURL, manifestFilename, strings.NewReader(renditionPlaylist.String()), UPLOAD_TIMEOUT)
+		err = backoff.Retry(func() error {
+			return clients.UploadToOSURL(renditionManifestBaseURL, manifestFilename, strings.NewReader(renditionPlaylist.String()), UPLOAD_TIMEOUT)
+		}, clients.RETRY_BACKOFF)
 		if err != nil {
 			return "", fmt.Errorf("failed to upload rendition playlist: %s", err)
 		}
@@ -141,7 +144,9 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 		}
 	}
 
-	err := clients.UploadToOSURL(targetOSURL, MASTER_MANIFEST_FILENAME, strings.NewReader(masterPlaylist.String()), UPLOAD_TIMEOUT)
+	err := backoff.Retry(func() error {
+		return clients.UploadToOSURL(targetOSURL, MASTER_MANIFEST_FILENAME, strings.NewReader(masterPlaylist.String()), UPLOAD_TIMEOUT)
+	}, clients.RETRY_BACKOFF)
 	if err != nil {
 		return "", fmt.Errorf("failed to upload master playlist: %s", err)
 	}

--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -25,7 +25,7 @@ func DownloadRenditionManifest(sourceManifestOSURL string) (m3u8.MediaPlaylist, 
 		}
 		playlist, playlistType, err = m3u8.DecodeFrom(rc, true)
 		return err
-	}, clients.DOWNLOAD_RETRY_BACKOFF)
+	}, transcodeRetryBackoff)
 	if err != nil {
 		return m3u8.MediaPlaylist{}, fmt.Errorf("error downloading manifest: %s", err)
 	}

--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -21,13 +21,16 @@ func DownloadRenditionManifest(sourceManifestOSURL string) (m3u8.MediaPlaylist, 
 	err := backoff.Retry(func() error {
 		rc, err := clients.DownloadOSURL(sourceManifestOSURL)
 		if err != nil {
-			return err
+			return fmt.Errorf("error downloading manifest: %s", err)
 		}
 		playlist, playlistType, err = m3u8.DecodeFrom(rc, true)
-		return err
+		if err != nil {
+			return fmt.Errorf("error decoding manifest: %s", err)
+		}
+		return nil
 	}, transcodeRetryBackoff)
 	if err != nil {
-		return m3u8.MediaPlaylist{}, fmt.Errorf("error downloading manifest: %s", err)
+		return m3u8.MediaPlaylist{}, err
 	}
 
 	// We shouldn't ever receive Master playlists from the previous section

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -19,7 +19,7 @@ import (
 
 const UPLOAD_TIMEOUT = 5 * time.Minute
 
-var transcodeRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), config.DownloadOSURLRetries)
+var transcodeRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10)
 
 type TranscodeSegmentRequest struct {
 	SourceFile        string                 `json:"source_location"`

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -19,6 +19,8 @@ import (
 
 const UPLOAD_TIMEOUT = 5 * time.Minute
 
+var transcodeRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), config.DownloadOSURLRetries)
+
 type TranscodeSegmentRequest struct {
 	SourceFile        string                 `json:"source_location"`
 	CallbackURL       string                 `json:"callback_url"`
@@ -186,7 +188,7 @@ func transcodeSegment(
 			}
 		}
 		return nil
-	}, clients.DOWNLOAD_RETRY_BACKOFF)
+	}, transcodeRetryBackoff)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
I discovered that our current upload retry mechanism is fundamentally wrong and therefore it **does not work**. This PR fixes the issue.

fix #473 

One non-backward-compatible change is that we'll no longer have the upload retries metrics.

---------

**Explanation**

We retry saving the data here:

https://github.com/livepeer/catalyst-api/blob/main/clients/object_store_client.go#L75

But what we pass is `data io.Reader` which is not something you can retry, because if some data was already read from the reader, then it's not there anymore. Therefore it does not make sense to have any retry mechanism in the `UploadToOSURL()` function. 

This PR moves the retry mechanism from the `UploadToOSURL()` function upper to the place where it can actually be retried.
