### PR TITLE
transcode: commonize mp4 flag between pipelines

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -135,7 +135,6 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) (o
 			return nil, fmt.Errorf("failed to get playback profiles: %w", err)
 		}
 	}
-
 	// only output MP4s for short videos, with duration less than maxMP4OutDuration
 	if args.GenerateMP4 {
 		// sets the mp4 path to be the same as HLS except for the suffix being "static"

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -28,7 +28,6 @@ var retryableHttpClient = newRetryableHttpClient()
 
 const (
 	rateLimitedPollDelay = 15 * time.Second
-	maxMP4OutDuration    = 2 * time.Minute
 	mp4OutFilePrefix     = "static"
 )
 
@@ -138,7 +137,7 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) (o
 	}
 
 	// only output MP4s for short videos, with duration less than maxMP4OutDuration
-	if args.AutoMP4 && mcArgs.InputFileInfo.Duration <= maxMP4OutDuration.Seconds() {
+	if args.GenerateMP4 {
 		// sets the mp4 path to be the same as HLS except for the suffix being "static"
 		// resulting files look something like https://storage.googleapis.com/bucket/25afy0urw3zu2476/static360p0.mp4
 		mcArgs.MP4OutputLocation = mc.s3TransferBucket.JoinPath(path.Join("output", targetDir, mp4OutFilePrefix))

--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -245,22 +245,24 @@ func Test_MP4OutDurationCheck(t *testing.T) {
 	require := require.New(t)
 
 	tests := []struct {
-		name     string
-		duration float64
-		outputs  []string
+		name        string
+		duration    float64
+		outputs     []string
+		generatemp4 bool
 	}{
 		{
-			name:     "hls and mp4",
-			duration: 120,
-			outputs:  []string{"hls", "mp4"},
+			name:        "hls and mp4",
+			duration:    120,
+			outputs:     []string{"hls", "mp4"},
+			generatemp4: true,
 		},
 		{
-			name:     "hls only",
-			duration: 121,
-			outputs:  []string{"hls"},
+			name:        "hls only",
+			duration:    121,
+			outputs:     []string{"hls"},
+			generatemp4: false,
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			awsStub := &stubMediaConvertClient{
@@ -277,11 +279,10 @@ func Test_MP4OutDurationCheck(t *testing.T) {
 			defer cleanup()
 			iv := inputVideo
 			iv.Duration = tt.duration
-
 			_, err := mc.Transcode(context.Background(), TranscodeJobArgs{
 				InputFile:     mustParseURL(t, "file://"+f.Name()),
 				HLSOutputFile: mustParseURL(t, "s3+https://endpoint.com/bucket/1234/index.m3u8"),
-				AutoMP4:       true,
+				GenerateMP4:   tt.generatemp4,
 				InputFileInfo: iv,
 			})
 			require.Error(err)

--- a/clients/transcode_provider.go
+++ b/clients/transcode_provider.go
@@ -19,7 +19,7 @@ type TranscodeJobArgs struct {
 	// Input File info used to by transcoder provider(s) to set transcode options
 	InputFileInfo video.InputVideo
 	Profiles      []video.EncodedProfile
-	AutoMP4       bool
+	GenerateMP4   bool
 
 	// Collect size of an asset
 	CollectSourceSize        func(size int64)

--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -33,7 +33,7 @@ func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		InputFile:     sourceFileUrl,
 		HLSOutputFile: job.TargetURL,
 		Profiles:      job.Profiles,
-		AutoMP4:       job.AutoMP4,
+		GenerateMP4:   job.GenerateMP4,
 		ReportProgress: func(progress float64) {
 			job.ReportProgress(clients.TranscodeStatusTranscoding, progress)
 		},

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -150,6 +150,7 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 		TargetURL:         job.TargetURL.String(),
 		RequestID:         requestID,
 		ReportProgress:    job.ReportProgress,
+		GenerateMP4:       job.GenerateMP4,
 	}
 
 	var audioCodec = ""

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -39,6 +39,7 @@ type TranscodeSegmentRequest struct {
 	SourceStreamInfo clients.MistStreamInfo                 `json:"-"`
 	RequestID        string                                 `json:"-"`
 	ReportProgress   func(clients.TranscodeStatus, float64) `json:"-"`
+	GenerateMP4      bool
 }
 
 var LocalBroadcasterClient clients.BroadcasterClient


### PR DESCRIPTION
The AutoMP4 field in the studio request and the input file's duration is checked to enable MP4 generation -- this is currently only implemented for the mediaconvert pipeline. This commit moves the check and decision to HandleStartUploadJob such that it applies to both MediaConvert and Livepeer pipelines.

TODOs: 
* fix tests