### PR TITLE
Bump limit for files we send to Mist from 500Mb to 1Gb

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ const MaxSegmentSizeSecs = 20
 const MAX_JOBS_IN_FLIGHT = 8
 
 // How big an input file has to be before we avoid routing it to Mist (because of known issues handling large files)
-const MAX_MIST_INPUT_SIZE_BYTES = 1024 * 1024 * 500
+const MAX_MIST_INPUT_SIZE_BYTES = 1024 * 1024 * 1024
 
 // The maximum allowed input file size
 const MaxInputFileSizeBytes = 30 * 1024 * 1024 * 1024 // 30 GiB

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -741,7 +741,7 @@ func Test_checkMistCompatible(t *testing.T) {
 				Type:  video.TrackTypeAudio,
 			},
 		},
-		SizeBytes: 525336576, // 201 Megabytes
+		SizeBytes: 1074790400, // 1025 Megabytes
 	}
 	tests := []struct {
 		name          string


### PR DESCRIPTION
We haven't seen any issues with it handling the smaller files