### PR TITLE
Fix confusing error message

### DIFF
--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"path/filepath"
 	"time"
 
 	"github.com/livepeer/catalyst-api/log"
@@ -65,7 +66,7 @@ func UploadToOSURL(osURL, filename string, data io.Reader, timeout time.Duration
 
 	if err != nil {
 		metrics.Metrics.ObjectStoreClient.FailureCount.WithLabelValues(url, "write").Inc()
-		return fmt.Errorf("failed to write file %q to OS URL %q: %s", filename, log.RedactURL(osURL), err)
+		return fmt.Errorf("failed to write to OS URL %q: %s", log.RedactURL(filepath.Join(osURL, filename)), err)
 	}
 
 	duration := time.Since(start)


### PR DESCRIPTION
In a few places we're passing in the full destination URL as the `osURL` param with `filename` blank. This meant the error message made it appear like there was a bug with filename being empty