### PR TITLE
Fix access control for live streams

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -118,7 +118,7 @@ func (ac *AccessControlHandlersCollection) handleUserNew(payload []byte) []byte 
 }
 
 func (ac *AccessControlHandlersCollection) IsAuthorized(playbackID string, reqURL *url.URL) (bool, error) {
-	acReq := PlaybackAccessControlRequest{Stream: playbackID}
+	acReq := PlaybackAccessControlRequest{Stream: playbackID, Type: "accessKey"}
 	cacheKey := ""
 	accessKey := reqURL.Query().Get("accessKey")
 	jwt := reqURL.Query().Get("jwt")


### PR DESCRIPTION
The gate API is expecting to receive a type field, previously it always had a default value even for public streams so this is just to restore that behaviour