### PR TITLE
Check codecs are compatible with mist

### DIFF
--- a/clients/mediaconvert_test.go
+++ b/clients/mediaconvert_test.go
@@ -301,13 +301,21 @@ func TestProbe(t *testing.T) {
 		Duration: 16.254,
 		Tracks: []video.InputTrack{
 			{
-				Type:    "video",
+				Type:    video.TrackTypeVideo,
 				Codec:   "h264",
 				Bitrate: 1234521,
 				VideoTrack: video.VideoTrack{
 					Width:  576,
 					Height: 1024,
 					FPS:    30,
+				},
+			},
+			{
+				Type:    video.TrackTypeAudio,
+				Codec:   "aac",
+				Bitrate: 128248,
+				AudioTrack: video.AudioTrack{
+					Channels: 2,
 				},
 			},
 		},

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -283,11 +283,16 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 	}
 }
 
+// checkMistCompatibleCodecs checks if the input codecs are compatible with mist and overrides the pipeline strategy
+// to external if they are incompatible
 func checkMistCompatibleCodecs(strategy Strategy, iv video.InputVideo) Strategy {
-	if strategy == StrategyCatalystDominance {
+	// allow StrategyCatalystDominance to pass through as this is used in tests and we might want to manually force it for debugging
+	// allow StrategyExternalDominance to pass through because we're already not trying to use mist so no need to loop through the tracks
+	if strategy == StrategyCatalystDominance || strategy == StrategyExternalDominance {
 		return strategy
 	}
 	for _, track := range iv.Tracks {
+		// if the codecs are not compatible then override to external pipeline to avoid sending to mist
 		if track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264" {
 			return StrategyExternalDominance
 		} else if track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac" {

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -9,6 +9,8 @@ const (
 	MinVideoBitrate         = 100_000
 	AbsoluteMinVideoBitrate = 5_000
 	MaxVideoBitrate         = 288_000_000
+	TrackTypeVideo          = "video"
+	TrackTypeAudio          = "audio"
 )
 
 type InputVideo struct {
@@ -23,7 +25,7 @@ type InputVideo struct {
 // If no video tracks present, returns an error
 func (i InputVideo) GetVideoTrack() (InputTrack, error) {
 	for _, t := range i.Tracks {
-		if t.Type == "video" {
+		if t.Type == TrackTypeVideo {
 			return t, nil
 		}
 	}


### PR DESCRIPTION
Only send to mist if the input codecs are known to be compatible to avoid unnecessary failures