### PR TITLE
Add a metric flag to show whether codecs are mist supported

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -35,7 +35,7 @@ type CatalystAPIMetrics struct {
 	VODPipelineMetrics VODPipelineMetrics
 }
 
-var vodLabels = []string{"source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "num_profiles", "stage", "version", "is_fallback_mode"}
+var vodLabels = []string{"source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "num_profiles", "stage", "version", "is_fallback_mode", "is_mist_supported"}
 
 func NewMetrics() *CatalystAPIMetrics {
 	m := &CatalystAPIMetrics{

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -74,6 +74,7 @@ type UploadJobPayload struct {
 	InputFileInfo         video.InputVideo
 	SignedSourceURL       string
 	InFallbackMode        bool
+	MistSupported         bool
 }
 
 // UploadJobResult is the object returned by the successful execution of an
@@ -262,7 +263,7 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 	if p.PipelineStrategy.IsValid() {
 		strategy = p.PipelineStrategy
 	}
-	strategy = checkMistCompatibleCodecs(strategy, p.InputFileInfo)
+	p.MistSupported, strategy = checkMistCompatibleCodecs(strategy, p.InputFileInfo)
 	log.AddContext(p.RequestID, "strategy", strategy)
 
 	switch strategy {
@@ -292,21 +293,19 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 
 // checkMistCompatibleCodecs checks if the input codecs are compatible with mist and overrides the pipeline strategy
 // to external if they are incompatible
-func checkMistCompatibleCodecs(strategy Strategy, iv video.InputVideo) Strategy {
-	// allow StrategyCatalystDominance to pass through as this is used in tests and we might want to manually force it for debugging
-	// allow StrategyExternalDominance to pass through because we're already not trying to use mist so no need to loop through the tracks
-	if strategy == StrategyCatalystDominance || strategy == StrategyExternalDominance {
-		return strategy
-	}
+func checkMistCompatibleCodecs(strategy Strategy, iv video.InputVideo) (bool, Strategy) {
 	for _, track := range iv.Tracks {
 		// if the codecs are not compatible then override to external pipeline to avoid sending to mist
-		if track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264" {
-			return StrategyExternalDominance
-		} else if track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac" {
-			return StrategyExternalDominance
+		if (track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264") ||
+			(track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac") {
+			// allow StrategyCatalystDominance to pass through as this is used in tests and we might want to manually force it for debugging
+			if strategy == StrategyCatalystDominance {
+				return false, strategy
+			}
+			return false, StrategyExternalDominance
 		}
 	}
-	return strategy
+	return true, strategy
 }
 
 // Starts a single upload job with specified pipeline Handler. If the job is
@@ -455,6 +454,7 @@ func (c *Coordinator) finishJob(job *JobInfo, out *HandlerOutput, err error) {
 		job.state,
 		config.Version,
 		strconv.FormatBool(job.InFallbackMode),
+		strconv.FormatBool(job.MistSupported),
 	}
 
 	metrics.Metrics.VODPipelineMetrics.Count.

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -263,7 +263,7 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 	if p.PipelineStrategy.IsValid() {
 		strategy = p.PipelineStrategy
 	}
-	p.MistSupported, strategy = checkMistCompatibleCodecs(strategy, p.InputFileInfo)
+	p.MistSupported, strategy = checkMistCompatibleCodecs(p.RequestID, strategy, p.InputFileInfo)
 	log.AddContext(p.RequestID, "strategy", strategy)
 
 	switch strategy {
@@ -293,11 +293,12 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 
 // checkMistCompatibleCodecs checks if the input codecs are compatible with mist and overrides the pipeline strategy
 // to external if they are incompatible
-func checkMistCompatibleCodecs(strategy Strategy, iv video.InputVideo) (bool, Strategy) {
+func checkMistCompatibleCodecs(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
 	for _, track := range iv.Tracks {
 		// if the codecs are not compatible then override to external pipeline to avoid sending to mist
 		if (track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264") ||
 			(track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac") {
+			log.Log(requestID, "codec not supported by mist", "trackType", track.Type, "codec", track.Codec)
 			// allow StrategyCatalystDominance to pass through as this is used in tests and we might want to manually force it for debugging
 			if strategy == StrategyCatalystDominance {
 				return false, strategy

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -796,7 +796,7 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			supported, got := checkMistCompatibleCodecs(tt.args.strategy, tt.args.iv)
+			supported, got := checkMistCompatibleCodecs("requestID", tt.args.strategy, tt.args.iv)
 			require.Equal(t, tt.want, got)
 			require.Equal(t, tt.wantSupported, supported)
 		})

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -691,6 +691,18 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 			},
 		},
 	}
+	inCompatibleAudio := video.InputVideo{
+		Tracks: []video.InputTrack{
+			{
+				Codec: "h264",
+				Type:  video.TrackTypeVideo,
+			},
+			{
+				Codec: "ac-3",
+				Type:  video.TrackTypeAudio,
+			},
+		},
+	}
 	compatibleVideoAndAudio := video.InputVideo{
 		Tracks: []video.InputTrack{
 			{
@@ -704,9 +716,10 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 		},
 	}
 	tests := []struct {
-		name string
-		args args
-		want Strategy
+		name          string
+		args          args
+		want          Strategy
+		wantSupported bool
 	}{
 		{
 			name: "catalyst dominance",
@@ -714,7 +727,8 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyCatalystDominance,
 				iv:       inCompatibleVideoAndAudio,
 			},
-			want: StrategyCatalystDominance,
+			want:          StrategyCatalystDominance,
+			wantSupported: false,
 		},
 		{
 			name: "catalyst dominance",
@@ -722,7 +736,8 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyCatalystDominance,
 				iv:       inCompatibleVideo,
 			},
-			want: StrategyCatalystDominance,
+			want:          StrategyCatalystDominance,
+			wantSupported: false,
 		},
 		{
 			name: "incompatible with mist - StrategyBackgroundMist",
@@ -730,7 +745,8 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyBackgroundMist,
 				iv:       inCompatibleVideoAndAudio,
 			},
-			want: StrategyExternalDominance,
+			want:          StrategyExternalDominance,
+			wantSupported: false,
 		},
 		{
 			name: "incompatible with mist - StrategyBackgroundMist",
@@ -738,7 +754,8 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyBackgroundMist,
 				iv:       inCompatibleVideo,
 			},
-			want: StrategyExternalDominance,
+			want:          StrategyExternalDominance,
+			wantSupported: false,
 		},
 		{
 			name: "compatible with mist - StrategyBackgroundMist",
@@ -746,7 +763,8 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyBackgroundMist,
 				iv:       compatibleVideoAndAudio,
 			},
-			want: StrategyBackgroundMist,
+			want:          StrategyBackgroundMist,
+			wantSupported: true,
 		},
 		{
 			name: "incompatible with mist - StrategyFallbackExternal",
@@ -754,7 +772,17 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyFallbackExternal,
 				iv:       inCompatibleVideo,
 			},
-			want: StrategyExternalDominance,
+			want:          StrategyExternalDominance,
+			wantSupported: false,
+		},
+		{
+			name: "incompatible with mist - StrategyFallbackExternal",
+			args: args{
+				strategy: StrategyFallbackExternal,
+				iv:       inCompatibleAudio,
+			},
+			want:          StrategyExternalDominance,
+			wantSupported: false,
 		},
 		{
 			name: "compatible with mist - StrategyFallbackExternal",
@@ -762,13 +790,15 @@ func Test_checkMistCompatibleCodecs(t *testing.T) {
 				strategy: StrategyFallbackExternal,
 				iv:       compatibleVideoAndAudio,
 			},
-			want: StrategyFallbackExternal,
+			want:          StrategyFallbackExternal,
+			wantSupported: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := checkMistCompatibleCodecs(tt.args.strategy, tt.args.iv)
+			supported, got := checkMistCompatibleCodecs(tt.args.strategy, tt.args.iv)
 			require.Equal(t, tt.want, got)
+			require.Equal(t, tt.wantSupported, supported)
 		})
 	}
 }


### PR DESCRIPTION
This will allow us to track on our dashboard which jobs are being sent to mediaconvert due to the codecs not being supported by mist