### PR TITLE
Fix IPFS resource ID parsing

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -47,7 +48,7 @@ func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser,
 		resourceID = dStorageURL.Host
 	} else if dStorageURL.Scheme == SCHEME_IPFS {
 		gateways = config.ImportIPFSGatewayURLs
-		resourceID = dStorageURL.Host
+		resourceID = path.Join(dStorageURL.Host, dStorageURL.Path)
 	} else {
 		var gateway, dStorageType string
 		resourceID, gateway, dStorageType = parseDStorageGatewayURL(dStorageURL)

--- a/main.go
+++ b/main.go
@@ -97,15 +97,6 @@ func parseURL(s string, dest **url.URL) error {
 	return nil
 }
 
-func URLVarFlag(fs *flag.FlagSet, dest **url.URL, name, value, usage string) {
-	if err := parseURL(value, dest); err != nil {
-		panic(err)
-	}
-	fs.Func(name, usage, func(s string) error {
-		return parseURL(s, dest)
-	})
-}
-
 func URLSliceVarFlag(dest *[]*url.URL, name, value, usage string) {
 	if err := parseURLs(value, dest); err != nil {
 		panic(err)


### PR DESCRIPTION
We were ignoring the path of the incoming IPFS urls which meant we were fetching directory/contents pages rather than the intended files. From testing it appears that if we concatenate the host and path we get the correct result, for IPFS urls without any path this continues to work fine.

(Also removed an unused function in main.go)