### PR TITLE
Add external_id to VOD upload request

### DIFF
--- a/handlers/schemas/UploadVOD.yaml
+++ b/handlers/schemas/UploadVOD.yaml
@@ -1,5 +1,7 @@
 type: "object"
 properties:
+  external_id:
+    type: "string"
   url:
     type: "string"
     format: "uri"

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -35,6 +35,7 @@ type UploadVODRequestOutputLocation struct {
 }
 
 type UploadVODRequest struct {
+	ExternalID      string                           `json:"external_id,omitempty"`
 	Url             string                           `json:"url"`
 	CallbackUrl     string                           `json:"callback_url"`
 	OutputLocations []UploadVODRequestOutputLocation `json:"output_locations,omitempty"`
@@ -127,7 +128,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 
 	// Generate a Request ID that will be used throughout all logging
 	var requestID = config.RandomTrailer(8)
-	log.AddContext(requestID, "source", uploadVODRequest.Url)
+	log.AddContext(requestID, "source", uploadVODRequest.Url, "external_id", uploadVODRequest.ExternalID)
 
 	if err := CheckSourceURLValid(uploadVODRequest.Url); err != nil {
 		return false, errors.WriteHTTPBadRequest(w, "Invalid request payload", err)
@@ -176,6 +177,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 		AccessToken:           uploadVODRequest.AccessToken,
 		TranscodeAPIUrl:       uploadVODRequest.TranscodeAPIUrl,
 		RequestID:             requestID,
+		ExternalID:            uploadVODRequest.ExternalID,
 		Profiles:              uploadVODRequest.Profiles,
 		PipelineStrategy:      uploadVODRequest.PipelineStrategy,
 		TargetSegmentSizeSecs: uploadVODRequest.TargetSegmentSizeSecs,

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -68,6 +68,7 @@ type UploadJobPayload struct {
 	TranscodeAPIUrl       string
 	HardcodedBroadcasters string
 	RequestID             string
+	ExternalID            string
 	Profiles              []video.EncodedProfile
 	PipelineStrategy      Strategy
 	TargetSegmentSizeSecs int64
@@ -533,6 +534,7 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo, out *HandlerOutput) {
                             "finished_at",
                             "started_at",
                             "request_id",
+                            "external_id",
                             "source_codec_video",
                             "source_codec_audio",
                             "pipeline",
@@ -547,12 +549,13 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo, out *HandlerOutput) {
                             "source_url",
                             "target_url",
                             "in_fallback_mode"
-                            ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`
+                            ) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`
 	_, err := c.MetricsDB.Exec(
 		insertDynStmt,
 		time.Now().Unix(),
 		job.startTime.Unix(),
 		job.RequestID,
+		job.ExternalID,
 		job.sourceCodecVideo,
 		job.sourceCodecAudio,
 		job.pipeline,

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -411,7 +411,7 @@ func TestPipelineCollectedMetrics(t *testing.T) {
 
 	dbMock.
 		ExpectExec("insert into \"vod_completed\".*").
-		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
+		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	coord.StartUploadJob(job)


### PR DESCRIPTION
I already added the `external_id` column to both staging (canary) and prod metrics DBs.

Related Linear issue: https://linear.app/livepeer/issue/VID-103/allow-passthrough-of-external-id-to-metrics-database

FYI: @ecmulli 