### PR TITLE
build.yaml: tar up everything in build/ dir of catalyst-api

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
         if: matrix.platform.name != 'windows'
         run: |
           cd build/
-          tar -czvf "../releases/livepeer-catalyst-api-${GOOS}-${GOARCH}.tar.gz" ./livepeer-catalyst-api
+          tar -czvf "../releases/livepeer-catalyst-api-${GOOS}-${GOARCH}.tar.gz" .
 
       - name: Upload artifacts for cutting release
         uses: actions/upload-artifact@master


### PR DESCRIPTION
This change will ensure all output from 'make build' in catalyst-api will get copied to the tar balls. Specifically, this change is being done so that the mist-cleanup scripts get installed onto pods which will be called by catalyst-api.