### PR TITLE
Bump go-tools to v0.2.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.7
-	github.com/livepeer/go-tools v0.2.5
+	github.com/livepeer/go-tools v0.2.8
 	github.com/livepeer/livepeer-data v0.6.4
 	github.com/minio/madmin-go v1.7.5
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -330,6 +330,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/go-tools v0.2.5 h1:XeplmNfoPZK7mQesMQ814SUF/H+kdTubAsQR/NNTHQc=
 github.com/livepeer/go-tools v0.2.5/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
+github.com/livepeer/go-tools v0.2.8 h1:gwHAmrR34uT6noqdbrM3bP1aa87Ml8ZINXXkRuwn1cE=
+github.com/livepeer/go-tools v0.2.8/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
 github.com/livepeer/livepeer-data v0.6.4 h1:OFmIyKvnYqtXKKFnSORxB+tDPotLHEwRS6SXOEplugo=
 github.com/livepeer/livepeer-data v0.6.4/go.mod h1:/PPM48tccbKbD46eogmRKy7E087z4THaMB4Jfvn1cnI=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=


### PR DESCRIPTION
This brings in a mime-type fix https://github.com/livepeer/go-tools/pull/28