### PR TITLE
transcode: skip mp4 output for low-bitrate profiles

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -167,6 +167,10 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 			}
 
 			// b. create a single .ts file for a given rendition by concatenating all segments in order
+			if rendition == "low-bitrate" {
+				// skip mp4 generation for low-bitrate profile
+				continue
+			}
 			concatTsFileName := filepath.Join(TRANSMUX_STORAGE_DIR, transcodeRequest.RequestID+"_"+rendition+".ts")
 			defer os.Remove(concatTsFileName)
 			totalBytes, err := video.ConcatTS(concatTsFileName, segments)


### PR DESCRIPTION
When the input video's res/bitrate combo is too low for the default ABR ladder, an additional low-bitrate profile with 50% of input bitrate is generated for ABR HLS based playback. For MP4s, only a single MP4 matching the default ABR is required so skip MP4 output for low bitrate profiles.