### PR TITLE
Fix range requests on safari

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.7
 	github.com/livepeer/go-api-client v0.4.6
-	github.com/livepeer/go-tools v0.2.11
+	github.com/livepeer/go-tools v0.2.12
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.6.4
 	github.com/livepeer/m3u8 v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/go-api-client v0.4.6 h1:Eo9mq5k9gnu8fgclbT7ibQdTgBV7a/NDIBIuYXHMzV0=
 github.com/livepeer/go-api-client v0.4.6/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-tools v0.2.11 h1:LEW08kXsjswIn3YtZiCZydI2sZ3WI5FtleoD8pBwVSE=
-github.com/livepeer/go-tools v0.2.11/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
+github.com/livepeer/go-tools v0.2.12 h1:JsonAT9UXGLnwlBG97Nfd+/SC0E/FOfKFs++ud+eCrc=
+github.com/livepeer/go-tools v0.2.12/go.mod h1:/aZ+20XYLdeebFA3CrQTkHUf7DmiGBzh6Bs8JkbelUA=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
 github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.6.4 h1:OFmIyKvnYqtXKKFnSORxB+tDPotLHEwRS6SXOEplugo=

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -411,7 +411,7 @@ func TestPipelineCollectedMetrics(t *testing.T) {
 
 	dbMock.
 		ExpectExec("insert into \"vod_completed\".*").
-		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
+		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "stub", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	coord.StartUploadJob(job)

--- a/playback/playback.go
+++ b/playback/playback.go
@@ -31,6 +31,7 @@ type Response struct {
 	ContentType   string
 	ContentLength *int64
 	ETag          string
+	ContentRange  string
 }
 
 func Handle(req Request) (*Response, error) {
@@ -45,6 +46,7 @@ func Handle(req Request) (*Response, error) {
 			ContentType:   f.ContentType,
 			ContentLength: f.Size,
 			ETag:          f.ETag,
+			ContentRange:  f.ContentRange,
 		}, nil
 	}
 	// don't close the body for non-manifest files where we return above as we simply proxying the body back
@@ -83,9 +85,12 @@ func Handle(req Request) (*Response, error) {
 		}
 	}
 
+	playlistBuffer := p.Encode()
+	bufferSize := int64(playlistBuffer.Len())
 	return &Response{
-		Body:        io.NopCloser(p.Encode()),
-		ContentType: f.ContentType,
+		Body:          io.NopCloser(playlistBuffer),
+		ContentType:   f.ContentType,
+		ContentLength: &bufferSize,
 	}, nil
 }
 


### PR DESCRIPTION
In order for MP4 playback to work in safari it needs the content-range header to be returned.

I've tested this on chrome, safari, firefox and edge (macos). It's taking longer than hoped to write a cucumber test for this so I'm going to do a follow up PR.