### PR TITLE
api: Set CORS headers on gated playback API

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -61,8 +61,10 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	// Playback endpoint
 	router.GET("/asset/hls/:playbackID/*file",
 		withLogging(
-			withGatingCheck(
-				handlers.PlaybackHandler(),
+			withCORS(
+				withGatingCheck(
+					handlers.PlaybackHandler(),
+				),
 			),
 		),
 	)

--- a/api/http.go
+++ b/api/http.go
@@ -46,6 +46,7 @@ func ListenAndServe(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coo
 func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal balancer.Balancer, c cluster.Cluster) *httprouter.Router {
 	router := httprouter.New()
 	withLogging := middleware.LogRequest()
+	withCORS := middleware.AllowCORS()
 	withGatingCheck := middleware.NewGatingHandler(cli).GatingCheck
 
 	catalystApiHandlers := &handlers.CatalystAPIHandlersCollection{VODEngine: vodEngine}
@@ -67,7 +68,7 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	)
 
 	// Handling incoming playback redirection requests
-	redirectHandler := withLogging(geoHandlers.RedirectHandler())
+	redirectHandler := withLogging(withCORS(geoHandlers.RedirectHandler()))
 	router.NotFound = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		redirectHandler(w, r, httprouter.Params{})
 	})

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -28,8 +28,6 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 		nodeHost := c.Config.NodeHost
 		redirectPrefixes := c.Config.RedirectPrefixes
-		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Headers", "*")
 
 		if nodeHost != "" {
 			host := r.Host

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -1,0 +1,19 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+)
+
+func AllowCORS() func(httprouter.Handle) httprouter.Handle {
+	return func(next httprouter.Handle) httprouter.Handle {
+		handler := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+			w.Header().Set("Access-Control-Allow-Origin", "*")
+			w.Header().Set("Access-Control-Allow-Headers", "*")
+
+			next(w, r, ps)
+		}
+		return handler
+	}
+}


### PR DESCRIPTION
Simple change but I created a middleware for it so we can re-use it across browser-facing APIs.