### PR TITLE
Fix MP4 range requests for access control playback

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -59,15 +59,16 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
 
 	// Playback endpoint
-	router.GET("/asset/hls/:playbackID/*file",
-		withLogging(
-			withCORS(
-				withGatingCheck(
-					handlers.PlaybackHandler(),
-				),
+	playback := withLogging(
+		withCORS(
+			withGatingCheck(
+				handlers.PlaybackHandler(),
 			),
 		),
 	)
+	router.GET("/asset/hls/:playbackID/*file", playback)
+	router.HEAD("/asset/hls/:playbackID/*file", playback)
+	router.OPTIONS("/asset/hls/:playbackID/*file", withLogging(handlers.PlaybackOptionsHandler()))
 
 	// Handling incoming playback redirection requests
 	redirectHandler := withLogging(withCORS(geoHandlers.RedirectHandler()))

--- a/api/http.go
+++ b/api/http.go
@@ -68,7 +68,7 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	)
 	router.GET("/asset/hls/:playbackID/*file", playback)
 	router.HEAD("/asset/hls/:playbackID/*file", playback)
-	router.OPTIONS("/asset/hls/:playbackID/*file", withLogging(handlers.PlaybackOptionsHandler()))
+	router.OPTIONS("/asset/hls/:playbackID/*file", withLogging(withCORS(handlers.PlaybackOptionsHandler())))
 
 	// Handling incoming playback redirection requests
 	redirectHandler := withLogging(withCORS(geoHandlers.RedirectHandler()))

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -45,7 +45,7 @@ func PlaybackHandler() httprouter.Handle {
 		w.Header().Set("etag", response.ETag)
 		w.WriteHeader(http.StatusOK)
 
-		if req.Method == "HEAD" {
+		if req.Method == http.MethodHead {
 			return
 		}
 		_, err = io.Copy(w, response.Body)
@@ -59,6 +59,7 @@ func PlaybackOptionsHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
 		w.Header().Set("allow", "GET, HEAD, OPTIONS")
 		w.Header().Set("content-length", "0")
+		w.Header().Set("accept-ranges", "bytes")
 		w.WriteHeader(http.StatusOK)
 	}
 }

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 
@@ -36,11 +37,29 @@ func PlaybackHandler() httprouter.Handle {
 		}
 		defer response.Body.Close()
 
+		w.Header().Set("accept-ranges", "bytes")
 		w.Header().Set("content-type", response.ContentType)
+		if response.ContentLength != nil {
+			w.Header().Set("content-length", fmt.Sprintf("%d", *response.ContentLength))
+		}
+		w.Header().Set("etag", response.ETag)
+		w.WriteHeader(http.StatusOK)
+
+		if req.Method == "HEAD" {
+			return
+		}
 		_, err = io.Copy(w, response.Body)
 		if err != nil {
 			log.LogError(requestID, "failed to write response", err)
 		}
+	}
+}
+
+func PlaybackOptionsHandler() httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, params httprouter.Params) {
+		w.Header().Set("allow", "GET, HEAD, OPTIONS")
+		w.Header().Set("content-length", "0")
+		w.WriteHeader(http.StatusOK)
 	}
 }
 

--- a/playback/playback.go
+++ b/playback/playback.go
@@ -27,8 +27,10 @@ type Request struct {
 }
 
 type Response struct {
-	Body        io.ReadCloser
-	ContentType string
+	Body          io.ReadCloser
+	ContentType   string
+	ContentLength *int64
+	ETag          string
 }
 
 func Handle(req Request) (*Response, error) {
@@ -39,8 +41,10 @@ func Handle(req Request) (*Response, error) {
 
 	if !IsManifest(req.File) {
 		return &Response{
-			Body:        f.Body,
-			ContentType: f.ContentType,
+			Body:          f.Body,
+			ContentType:   f.ContentType,
+			ContentLength: f.Size,
+			ETag:          f.ETag,
 		}, nil
 	}
 	// don't close the body for non-manifest files where we return above as we simply proxying the body back

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -77,7 +77,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^Studio API server is running at "([^"]*)"$`, stepContext.StartStudioAPI)
 	ctx.Step(`^Mist is running at "([^"]*)"$`, stepContext.StartMist)
 
-	ctx.Step(`^I query the "([^"]*)" endpoint$`, stepContext.CreateGetRequest)
+	ctx.Step(`^I query the "([^"]*)" endpoint( with "([^"]*)")?$`, stepContext.CreateRequest)
 	ctx.Step(`^I query the internal "([^"]*)" endpoint$`, stepContext.CreateGetRequestInternal)
 	ctx.Step(`^I submit to the "([^"]*)" endpoint with "([^"]*)"$`, stepContext.CreatePostRequest)
 	ctx.Step(`^I submit to the internal "([^"]*)" endpoint with "([^"]*)"$`, stepContext.CreatePostRequestInternal)
@@ -89,6 +89,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the body matches file "([^"]*)"$`, stepContext.CheckHTTPResponseBodyFromFile)
 	ctx.Step(`^the gate API will (allow|deny) playback$`, stepContext.SetGateAPIResponse)
 	ctx.Step(`^the gate API will be called (\d+) times$`, stepContext.CheckGateAPICallCount)
+	ctx.Step(`^the headers match$`, stepContext.CheckHTTPHeaders)
 
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
 		if app != nil && app.Process != nil {

--- a/test/features/playback.feature
+++ b/test/features/playback.feature
@@ -43,3 +43,13 @@ Feature: Playback
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And the gate API will be called 1 times
+
+  Scenario: HEAD requests
+    Given the gate API will allow playback
+    When I query the "/asset/hls/dbe3q3g6q2kia036/index.m3u8?accessKey=secretlpkey" endpoint with "HEAD"
+    And receive a response within "3" seconds
+    Then I get an HTTP response with code "200"
+    And the headers match
+      | key                         | value |
+      | accept-ranges               | bytes |
+      | Access-Control-Allow-Origin | *     |


### PR DESCRIPTION
Seeking in the player was broken because we weren't signaling that we support range requests. I have added an http HEAD handler for this and implemented a custom OPTIONS handler.