### PR TITLE
upload: Trim URL suffix instead of "charset"

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -218,7 +218,7 @@ func tempBackwardsCompatibilityUpdate(locations []UploadVODRequestOutputLocation
 			if l.Outputs.ForceMP4 {
 				l.Outputs.MP4 = "enabled"
 			}
-			l.URL = strings.TrimRight(l.URL, "/index.m3u8")
+			l.URL = strings.TrimSuffix(l.URL, "/index.m3u8")
 		}
 		res = append(res, l)
 	}


### PR DESCRIPTION
We are basically failing upload processing of all assets whose playback ID ends in `e`, `3` or `8` (~18% since it's hex)

There has been ~124 failed assets until now: https://lvpr.link/3ztoAjW