### PR TITLE
Switch 'fallback' strategy to FFMPEG->External

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -110,7 +110,7 @@ func TestVODHandlerProfiles(t *testing.T) {
 	// Set up out own callback client so that we can ensure it just fires once
 	statusClient := clients.NewPeriodicCallbackClient(100*time.Minute, map[string]string{})
 	// Workflow engine
-	vodEngine := pipeline.NewStubCoordinatorOpts("", statusClient, nil, nil, outputDirUrl)
+	vodEngine := pipeline.NewStubCoordinatorOpts("", statusClient, nil, nil, nil, outputDirUrl)
 	vodEngine.InputCopy = &clients.StubInputCopy{}
 	internalState := vodEngine.Jobs.UnittestIntrospection()
 

--- a/middleware/capacity_test.go
+++ b/middleware/capacity_test.go
@@ -41,7 +41,7 @@ func TestItErrorsWhenNoCapacityAvailable(t *testing.T) {
 
 	pipeMist, release := pipeline.NewBlockingStubHandler()
 	defer release()
-	coordinator := pipeline.NewStubCoordinatorOpts(pipeline.StrategyCatalystDominance, nil, pipeMist, nil, "")
+	coordinator := pipeline.NewStubCoordinatorOpts(pipeline.StrategyCatalystDominance, nil, pipeMist, nil, nil, "")
 	coordinator.InputCopy = &clients.StubInputCopy{}
 
 	// Create a lot of in-flight jobs


### PR DESCRIPTION
Once we get this onto Staging, it will mean the FFMPEG become the default first pipeline and we can begin testing in earnest.

Still TODO in future PRs: 
- Check if there are any pipeline-specific metrics we want to add
- Check for callbacks in integration tests