### PR TITLE
Makefile: install golangci-lint and godog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ fmt:
 
 .PHONY: integration-test
 integration-test:
+	go install github.com/cucumber/godog/cmd/godog@v0.12.5
 	cd test && godog run --strict --stop-on-failure 2> ./logs/test.log
 
 .PHONY: lint
@@ -47,4 +48,4 @@ tidy:
 
 .PHONY: test-canary
 test-canary:
-	cd test && CUCUMBER_ENV=canary godog run --strict --stop-on-failure 2> ./logs/test.log
+	CUCUMBER_ENV=canary $(MAKE) integration-test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ integration-test:
 
 .PHONY: lint
 lint:
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 	golangci-lint run
 
 .PHONY: run


### PR DESCRIPTION
Needed for a working `make` on first run.