### PR TITLE
Update to latest ffprobe library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	go.opencensus.io v0.24.0
 	golang.org/x/sync v0.1.0
 	golang.org/x/text v0.9.0
-	gopkg.in/vansante/go-ffprobe.v2 v2.1.1
+	gopkg.in/vansante/go-ffprobe.v2 v2.1.2-0.20230412093356-81f7fcbea828
 	sigs.k8s.io/yaml v1.3.0
 )
 
@@ -173,5 +173,3 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace gopkg.in/vansante/go-ffprobe.v2 => github.com/mjh1/go-ffprobe v0.0.0-20230402193815-b6c2609ab5da

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,6 @@ github.com/mitchellh/gox v0.4.0/go.mod h1:Sd9lOJ0+aimLBi73mGofS1ycjY8lL3uZM3JPS4
 github.com/mitchellh/iochan v1.0.0/go.mod h1:JwYml1nuB7xOzsp52dPpHFffvOCDupsG0QubkSMEySY=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
-github.com/mjh1/go-ffprobe v0.0.0-20230402193815-b6c2609ab5da h1:5iB+hAHnQfJV5I25duS9MKeI72n6Rkc6uVS80EU5VYQ=
-github.com/mjh1/go-ffprobe v0.0.0-20230402193815-b6c2609ab5da/go.mod h1:qF0AlAjk7Nqzqf3y333Ly+KxN3cKF2JqA3JT5ZheUGE=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1342,6 +1340,8 @@ gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/vansante/go-ffprobe.v2 v2.1.2-0.20230412093356-81f7fcbea828 h1:Lgy8+/c69rrihi4+GQBRs5dWgUczh4wzmwZDLtbPgPo=
+gopkg.in/vansante/go-ffprobe.v2 v2.1.2-0.20230412093356-81f7fcbea828/go.mod h1:qF0AlAjk7Nqzqf3y333Ly+KxN3cKF2JqA3JT5ZheUGE=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/video/probe.go
+++ b/video/probe.go
@@ -82,12 +82,12 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 		return InputVideo{}, fmt.Errorf("error parsing fps numerator from probed data: %w", err)
 	}
 
-	var rotation float64
-	for _, sideData := range videoStream.SideDataList {
-		r := getSideData[float64](sideData, "rotation")
-		if r != nil {
-			rotation = *r
-			break
+	var rotation int64
+	displaySideData, err := videoStream.SideDataList.GetSideData("Display Matrix")
+	if err == nil {
+		r, err := displaySideData.GetInt("rotation")
+		if err == nil {
+			rotation = r
 		}
 	}
 
@@ -167,13 +167,4 @@ func parseFps(framerate string) (float64, error) {
 	}
 
 	return float64(num) / float64(den), nil
-}
-
-func getSideData[T any](sideData ffprobe.SideData, key string) *T {
-	if value, ok := sideData[key]; ok {
-		if res, ok := value.(T); ok {
-			return &res
-		}
-	}
-	return nil
 }

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -108,19 +108,5 @@ func TestProbe_VideoRotation(t *testing.T) {
 	require.NoError(t, err)
 	track, err := iv.GetTrack("video")
 	require.NoError(t, err)
-	require.Equal(t, float64(-180), track.Rotation)
-}
-
-func Test_getSideData(t *testing.T) {
-	sideData := make(map[string]interface{})
-	sideData["rotation"] = float64(180)
-	found := getSideData[float64](sideData, "rotation")
-	require.NotNil(t, found)
-	require.Equal(t, float64(180), *found)
-
-	wrongType := getSideData[int](sideData, "rotation")
-	require.Nil(t, wrongType)
-
-	keyNotFound := getSideData[float64](sideData, "foo")
-	require.Nil(t, keyNotFound)
+	require.Equal(t, int64(-180), track.Rotation)
 }

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -41,7 +41,7 @@ type VideoTrack struct {
 	Height      int64   `json:"height,omitempty"`
 	PixelFormat string  `json:"pixel_format,omitempty"`
 	FPS         float64 `json:"fps,omitempty"`
-	Rotation    float64 `json:"rotation,omitempty"`
+	Rotation    int64   `json:"rotation,omitempty"`
 }
 
 type AudioTrack struct {


### PR DESCRIPTION
My go-ffprobe PR has been merged upstream now so updating to the latest here. I included a built in helper for the library so I've removed the one here now.