### PR TITLE
Record the correct pipeline name

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -360,8 +360,8 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 	log.AddContext(p.RequestID, "stream_name", streamName)
 	log.AddContext(p.RequestID, "handler", handler.Name())
 
-	var pipeline = "mist"
-	if handler.Name() == "external" {
+	var pipeline = handler.Name()
+	if pipeline == "external" {
 		pipeline = "aws-mediaconvert"
 	}
 


### PR DESCRIPTION
The new pipeline was getting grouped under "mist" in metrics because of this