### PR TITLE
Log input video/audio track info

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -62,21 +62,23 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 		return
 	}
 	log.Log(requestID, "probe succeeded", "source", inputFile.String(), "dest", osTransferURL.String())
-	videoTrack, err := inputVideoProbe.GetVideoTrack()
+	videoTrack, err := inputVideoProbe.GetTrack(video.TrackTypeVideo)
 	if err != nil {
 		err = fmt.Errorf("no video track found in input video: %w", err)
 		return
 	}
+	audioTrack, _ := inputVideoProbe.GetTrack(video.TrackTypeAudio)
 	if videoTrack.FPS <= 0 {
 		// unsupported, includes things like motion jpegs
 		err = fmt.Errorf("invalid framerate: %f", videoTrack.FPS)
 		return
 	}
-
 	if inputVideoProbe.SizeBytes > config.MaxInputFileSizeBytes {
 		err = fmt.Errorf("input file %d bytes was greater than %d bytes", inputVideoProbe.SizeBytes, config.MaxInputFileSizeBytes)
 		return
 	}
+	log.Log(requestID, "probed video track:", "codec", videoTrack.Codec, "bitrate", videoTrack.Bitrate, "duration", videoTrack.DurationSec, "w", videoTrack.Width, "h", videoTrack.Height, "pix-format", videoTrack.PixelFormat, "FPS", videoTrack.FPS)
+	log.Log(requestID, "probed audio track", "codec", audioTrack.Codec, "bitrate", audioTrack.Bitrate, "duration", audioTrack.DurationSec, "channels", audioTrack.Channels)
 	return
 }
 

--- a/video/probe.go
+++ b/video/probe.go
@@ -105,7 +105,6 @@ func addAudioTrack(probeData *ffprobe.ProbeData, iv InputVideo) InputVideo {
 	if audioTrack == nil {
 		return iv
 	}
-
 	bitrate, _ := strconv.ParseInt(audioTrack.BitRate, 10, 64)
 	iv.Tracks = append(iv.Tracks, InputTrack{
 		Type:    TrackTypeAudio,

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -64,7 +64,7 @@ func TestDefaultBitrate(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	track, err := iv.GetVideoTrack()
+	track, err := iv.GetTrack(TrackTypeVideo)
 	require.NoError(t, err)
 	require.Equal(t, DefaultProfile720p.Bitrate, track.Bitrate)
 }

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -23,9 +23,12 @@ type InputVideo struct {
 // Finds the video track from the list of input video tracks
 // If multiple video tracks present, returns the first one
 // If no video tracks present, returns an error
-func (i InputVideo) GetVideoTrack() (InputTrack, error) {
+func (i InputVideo) GetTrack(trackType string) (InputTrack, error) {
+	if trackType != TrackTypeVideo && trackType != TrackTypeAudio {
+		return InputTrack{}, fmt.Errorf("invalid track type - must be '%s' or '%s'", TrackTypeVideo, TrackTypeAudio)
+	}
 	for _, t := range i.Tracks {
-		if t.Type == TrackTypeVideo {
+		if t.Type == trackType {
 			return t, nil
 		}
 	}
@@ -79,7 +82,7 @@ var DefaultProfile720p = EncodedProfile{
 var DefaultTranscodeProfiles = []EncodedProfile{DefaultProfile360p, DefaultProfile720p}
 
 func GetPlaybackProfiles(iv InputVideo) ([]EncodedProfile, error) {
-	video, err := iv.GetVideoTrack()
+	video, err := iv.GetTrack(TrackTypeVideo)
 	if err != nil {
 		return nil, fmt.Errorf("no video track found in input video: %w", err)
 	}
@@ -170,7 +173,7 @@ func PopulateOutput(probe Prober, outputURL string, videoFile OutputVideoFile) (
 
 	}
 	videoFile.SizeBytes = outputVideoProbe.SizeBytes
-	videoTrack, err := outputVideoProbe.GetVideoTrack()
+	videoTrack, err := outputVideoProbe.GetTrack(TrackTypeVideo)
 	if err != nil {
 		return OutputVideoFile{}, fmt.Errorf("no video track found in output video: %w", err)
 	}


### PR DESCRIPTION
Log input video/audio track info so that we can identify any raciness in the ffprobe behavior to root
cause cases where the input file uses mp4 + aac but still ends up in the
mediaconvert pipeline instead of solely using the mist pipeline.