### PR TITLE
Dont copy input file to transfer bucket if its a direct upload

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -2,12 +2,12 @@ package clients
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -23,36 +23,48 @@ const MaxCopyFileDuration = 2 * time.Hour
 const PresignDuration = 24 * time.Hour
 
 type InputCopier interface {
-	CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL) (video.InputVideo, string, error)
+	CopyInputToS3(requestID string, inputFile *url.URL) (video.InputVideo, string, *url.URL, error)
 }
 
 type InputCopy struct {
-	S3    S3
-	Probe video.Prober
+	S3              S3
+	Probe           video.Prober
+	SourceOutputUrl string
 }
 
 // CopyInputToS3 copies the input video to our S3 transfer bucket and probes the file.
-func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL) (inputVideoProbe video.InputVideo, signedURL string, err error) {
-	if osTransferURL == nil {
-		err = errors.New("osTransferURL was nil")
-		return
-	}
+func (s *InputCopy) CopyInputToS3(requestID string, inputFile *url.URL) (inputVideoProbe video.InputVideo, signedURL string, osTransferURL *url.URL, err error) {
+	if strings.HasSuffix(inputFile.Host, "storage.googleapis.com") && strings.HasPrefix(inputFile.Path, "/directUpload") {
+		log.Log(requestID, "Direct upload detected", "source", inputFile.String())
+		signedURL = inputFile.String()
+		osTransferURL = inputFile
+	} else {
+		var (
+			size            int64
+			sourceOutputUrl *url.URL
+		)
+		sourceOutputUrl, err = url.Parse(s.SourceOutputUrl)
+		if err != nil {
+			err = fmt.Errorf("cannot create sourceOutputUrl: %w", err)
+			return
+		}
+		osTransferURL = sourceOutputUrl.JoinPath(requestID, "transfer", path.Base(inputFile.Path))
+		log.Log(requestID, "Copying input file to S3", "source", inputFile.String(), "dest", osTransferURL.String())
+		size, err = CopyFile(context.Background(), inputFile.String(), osTransferURL.String(), "", requestID)
+		if err != nil {
+			err = fmt.Errorf("error copying input file to S3: %w", err)
+			return
+		}
+		if size <= 0 {
+			err = fmt.Errorf("zero bytes found for source: %s", inputFile)
+			return
+		}
+		log.Log(requestID, "Copied", "bytes", size, "source", inputFile.String(), "dest", osTransferURL.String())
 
-	log.Log(requestID, "Copying input file to S3", "source", inputFile.String(), "dest", osTransferURL.String())
-	size, err := CopyFile(context.Background(), inputFile.String(), osTransferURL.String(), "", requestID)
-	if err != nil {
-		err = fmt.Errorf("error copying input file to S3: %w", err)
-		return
-	}
-	if size <= 0 {
-		err = fmt.Errorf("zero bytes found for source: %s", inputFile)
-		return
-	}
-	log.Log(requestID, "Copied", "bytes", size, "source", inputFile.String(), "dest", osTransferURL.String())
-
-	signedURL, err = SignURL(osTransferURL)
-	if err != nil {
-		return
+		signedURL, err = SignURL(osTransferURL)
+		if err != nil {
+			return
+		}
 	}
 
 	log.Log(requestID, "starting probe", "source", inputFile.String(), "dest", osTransferURL.String())
@@ -158,6 +170,6 @@ func getFileHTTP(ctx context.Context, url string) (io.ReadCloser, error) {
 
 type StubInputCopy struct{}
 
-func (s *StubInputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL) (inputVideoProbe video.InputVideo, signedURL string, err error) {
-	return video.InputVideo{}, "", nil
+func (s *StubInputCopy) CopyInputToS3(requestID string, inputFile *url.URL) (video.InputVideo, string, *url.URL, error) {
+	return video.InputVideo{}, "", &url.URL{}, nil
 }

--- a/clients/input_copy_test.go
+++ b/clients/input_copy_test.go
@@ -1,0 +1,34 @@
+package clients
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isDirectUpload(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputFile string
+		want      bool
+	}{
+		{
+			name:      "direct upload",
+			inputFile: "https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4",
+			want:      true,
+		},
+		{
+			name:      "not direct upload",
+			inputFile: "s3+https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputURL, err := url.Parse(tt.inputFile)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, isDirectUpload(inputURL))
+		})
+	}
+}

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -61,7 +61,10 @@ func setupTransferDir(t *testing.T, coor *Coordinator) (inputFile *os.File, tran
 		require.NoError(t, inputFile.Close())
 	}
 
-	coor.SourceOutputUrl = transferDir
+	coor.InputCopy = &clients.InputCopy{
+		Probe:           video.Probe{},
+		SourceOutputUrl: transferDir,
+	}
 	return
 }
 
@@ -493,6 +496,8 @@ func Test_ProbeErrors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			callbackHandler, callbacks := callbacksRecorder()
 			coord := NewStubCoordinatorOpts("", callbackHandler, nil, nil, "")
+			inputFile, transferDir, cleanup := setupTransferDir(t, coord)
+			defer cleanup()
 			coord.InputCopy = &clients.InputCopy{
 				Probe: stubFFprobe{
 					FPS:  tt.fps,
@@ -500,9 +505,8 @@ func Test_ProbeErrors(t *testing.T) {
 					Size: tt.size,
 					Err:  tt.probeErr,
 				},
+				SourceOutputUrl: transferDir,
 			}
-			inputFile, _, cleanup := setupTransferDir(t, coord)
-			defer cleanup()
 
 			job := testJob
 			job.SourceFile = "file://" + inputFile.Name()


### PR DESCRIPTION
Direct uploads mean that studio has already copied the input file to object store so there's no need for us to copy to our transfer bucket which will save some moneys