### PR TITLE
Fix data race

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -29,7 +29,7 @@ func CopyDStorageToS3(url, s3URL string, requestID string) error {
 		}
 
 		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2))
+	}, DStorageRetryBackoff())
 }
 
 func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser, error) {
@@ -125,4 +125,8 @@ func parseDStorageGatewayURL(u *url.URL) (string, string, string) {
 	}
 
 	return "", "", ""
+}
+
+func DStorageRetryBackoff() backoff.BackOff {
+	return backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2)
 }

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -16,8 +16,6 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-var dstorageRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2)
-
 func CopyDStorageToS3(url, s3URL string, requestID string) error {
 	return backoff.Retry(func() error {
 		content, err := DownloadDStorageFromGatewayList(url, requestID)
@@ -31,7 +29,7 @@ func CopyDStorageToS3(url, s3URL string, requestID string) error {
 		}
 
 		return nil
-	}, dstorageRetryBackoff)
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(1*time.Second), 2))
 }
 
 func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser, error) {

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -113,7 +113,7 @@ func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID
 		content := io.TeeReader(c, &byteAccWriter)
 
 		return UploadToOSURL(destOSBaseURL, filename, content, MAX_COPY_FILE_DURATION)
-	}, RetryBackoff())
+	}, UploadRetryBackoff())
 	return
 }
 
@@ -152,8 +152,4 @@ type StubInputCopy struct{}
 
 func (s *StubInputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL) (inputVideoProbe video.InputVideo, signedURL string, err error) {
 	return video.InputVideo{}, "", nil
-}
-
-func RetryBackoff() backoff.BackOff {
-	return backoff.WithMaxRetries(newExponentialBackOffExecutor(), 5)
 }

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -131,3 +131,7 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 
 	return backOff
 }
+
+func UploadRetryBackoff() backoff.BackOff {
+	return backoff.WithMaxRetries(newExponentialBackOffExecutor(), 5)
+}

--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/grafov/m3u8"
@@ -28,7 +29,7 @@ func DownloadRenditionManifest(sourceManifestOSURL string) (m3u8.MediaPlaylist, 
 			return fmt.Errorf("error decoding manifest: %s", err)
 		}
 		return nil
-	}, transcodeRetryBackoff)
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10))
 	if err != nil {
 		return m3u8.MediaPlaylist{}, err
 	}

--- a/transcode/manifest.go
+++ b/transcode/manifest.go
@@ -138,7 +138,7 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 		renditionManifestBaseURL := fmt.Sprintf("%s/%s", targetOSURL, profile.Name)
 		err = backoff.Retry(func() error {
 			return clients.UploadToOSURL(renditionManifestBaseURL, manifestFilename, strings.NewReader(renditionPlaylist.String()), UPLOAD_TIMEOUT)
-		}, clients.RETRY_BACKOFF)
+		}, clients.RetryBackoff())
 		if err != nil {
 			return "", fmt.Errorf("failed to upload rendition playlist: %s", err)
 		}
@@ -152,7 +152,7 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 
 	err := backoff.Retry(func() error {
 		return clients.UploadToOSURL(targetOSURL, MASTER_MANIFEST_FILENAME, strings.NewReader(masterPlaylist.String()), UPLOAD_TIMEOUT)
-	}, clients.RETRY_BACKOFF)
+	}, clients.RetryBackoff())
 	if err != nil {
 		return "", fmt.Errorf("failed to upload master playlist: %s", err)
 	}

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -210,7 +210,7 @@ func transcodeSegment(
 
 		err = backoff.Retry(func() error {
 			return clients.UploadToOSURL(targetRenditionURL, fmt.Sprintf("%d.ts", segment.Index), bytes.NewReader(transcodedSegment.MediaData), UPLOAD_TIMEOUT)
-		}, clients.RETRY_BACKOFF)
+		}, clients.RetryBackoff())
 		if err != nil {
 			return fmt.Errorf("failed to upload master playlist: %s", err)
 		}

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -19,8 +19,6 @@ import (
 
 const UPLOAD_TIMEOUT = 5 * time.Minute
 
-var transcodeRetryBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10)
-
 type TranscodeSegmentRequest struct {
 	SourceFile        string                 `json:"source_location"`
 	CallbackURL       string                 `json:"callback_url"`
@@ -188,7 +186,7 @@ func transcodeSegment(
 			}
 		}
 		return nil
-	}, transcodeRetryBackoff)
+	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10))
 
 	if err != nil {
 		return err

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -186,7 +186,7 @@ func transcodeSegment(
 			}
 		}
 		return nil
-	}, backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10))
+	}, TranscodeRetryBackoff())
 
 	if err != nil {
 		return err
@@ -208,7 +208,7 @@ func transcodeSegment(
 
 		err = backoff.Retry(func() error {
 			return clients.UploadToOSURL(targetRenditionURL, fmt.Sprintf("%d.ts", segment.Index), bytes.NewReader(transcodedSegment.MediaData), UPLOAD_TIMEOUT)
-		}, clients.RetryBackoff())
+		}, clients.UploadRetryBackoff())
 		if err != nil {
 			return fmt.Errorf("failed to upload master playlist: %s", err)
 		}
@@ -273,4 +273,8 @@ type RenditionStats struct {
 	DurationMs       float64
 	ManifestLocation string
 	BitsPerSecond    uint32
+}
+
+func TranscodeRetryBackoff() backoff.BackOff {
+	return backoff.WithMaxRetries(backoff.NewConstantBackOff(5*time.Second), 10)
 }


### PR DESCRIPTION
We were seeing intermittent data race failures in our unit tests. This backoff implementation is advertised as not thread safe so we need a new instance each time. https://github.com/cenkalti/backoff/blob/v4.2.0/tries.go#L10-L12