### PR TITLE
clients/callback: send auth key back up

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -106,7 +106,7 @@ func TestVODHandlerProfiles(t *testing.T) {
 	defer callbackServer.Close()
 
 	// Set up out own callback client so that we can ensure it just fires once
-	statusClient := clients.NewPeriodicCallbackClient(100 * time.Minute)
+	statusClient := clients.NewPeriodicCallbackClient(100*time.Minute, map[string]string{})
 	// Workflow engine
 	vodEngine := pipeline.NewStubCoordinatorOpts("", statusClient, nil, nil)
 	vodEngine.InputCopy = &clients.StubInputCopy{}

--- a/main.go
+++ b/main.go
@@ -132,7 +132,8 @@ func main() {
 	}
 
 	// Kick off the callback client, to send job update messages on a regular interval
-	statusClient := clients.NewPeriodicCallbackClient(15 * time.Second).Start()
+	headers := map[string]string{"Authorization": fmt.Sprintf("Bearer %s", cli.APIToken)}
+	statusClient := clients.NewPeriodicCallbackClient(15*time.Second, headers).Start()
 
 	// Emit high-cardinality metrics to a Postrgres database if configured
 	if cli.MetricsDBConnectionString != "" {

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -108,7 +108,7 @@ func TestItCanTranscode(t *testing.T) {
 		},
 	}
 
-	statusClient := clients.NewPeriodicCallbackClient(100 * time.Minute)
+	statusClient := clients.NewPeriodicCallbackClient(100*time.Minute, map[string]string{})
 	// Check we don't get an error downloading or parsing it
 	outputs, segmentsCount, err := RunTranscodeProcess(
 		TranscodeSegmentRequest{


### PR DESCRIPTION
Callback client now passes `--api-key` instead of a hardcoded `IAmAuthorized`.