### PR TITLE
Populate MP4 outputs in studio notification for mist

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -49,7 +49,7 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 	}
 	log.Log(requestID, "Copied", "bytes", size, "source", inputFile.String(), "dest", osTransferURL.String())
 
-	signedURL, err = signURL(osTransferURL)
+	signedURL, err = SignURL(osTransferURL)
 	if err != nil {
 		return
 	}
@@ -78,23 +78,6 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 		return
 	}
 	return
-}
-
-func signURL(u *url.URL) (string, error) {
-	if u.Scheme == "" || u.Scheme == "file" { // not compatible with presigning
-		return u.String(), nil
-	}
-	driver, err := drivers.ParseOSURL(u.String(), true)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse OS url: %w", err)
-	}
-
-	sess := driver.NewSession("")
-	signedURL, err := sess.Presign("", PresignDuration)
-	if err != nil {
-		return "", fmt.Errorf("failed to generate signed url: %w", err)
-	}
-	return signedURL, nil
 }
 
 func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string) (writtenBytes int64, err error) {

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -200,19 +200,10 @@ func (mc *MediaConvert) outputVideoFiles(mcArgs TranscodeJobArgs, ourOutputBaseD
 			if err != nil {
 				return nil, fmt.Errorf("error creating s3 url: %w", err)
 			}
-			outputVideoProbe, err := mc.probe.ProbeFile(presignedOutputFileURL)
+			videoFile, err = video.PopulateOutput(mc.probe, presignedOutputFileURL, videoFile)
 			if err != nil {
-				return nil, fmt.Errorf("error probing output file from S3: %w", err)
-
+				return nil, err
 			}
-			videoFile.SizeBytes = outputVideoProbe.SizeBytes
-			videoTrack, err := outputVideoProbe.GetVideoTrack()
-			if err != nil {
-				return nil, fmt.Errorf("no video track found in output video: %w", err)
-			}
-			videoFile.Height = videoTrack.Height
-			videoFile.Width = videoTrack.Width
-			videoFile.Bitrate = videoTrack.Bitrate
 		}
 		files = append(files, videoFile)
 	}

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -135,3 +135,20 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 func UploadRetryBackoff() backoff.BackOff {
 	return backoff.WithMaxRetries(newExponentialBackOffExecutor(), 5)
 }
+
+func SignURL(u *url.URL) (string, error) {
+	if u.Scheme == "" || u.Scheme == "file" { // not compatible with presigning
+		return u.String(), nil
+	}
+	driver, err := drivers.ParseOSURL(u.String(), true)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse OS url: %w", err)
+	}
+
+	sess := driver.NewSession("")
+	signedURL, err := sess.Presign("", PresignDuration)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate signed url: %w", err)
+	}
+	return signedURL, nil
+}

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -162,3 +162,20 @@ type OutputVideoFile struct {
 	Height    int64  `json:"height,omitempty"`
 	Bitrate   int64  `json:"bitrate,omitempty"`
 }
+
+func PopulateOutput(probe Prober, outputURL string, videoFile OutputVideoFile) (OutputVideoFile, error) {
+	outputVideoProbe, err := probe.ProbeFile(outputURL)
+	if err != nil {
+		return OutputVideoFile{}, fmt.Errorf("error probing output file from S3: %w", err)
+
+	}
+	videoFile.SizeBytes = outputVideoProbe.SizeBytes
+	videoTrack, err := outputVideoProbe.GetVideoTrack()
+	if err != nil {
+		return OutputVideoFile{}, fmt.Errorf("no video track found in output video: %w", err)
+	}
+	videoFile.Height = videoTrack.Height
+	videoFile.Width = videoTrack.Width
+	videoFile.Bitrate = videoTrack.Bitrate
+	return videoFile, nil
+}


### PR DESCRIPTION
The MP4 outputs are now being added to the studio notification for the mist pipeline, so that we can advertise these for playback