### PR TITLE
Set a maximum bitrate for our output renditions

### DIFF
--- a/video/profiles.go
+++ b/video/profiles.go
@@ -107,6 +107,10 @@ func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 	return profiles, nil
 }
 
+// When the input video's height and bitrate combo is too low to meet the default ABR ladder we output a low bitrate
+// profile as well as the profile matching the input video to achieve at least some ABR playback.
+// 50% of the input video's bitrate was found to give a decent experience. We also then check that this isn't below
+// some sensible minimum values.
 func lowBitrateProfile(video InputTrack) EncodedProfile {
 	bitrate := int64(float64(video.Bitrate) * (1.0 / 2.0))
 	if bitrate < MinVideoBitrate && video.Bitrate > MinVideoBitrate {

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	MIN_VIDEO_BITRATE          = 100_000
-	ABSOLUTE_MIN_VIDEO_BITRATE = 5_000
+	MinVideoBitrate         = 100_000
+	AbsoluteMinVideoBitrate = 5_000
+	MaxVideoBitrate         = 288_000_000
 )
 
 type InputVideo struct {
@@ -92,9 +93,13 @@ func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 	if len(profiles) == 0 {
 		profiles = []EncodedProfile{lowBitrateProfile(video)}
 	}
+	videoBitrate := video.Bitrate
+	if videoBitrate > MaxVideoBitrate {
+		videoBitrate = MaxVideoBitrate
+	}
 	profiles = append(profiles, EncodedProfile{
 		Name:    strconv.FormatInt(nearestEven(video.Height), 10) + "p0",
-		Bitrate: video.Bitrate,
+		Bitrate: videoBitrate,
 		FPS:     0,
 		Width:   nearestEven(video.Width),
 		Height:  nearestEven(video.Height),
@@ -104,10 +109,10 @@ func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 
 func lowBitrateProfile(video InputTrack) EncodedProfile {
 	bitrate := int64(float64(video.Bitrate) * (1.0 / 2.0))
-	if bitrate < MIN_VIDEO_BITRATE && video.Bitrate > MIN_VIDEO_BITRATE {
-		bitrate = MIN_VIDEO_BITRATE
-	} else if bitrate < ABSOLUTE_MIN_VIDEO_BITRATE {
-		bitrate = ABSOLUTE_MIN_VIDEO_BITRATE
+	if bitrate < MinVideoBitrate && video.Bitrate > MinVideoBitrate {
+		bitrate = MinVideoBitrate
+	} else if bitrate < AbsoluteMinVideoBitrate {
+		bitrate = AbsoluteMinVideoBitrate
 	}
 	return EncodedProfile{
 		Name:    "low-bitrate",

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -103,6 +103,22 @@ func TestGetPlaybackProfiles(t *testing.T) {
 				{Name: "240p0", Width: 400, Height: 240, Bitrate: 517099},
 			},
 		},
+		{
+			name: "input with excessively high bitrate",
+			track: InputTrack{
+				Type:    "video",
+				Bitrate: 500_000_000,
+				VideoTrack: VideoTrack{
+					Width:  1920,
+					Height: 1080,
+				},
+			},
+			want: []EncodedProfile{
+				{Name: "360p0", Width: 640, Height: 360, Bitrate: 1_000_000},
+				{Name: "720p0", Width: 1280, Height: 720, Bitrate: 4_000_000},
+				{Name: "1080p0", Width: 1920, Height: 1080, Bitrate: MaxVideoBitrate},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- mediaconvert was throwing an error when an input had a very high bitrate, over 288000000
- renamed constants to match the golang convention