### PR TITLE
Remove media playback endpoint

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -57,13 +57,6 @@ func NewCatalystAPIRouter(vodEngine *pipeline.Coordinator, apiToken string) *htt
 		),
 	)
 
-	// Media endpoint
-	router.GET("/media/hls/:playbackID/*file",
-		withLogging(
-			handlers.MediaHandler(),
-		),
-	)
-
 	// Endpoint to receive "Triggers" (callbacks) from Mist
 	router.POST("/api/mist/trigger", withLogging(mistCallbackHandlers.Trigger()))
 

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -46,38 +46,6 @@ func ManifestHandler() httprouter.Handle {
 	}
 }
 
-func MediaHandler() httprouter.Handle {
-	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
-		var requestID = config.RandomTrailer(8)
-		err := req.ParseForm()
-		if err != nil {
-			handleError(err, req, requestID, w)
-			return
-		}
-
-		key := req.Form.Get(playback.ManifestKeyParam)
-		if err := checkKey(key); err != nil {
-			handleError(err, req, requestID, w)
-			return
-		}
-		media, err := playback.Media(playback.PlaybackRequest{
-			RequestID:  requestID,
-			PlaybackID: params.ByName("playbackID"),
-			File:       params.ByName("file"),
-		})
-		if err != nil {
-			handleError(err, req, requestID, w)
-			return
-		}
-		defer media.Close()
-
-		_, err = io.Copy(w, media)
-		if err != nil {
-			log.LogError(requestID, "failed to write response", err)
-		}
-	}
-}
-
 // temporary hard coded check until real auth is implemented
 func checkKey(key string) error {
 	if key != "secretlpkey" {


### PR DESCRIPTION
Removing this as MP4s will still come in via the manifest endpoint which won't work. I am switching to handling manifests and media from a single endpoint in another PR, I'm removing this code in its own PR because it cleans up the diff nicely for the next PR