### PR TITLE
Bump Mist input file size limit from 200Mb -> 500Mb

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,9 @@ const MaxSegmentSizeSecs = 20
 // the future.
 const MAX_JOBS_IN_FLIGHT = 8
 
+// How big an input file has to be before we avoid routing it to Mist (because of known issues handling large files)
+const MAX_MIST_INPUT_SIZE_BYTES = 1024 * 1024 * 500
+
 // The maximum allowed input file size
 const MaxInputFileSizeBytes = 30 * 1024 * 1024 * 1024 // 30 GiB
 

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -287,8 +287,8 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 // checkMistCompatible checks if the input codecs are compatible with mist and overrides the pipeline strategy
 // to external if they are incompatible
 func checkMistCompatible(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
-	// Mist currently struggles with large files, so we don't send it any files bigger than 200Mb
-	if iv.SizeBytes > 1024*1024*200 {
+	// Mist currently struggles with large files, so we don't send it any files bigger than MAX_MIST_INPUT_SIZE_BYTES
+	if iv.SizeBytes > config.MAX_MIST_INPUT_SIZE_BYTES {
 		return mistNotSupported(strategy)
 	}
 

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -741,7 +741,7 @@ func Test_checkMistCompatible(t *testing.T) {
 				Type:  video.TrackTypeAudio,
 			},
 		},
-		SizeBytes: 210763776, // 201 Megabytes
+		SizeBytes: 525336576, // 201 Megabytes
 	}
 	tests := []struct {
 		name          string


### PR DESCRIPTION
We've been seeing a much improved Mist error rate with the latest changes, so going to gradually increase this limit again