### PR TITLE
add + fix pipeline metrics

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -72,7 +72,7 @@ type UploadJobPayload struct {
 	GenerateMP4           bool
 	InputFileInfo         video.InputVideo
 	SignedSourceURL       string
-	InFallbackMode        bool 
+	InFallbackMode        bool
 }
 
 // UploadJobResult is the object returned by the successful execution of an
@@ -248,6 +248,7 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 			}
 			return false
 		}(p.ForceMP4, p.AutoMP4, p.InputFileInfo.Duration)
+
 		log.AddContext(si.RequestID, "new_source_url", newSourceURL)
 		log.AddContext(si.RequestID, "signed_url", signedURL)
 
@@ -330,6 +331,9 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		pipeline = "aws-mediaconvert"
 	}
 
+	videoTrack, _ := p.InputFileInfo.GetTrack(video.TrackTypeVideo)
+	audioTrack, _ := p.InputFileInfo.GetTrack(video.TrackTypeAudio)
+
 	si := &JobInfo{
 		UploadJobPayload: p,
 		StreamName:       streamName,
@@ -345,6 +349,8 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		transcodedSegments:    0,
 		targetSegmentSizeSecs: p.TargetSegmentSizeSecs,
 		catalystRegion:        os.Getenv("MY_REGION"),
+		sourceCodecVideo:      videoTrack.Codec,
+		sourceCodecAudio:      audioTrack.Codec,
 	}
 	si.ReportProgress(clients.TranscodeStatusPreparing, 0)
 

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -408,7 +408,7 @@ func TestPipelineCollectedMetrics(t *testing.T) {
 
 	dbMock.
 		ExpectExec("insert into \"vod_completed\".*").
-		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key").
+		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	coord.StartUploadJob(job)
@@ -475,7 +475,7 @@ func Test_ProbeErrors(t *testing.T) {
 		{
 			name:        "audio only",
 			assetType:   "audio",
-			expectedErr: "error copying input to storage: no video track found in input video: no video tracks found",
+			expectedErr: "error copying input to storage: no video track found in input video: no 'video' tracks found",
 		},
 		{
 			name:        "filesize greater than max",

--- a/pipeline/external.go
+++ b/pipeline/external.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"net/url"
 	"time"
 
@@ -21,6 +22,7 @@ func (m *external) Name() string {
 
 func (e *external) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	job.sourceBytes = job.InputFileInfo.SizeBytes
+	job.sourceDurationMs = int64(math.Round(job.InputFileInfo.Duration) * 1000)
 	sourceFileUrl, err := url.Parse(job.SignedSourceURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid source file URL: %w", err)

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -195,9 +195,6 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 		}
 	}
 
-	job.sourceCodecVideo = videoCodec
-	job.sourceCodecAudio = audioCodec
-
 	job.state = "transcoding"
 	job.sourceBytes = int64(p.WrittenBytes)
 	job.sourceDurationMs = p.StreamMediaDurationMillis

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -32,7 +32,7 @@ func (i InputVideo) GetTrack(trackType string) (InputTrack, error) {
 			return t, nil
 		}
 	}
-	return InputTrack{}, fmt.Errorf("no video tracks found")
+	return InputTrack{}, fmt.Errorf("no '%s' tracks found", trackType)
 }
 
 type VideoTrack struct {


### PR DESCRIPTION
    **metrics: add in_fallback_mode metric to track fallbacks**

    If the Catalyst pipeline fails for any reason, we want to track every
    request-id that ends up falling back to the Mediaconvert pipeline. Add a
    metric (in_fallback_mode) to track when a job has fallen back into the
    backup pipeline.

    **metrics: fix duration/codec metrics to track pipeline state**

    A few metrics were not populated in the postgres db depending on the
    pipeline used (catalyst vs mediaconvert). Add the missing metrics and
    commonize codec metrics between the two pipelines.