### PR TITLE
add mist cleanup script to catalyst-api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ all: build fmt test lint integration-test tidy
 .PHONY: build
 build:
 	go build -ldflags="$(ldflags)" -o "$(GO_BUILD_DIR)catalyst-api" main.go
+	cp scripts/* "$(GO_BUILD_DIR)"
 
 .PHONY: build-linux
 build-linux:

--- a/scripts/mist-cleanup.sh
+++ b/scripts/mist-cleanup.sh
@@ -7,49 +7,49 @@ containsElement () {
   return 1
 }
 
-SEMS=`ls -tr /dev/shm/sem.MstTRKS* /dev/shm/sem.MstUser* /dev/shm/sem.MstInpt* /dev/shm/sem.MstPull* 2> /dev/null`
-PULS=`ls -tr /dev/shm/sem.MstPull* 2> /dev/null`
+SEMS=$(ls -tr /dev/shm/sem.MstTRKS* /dev/shm/sem.MstUser* /dev/shm/sem.MstInpt* /dev/shm/sem.MstPull* 2> /dev/null)
+PULS=$(ls -tr /dev/shm/sem.MstPull* 2> /dev/null)
 #sem.MstPull_golive+Preview
-PAGS=`find /dev/shm/ -name MstData* -o -name MstMeta* -o -name MstTrak* 2> /dev/null`
-STAT=`ls -tr /dev/shm/MstSTATEgolive* 2> /dev/null`
-ACTS=`ps -C MistInBuffer -o command= | awk ' { print $3 } ' | sort | uniq`
-DTPL=`ps -C MistInDTSC -o command= | awk ' { print $3 } ' | sort | uniq`
+PAGS=$(find /dev/shm/ -name "MstData*" -o -name "MstMeta*" -o -name "MstTrak*" 2> /dev/null)
+STAT=$(ls -tr /dev/shm/MstSTATEgolive* 2> /dev/null)
+ACTS=$(ps -C MistInBuffer -o command= | awk ' { print $3 } ' | sort | uniq)
+DTPL=$(ps -C MistInDTSC -o command= | awk ' { print $3 } ' | sort | uniq)
 DATA_DEL=0
 
 #Check for input semaphores without data
 for S in $SEMS ; do
   STRM=${S:20}
-  if containsElement $STRM $ACTS ; then
+  if containsElement "$STRM" "$ACTS" ; then
     echo "Yes: ${STRM} (${S})" > /dev/null
   else
     echo "SEM_INPUT: ${S}"
-    rm ${S}
+    rm "${S}"
   fi
 done
 
 #Check for pull semaphores without data
 for S in $PULS ; do
   STRM=${S:21}
-  if containsElement $STRM $DTPL ; then
+  if containsElement "$STRM" "$DTPL" ; then
     echo "Yes: ${STRM} (${S})" > /dev/null
   else
     #Silenced, since this one is mostly harmless.
     #echo "SEM_PULL: ${S}"
-    rm ${S}
+    rm "${S}"
   fi
 done
 
 #Check for data pages without buffer
-for P in $PAGS ; do
+for P in $PAGS; do
   FILE=${P%@*} #Remove everything after the '@'
   STRM=${FILE:16} #Strip the beginning
-  if containsElement $STRM $ACTS ; then
+  if containsElement "$STRM" "$ACTS" ; then
     echo "Yes: ${STRM} (${P})" > /dev/null
   else
     if (( $# != 0 )); then
       echo "DATA: ${P}"
     fi
-    rm ${P}
+    rm "${P}"
     DATA_DEL=$(( DATA_DEL + 1 ))
   fi
 done
@@ -57,11 +57,11 @@ done
 #Check for state pages without buffer
 for P in $STAT ; do
   STRM=${P:17} #Strip the beginning
-  if containsElement $STRM $ACTS ; then
+  if containsElement "$STRM" "$ACTS" ; then
     echo "Yes: ${STRM} (${P})" > /dev/null
   else
     echo "STATE: ${P}"
-    rm ${P}
+    rm "${P}"
   fi
 done
 

--- a/scripts/mist-cleanup.sh
+++ b/scripts/mist-cleanup.sh
@@ -1,4 +1,13 @@
-#!/bin/bash
+#!/bin/bash -e
+
+script=$(basename "$0")
+pidfile="/var/run/${script}"
+
+# lock so that multiple instances of this script cannot run in parallel
+exec 200>"$pidfile"
+flock -n 200 || exit 1
+pid=$$
+echo $pid 1>&200
 
 containsElement () {
   local e match="$1"

--- a/scripts/mist-cleanup.sh
+++ b/scripts/mist-cleanup.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+containsElement () {
+  local e match="$1"
+  shift
+  for e; do [[ "$e" == "$match" ]] && return 0; done
+  return 1
+}
+
+SEMS=`ls -tr /dev/shm/sem.MstTRKS* /dev/shm/sem.MstUser* /dev/shm/sem.MstInpt* /dev/shm/sem.MstPull* 2> /dev/null`
+PULS=`ls -tr /dev/shm/sem.MstPull* 2> /dev/null`
+#sem.MstPull_golive+Preview
+PAGS=`find /dev/shm/ -name MstData* -o -name MstMeta* -o -name MstTrak* 2> /dev/null`
+STAT=`ls -tr /dev/shm/MstSTATEgolive* 2> /dev/null`
+ACTS=`ps -C MistInBuffer -o command= | awk ' { print $3 } ' | sort | uniq`
+DTPL=`ps -C MistInDTSC -o command= | awk ' { print $3 } ' | sort | uniq`
+DATA_DEL=0
+
+#Check for input semaphores without data
+for S in $SEMS ; do
+  STRM=${S:20}
+  if containsElement $STRM $ACTS ; then
+    echo "Yes: ${STRM} (${S})" > /dev/null
+  else
+    echo "SEM_INPUT: ${S}"
+    rm ${S}
+  fi
+done
+
+#Check for pull semaphores without data
+for S in $PULS ; do
+  STRM=${S:21}
+  if containsElement $STRM $DTPL ; then
+    echo "Yes: ${STRM} (${S})" > /dev/null
+  else
+    #Silenced, since this one is mostly harmless.
+    #echo "SEM_PULL: ${S}"
+    rm ${S}
+  fi
+done
+
+#Check for data pages without buffer
+for P in $PAGS ; do
+  FILE=${P%@*} #Remove everything after the '@'
+  STRM=${FILE:16} #Strip the beginning
+  if containsElement $STRM $ACTS ; then
+    echo "Yes: ${STRM} (${P})" > /dev/null
+  else
+    if (( $# != 0 )); then
+      echo "DATA: ${P}"
+    fi
+    rm ${P}
+    DATA_DEL=$(( DATA_DEL + 1 ))
+  fi
+done
+
+#Check for state pages without buffer
+for P in $STAT ; do
+  STRM=${P:17} #Strip the beginning
+  if containsElement $STRM $ACTS ; then
+    echo "Yes: ${STRM} (${P})" > /dev/null
+  else
+    echo "STATE: ${P}"
+    rm ${P}
+  fi
+done
+
+echo "Deleted ${DATA_DEL} data pages"


### PR DESCRIPTION
This PR integrates the mist-cleanup script that will be called periodically to clean up /dev/shm. A separate PR will be used to actually schedule and call this script. 

Best to review on a per commit basis. @Thulinma: FYI so that you can see the diff from your original script. 

Related Catalyst PR to install the script in `build/` dir: https://github.com/livepeer/catalyst/pull/441