### PR TITLE
mapic: always return 200 from mist trigger

### DIFF
--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -366,8 +366,7 @@ func (mc *mac) triggerDefaultStream(w http.ResponseWriter, r *http.Request, line
 	//    haven't created new stream in Mist
 	// 2. When someone pulls HLS for stream that exists but is not active (no
 	//    RTMP stream coming in).
-	w.WriteHeader(http.StatusForbidden)
-	w.Write([]byte("false"))
+	w.Write([]byte(""))
 	return true
 }
 


### PR DESCRIPTION
In the event of a "banned" account, we want to return an empty string with a 200 rather than a 403 with "false" which Mist considers a failure.