### PR TITLE
Add request metrics for playback requests

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -12,6 +12,7 @@ import (
 	"github.com/livepeer/catalyst-api/handlers"
 	"github.com/livepeer/catalyst-api/handlers/geolocation"
 	"github.com/livepeer/catalyst-api/log"
+	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/livepeer/catalyst-api/middleware"
 	"github.com/livepeer/catalyst-api/pipeline"
 )
@@ -59,7 +60,7 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
 
 	// Playback endpoint
-	playback := withLogging(
+	playback := middleware.LogAndMetrics(metrics.Metrics.PlaybackRequestDurationSec)(
 		withCORS(
 			withGatingCheck(
 				handlers.PlaybackHandler(),

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -26,6 +26,7 @@ type CatalystAPIMetrics struct {
 	UploadVODRequestCount       prometheus.Counter
 	UploadVODRequestDurationSec *prometheus.SummaryVec
 	TranscodeSegmentDurationSec prometheus.Histogram
+	PlaybackRequestDurationSec  *prometheus.SummaryVec
 
 	TranscodingStatusUpdate ClientMetrics
 	BroadcasterClient       ClientMetrics
@@ -59,6 +60,10 @@ func NewMetrics() *CatalystAPIMetrics {
 			Help:    "Time taken to transcode a segment",
 			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 		}),
+		PlaybackRequestDurationSec: promauto.NewSummaryVec(prometheus.SummaryOpts{
+			Name: "catalyst_playback_request_duration_seconds",
+			Help: "The latency of the requests made to /asset/hls in seconds broken up by success and status code",
+		}, []string{"success", "status_code", "version"}),
 
 		// Clients metrics
 

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -1,13 +1,17 @@
 package middleware
 
 import (
+	"fmt"
 	"net/http"
 	"runtime/debug"
+	"strconv"
 	"time"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 type responseWriter struct {
@@ -30,7 +34,15 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.wroteHeader = true
 }
 
+func LogAndMetrics(metric *prometheus.SummaryVec) func(httprouter.Handle) httprouter.Handle {
+	return logRequest(metric)
+}
+
 func LogRequest() func(httprouter.Handle) httprouter.Handle {
+	return logRequest(nil)
+}
+
+func logRequest(metric *prometheus.SummaryVec) func(httprouter.Handle) httprouter.Handle {
 	return func(next httprouter.Handle) httprouter.Handle {
 		fn := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			start := time.Now()
@@ -44,14 +56,22 @@ func LogRequest() func(httprouter.Handle) httprouter.Handle {
 			}()
 
 			next(wrapped, r, ps)
+			duration := time.Since(start)
 			log.LogNoRequestID("received HTTP request",
 				"remote", r.RemoteAddr,
 				"proto", r.Proto,
 				"method", r.Method,
 				"uri", r.URL.RequestURI(),
-				"duration", time.Since(start),
+				"duration", duration,
 				"status", wrapped.status,
 			)
+
+			if metric != nil {
+				success := wrapped.status < 400
+				metric.
+					WithLabelValues(strconv.FormatBool(success), fmt.Sprint(wrapped.status), config.Version).
+					Observe(duration.Seconds())
+			}
 		}
 
 		return fn

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -89,7 +89,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^we wait for 5 seconds$`, stepContext.Wait)
 	ctx.Step(`^I get an HTTP response with code "([^"]*)"$`, stepContext.CheckHTTPResponseCode)
 	ctx.Step(`^I get an HTTP response with code "([^"]*)" and the following body "([^"]*)"$`, stepContext.CheckHTTPResponseCodeAndBody)
-	ctx.Step(`^my "((failed)|(successful))" request metrics get recorded$`, stepContext.CheckRecordedMetrics)
+	ctx.Step(`^my "(failed|successful)" (vod|playback) request metrics get recorded$`, stepContext.CheckRecordedMetrics)
 	ctx.Step(`^Mist receives a request for segmenting with "([^"]*)" second segments$`, stepContext.CheckMist)
 	ctx.Step(`^the body matches file "([^"]*)"$`, stepContext.CheckHTTPResponseBodyFromFile)
 	ctx.Step(`^the gate API will (allow|deny) playback$`, stepContext.SetGateAPIResponse)

--- a/test/features/playback.feature
+++ b/test/features/playback.feature
@@ -10,6 +10,7 @@ Feature: Playback
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And the body matches file "responses/hls/dbe3q3g6q2kia036/index.m3u8"
+    And my "successful" playback request metrics get recorded
 
   Scenario: Rendition playlist requests
     Given the gate API will allow playback
@@ -17,6 +18,7 @@ Feature: Playback
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And the body matches file "responses/hls/dbe3q3g6q2kia036/720p0/index.m3u8"
+    And my "successful" playback request metrics get recorded
 
   Scenario: Gate API deny
     Given the gate API will deny playback
@@ -28,6 +30,7 @@ Feature: Playback
     And receive a response within "3" seconds
     Then I get an HTTP response with code "401"
     And the body matches file "responses/unauthorised"
+    And my "failed" playback request metrics get recorded
 
   Scenario: No token param
     Given the gate API will allow playback

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -20,20 +20,20 @@ Feature: VOD Streaming
     When I submit to the internal "/api/vod" endpoint with "a valid upload vod request"
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
-    And my "successful" request metrics get recorded
+    And my "successful" vod request metrics get recorded
     And Mist receives a request for segmenting with "10" second segments
 
   Scenario: Submit a bad request to `/api/vod`
     And I submit to the internal "/api/vod" endpoint with "an invalid upload vod request"
     And receive a response within "3" seconds
     Then I get an HTTP response with code "400"
-    And my "failed" request metrics get recorded
+    And my "failed" vod request metrics get recorded
 
 Scenario: Submit a video asset to stream as VOD with a custom segment size
     When I submit to the internal "/api/vod" endpoint with "a valid upload vod request with a custom segment size"
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
-    And my "successful" request metrics get recorded
+    And my "successful" vod request metrics get recorded
     And Mist receives a request for segmenting with "3" second segments
 
 Scenario: Submit a video asset to stream as VOD with the FFMPEG / Livepeer pipeline
@@ -41,7 +41,7 @@ Scenario: Submit a video asset to stream as VOD with the FFMPEG / Livepeer pipel
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And I receive a Request ID in the response body
-    And my "successful" request metrics get recorded
+    And my "successful" vod request metrics get recorded
     And "4" source segments are written to storage within "5" seconds
     And the source manifest is written to storage within "3" seconds and contains "4" segments
     # TODO: Check for callbacks being received

--- a/test/steps/http.go
+++ b/test/steps/http.go
@@ -236,7 +236,7 @@ func (s *StepContext) CheckGateAPICallCount(expectedCount int) error {
 	return nil
 }
 
-func (s *StepContext) CheckRecordedMetrics(metricsType string) error {
+func (s *StepContext) CheckRecordedMetrics(metricsType, requestType string) error {
 	var url = s.BaseInternalURL + "/metrics"
 
 	res, err := http.Get(url)
@@ -249,23 +249,30 @@ func (s *StepContext) CheckRecordedMetrics(metricsType string) error {
 		return err
 	}
 
-	if metricsType == "failure" {
-		r := regexp.MustCompile(`\nupload_vod_request_duration_seconds_count{status_code="500",success="false",version="cucumber-test-version"} 1\n`)
+	metric := "upload_vod_request_duration_seconds_count"
+	if requestType == "playback" {
+		metric = "catalyst_playback_request_duration_seconds_count"
+	}
+
+	if metricsType == "failed" {
+		r := regexp.MustCompile(fmt.Sprintf(`\n%s{status_code="\d+",success="false",version="cucumber-test-version"} .+\n`, metric))
 		if !r.Match(body) {
-			return fmt.Errorf("not a valid failure upload_vod_request_duration_seconds_count")
+			return fmt.Errorf("not a valid failure %s: %q", metric, body)
 		}
 	}
 
 	if metricsType == "successful" {
-		r := regexp.MustCompile(`\nupload_vod_request_duration_seconds_count{status_code="200",success="true",version="cucumber-test-version"} 1\n`)
+		r := regexp.MustCompile(fmt.Sprintf(`\n%s{status_code="200",success="true",version="cucumber-test-version"} .+\n`, metric))
 		if !r.Match(body) {
-			return fmt.Errorf("not a valid success upload_vod_request_duration_seconds: %q", body)
+			return fmt.Errorf("not a valid success %s: %q", metric, body)
 		}
 	}
 
-	r := regexp.MustCompile(`\nupload_vod_request_count 1\n`)
-	if !r.Match(body) {
-		return fmt.Errorf("not a valid upload_vod_request_count metric")
+	if requestType == "vod" {
+		r := regexp.MustCompile(`\nupload_vod_request_count 1\n`)
+		if !r.Match(body) {
+			return fmt.Errorf("not a valid upload_vod_request_count metric")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
So we can monitor access control usage and the quality of the service (error rates and response times).