### PR TITLE
Set a default bitrate if we don't find one

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -37,7 +37,7 @@ func (p Probe) ProbeFile(url string) (iv InputVideo, err error) {
 	return parseProbeOutput(data)
 }
 
-func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
+func parseProbeOutput(probeData *ffprobe.ProbeData) (iv InputVideo, err error) {
 	// check for a valid video stream
 	videoStream := probeData.FirstVideoStream()
 	if videoStream == nil {
@@ -56,12 +56,14 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 	if bitRateValue == "" {
 		bitRateValue = probeData.Format.BitRate
 	}
+	var bitrate int64
 	if bitRateValue == "" {
-		return InputVideo{}, fmt.Errorf("error probing: bitrate field not found")
-	}
-	bitrate, err := strconv.ParseInt(bitRateValue, 10, 64)
-	if err != nil {
-		return InputVideo{}, fmt.Errorf("error parsing bitrate from probed data: %w", err)
+		bitrate = DefaultProfile720p.Bitrate
+	} else {
+		bitrate, err = strconv.ParseInt(bitRateValue, 10, 64)
+		if err != nil {
+			return InputVideo{}, fmt.Errorf("error parsing bitrate from probed data: %w", err)
+		}
 	}
 	// parse filesize
 	size, err := strconv.ParseInt(probeData.Format.Size, 10, 64)
@@ -74,7 +76,7 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 		return InputVideo{}, fmt.Errorf("error parsing fps numerator from probed data: %w", err)
 	}
 	// format file stats into InputVideo
-	iv := InputVideo{
+	iv = InputVideo{
 		Tracks: []InputTrack{
 			{
 				Type:    TrackTypeVideo,

--- a/video/probe.go
+++ b/video/probe.go
@@ -37,7 +37,7 @@ func (p Probe) ProbeFile(url string) (iv InputVideo, err error) {
 	return parseProbeOutput(data)
 }
 
-func parseProbeOutput(probeData *ffprobe.ProbeData) (iv InputVideo, err error) {
+func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 	// check for a valid video stream
 	videoStream := probeData.FirstVideoStream()
 	if videoStream == nil {
@@ -56,7 +56,10 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (iv InputVideo, err error) {
 	if bitRateValue == "" {
 		bitRateValue = probeData.Format.BitRate
 	}
-	var bitrate int64
+	var (
+		bitrate int64
+		err     error
+	)
 	if bitRateValue == "" {
 		bitrate = DefaultProfile720p.Bitrate
 	} else {
@@ -76,7 +79,7 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (iv InputVideo, err error) {
 		return InputVideo{}, fmt.Errorf("error parsing fps numerator from probed data: %w", err)
 	}
 	// format file stats into InputVideo
-	iv = InputVideo{
+	iv := InputVideo{
 		Tracks: []InputTrack{
 			{
 				Type:    TrackTypeVideo,

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -51,14 +51,20 @@ func TestItRejectsWhenFormatMissing(t *testing.T) {
 	require.ErrorContains(t, err, "format information missing")
 }
 
-func TestItRejectsWhenVideoBitrateMissing(t *testing.T) {
-	_, err := parseProbeOutput(&ffprobe.ProbeData{
+func TestDefaultBitrate(t *testing.T) {
+	iv, err := parseProbeOutput(&ffprobe.ProbeData{
 		Streams: []*ffprobe.Stream{
 			{
 				CodecType: "video",
+				BitRate:   "",
 			},
 		},
-		Format: &ffprobe.Format{},
+		Format: &ffprobe.Format{
+			Size: "1",
+		},
 	})
-	require.ErrorContains(t, err, "bitrate field not found")
+	require.NoError(t, err)
+	track, err := iv.GetVideoTrack()
+	require.NoError(t, err)
+	require.Equal(t, DefaultProfile720p.Bitrate, track.Bitrate)
 }

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -60,23 +60,23 @@ type InputTrack struct {
 	AudioTrack
 }
 
-// DefaultTranscodeProfiles defines the default set of encoding profiles to use when none are specified
-var DefaultTranscodeProfiles = []EncodedProfile{
-	{
-		Name:    "360p0",
-		FPS:     0,
-		Bitrate: 1_000_000,
-		Width:   640,
-		Height:  360,
-	},
-	{
-		Name:    "720p0",
-		FPS:     0,
-		Bitrate: 4_000_000,
-		Width:   1280,
-		Height:  720,
-	},
+var DefaultProfile360p = EncodedProfile{
+	Name:    "360p0",
+	FPS:     0,
+	Bitrate: 1_000_000,
+	Width:   640,
+	Height:  360,
 }
+var DefaultProfile720p = EncodedProfile{
+	Name:    "720p0",
+	FPS:     0,
+	Bitrate: 4_000_000,
+	Width:   1280,
+	Height:  720,
+}
+
+// DefaultTranscodeProfiles defines the default set of encoding profiles to use when none are specified
+var DefaultTranscodeProfiles = []EncodedProfile{DefaultProfile360p, DefaultProfile720p}
 
 func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
 	video, err := iv.GetVideoTrack()


### PR DESCRIPTION
This will allow us to continue processing videos where the only issue is a missing bitrate in the probe output