### PR TITLE
recordings v2: use hls input sources for mediaconvert pipeline

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -90,14 +90,14 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile *url.URL) (inputVi
 		err = fmt.Errorf("input file %d bytes was greater than %d bytes", inputVideoProbe.SizeBytes, config.MaxInputFileSizeBytes)
 		return
 	}
-	log.Log(requestID, "probed video track:", "codec", videoTrack.Codec, "bitrate", videoTrack.Bitrate, "duration", videoTrack.DurationSec, "w", videoTrack.Width, "h", videoTrack.Height, "pix-format", videoTrack.PixelFormat, "FPS", videoTrack.FPS)
+	log.Log(requestID, "probed video track:", "container", inputVideoProbe.Format, "codec", videoTrack.Codec, "bitrate", videoTrack.Bitrate, "duration", videoTrack.DurationSec, "w", videoTrack.Width, "h", videoTrack.Height, "pix-format", videoTrack.PixelFormat, "FPS", videoTrack.FPS)
 	log.Log(requestID, "probed audio track", "codec", audioTrack.Codec, "bitrate", audioTrack.Bitrate, "duration", audioTrack.DurationSec, "channels", audioTrack.Channels)
 	return
 }
 
 func isDirectUpload(inputFile *url.URL) bool {
+	// recordings via backup-recording path is also considered a "direct-upload"
 	return strings.HasSuffix(inputFile.Host, "storage.googleapis.com") &&
-		strings.HasPrefix(inputFile.Path, "/directUpload") &&
 		(inputFile.Scheme == "https" || inputFile.Scheme == "http")
 }
 

--- a/clients/input_copy_test.go
+++ b/clients/input_copy_test.go
@@ -14,9 +14,19 @@ func Test_isDirectUpload(t *testing.T) {
 		want      bool
 	}{
 		{
-			name:      "direct upload",
+			name:      "direct upload w/ directUpload in path",
 			inputFile: "https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4",
 			want:      true,
+		},
+		{
+			name:      "direct upload w/o directUpload in path",
+			inputFile: "https://lp-us-vod-com.storage.googleapis.com/2697c12g97x2sxn4",
+			want:      true,
+		},
+		{
+			name:      "not direct upload w/ directUpload in path",
+			inputFile: "https://lp-us-vod-com.storage.HELLO.com/2697c12g97x2sxn4",
+			want:      false,
 		},
 		{
 			name:      "not direct upload",

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -241,7 +241,7 @@ func (mc *MediaConvert) coreAwsTranscode(ctx context.Context, args TranscodeJobA
 	payload := createJobPayload(args.InputFile.String(), toStr(args.HLSOutputLocation), mp4OutputLocation, mc.role, accelerated, args.Profiles, args.SegmentSizeSecs)
 	job, err := mc.client.CreateJob(payload)
 	if err != nil {
-		return fmt.Errorf("error creting mediaconvert job: %w", err)
+		return fmt.Errorf("error creating mediaconvert job: %w", err)
 	}
 	jobID := job.Job.Id
 	log.AddContext(args.RequestID, "mediaconvert_job_id", aws.StringValue(jobID))

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -76,6 +76,7 @@ func TestProbe(t *testing.T) {
 	require.NoError(err)
 
 	expectedInput := InputVideo{
+		Format:   "mov,mp4,m4a,3gp,3g2,mj2",
 		Duration: 16.254,
 		Tracks: []InputTrack{
 			{


### PR DESCRIPTION
    Add support for HLS (m3u8) input files in mediaconvert VOD pipline

    * HLS input files will be used for backup-recordings - a VOD workflow
      will be kicked off with these source input m3u8s which will result in
    transcoded renditions of recordings.
    * Recordings will be considered as directUploads from a public GCS
      bucket
    * Probe functions were updated to handle HLS files where bitrate/fps may
      not get reported correctly.