### PR TITLE
Increase copy timeout

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -24,7 +24,7 @@ func CopyDStorageToS3(url, s3URL string, requestID string) error {
 			return err
 		}
 
-		err = UploadToOSURL(s3URL, "", content, MAX_COPY_FILE_DURATION)
+		err = UploadToOSURL(s3URL, "", content, MaxCopyFileDuration)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This is to improve the chances of us being able to download >2GiB files from IPFS.
Moved retryableHttpClient to input_copy.go since it was only used there.