### PR TITLE
Don't use Mist for large files

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -294,8 +294,8 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 // checkMistCompatible checks if the input codecs are compatible with mist and overrides the pipeline strategy
 // to external if they are incompatible
 func checkMistCompatible(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
-	// Mist currently struggles with large files, so we don't send it any files bigger than 100Mb
-	if iv.SizeBytes > 1024*1024*100 {
+	// Mist currently struggles with large files, so we don't send it any files bigger than 200Mb
+	if iv.SizeBytes > 1024*1024*200 {
 		return mistNotSupported(strategy)
 	}
 

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -294,6 +294,11 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 // checkMistCompatible checks if the input codecs are compatible with mist and overrides the pipeline strategy
 // to external if they are incompatible
 func checkMistCompatible(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
+	// Mist currently struggles with large files, so we don't send it any files bigger than 100Mb
+	if iv.SizeBytes > 1024*1024*100 {
+		return mistNotSupported(strategy)
+	}
+
 	for _, track := range iv.Tracks {
 		// if the codecs are not compatible then override to external pipeline to avoid sending to mist
 		if (track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264") ||

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -726,6 +726,19 @@ func Test_checkMistCompatible(t *testing.T) {
 			},
 		},
 	}
+	largeVideo := video.InputVideo{
+		Tracks: []video.InputTrack{
+			{
+				Codec: "h264",
+				Type:  video.TrackTypeVideo,
+			},
+			{
+				Codec: "aac",
+				Type:  video.TrackTypeAudio,
+			},
+		},
+		SizeBytes: 105906176, // 101 Megabytes
+	}
 	tests := []struct {
 		name          string
 		args          args
@@ -809,6 +822,15 @@ func Test_checkMistCompatible(t *testing.T) {
 			args: args{
 				strategy: StrategyFallbackExternal,
 				iv:       videoRotation,
+			},
+			want:          StrategyExternalDominance,
+			wantSupported: false,
+		},
+		{
+			name: "incompatible with mist - large video",
+			args: args{
+				strategy: StrategyFallbackExternal,
+				iv:       largeVideo,
 			},
 			want:          StrategyExternalDominance,
 			wantSupported: false,

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -737,7 +737,7 @@ func Test_checkMistCompatible(t *testing.T) {
 				Type:  video.TrackTypeAudio,
 			},
 		},
-		SizeBytes: 105906176, // 101 Megabytes
+		SizeBytes: 210763776, // 201 Megabytes
 	}
 	tests := []struct {
 		name          string


### PR DESCRIPTION
We've been seeing issues with Mist's handling of large files so until that's resolved, let's route those to the backup pipelines.