### PR TITLE
Remove size limit from FFMPEG pipeline

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -35,9 +35,6 @@ const MaxSegmentSizeSecs = 20
 // the future.
 const MAX_JOBS_IN_FLIGHT = 8
 
-// How big an input file has to be before we avoid routing it to Mist (because of known issues handling large files)
-const MAX_MIST_INPUT_SIZE_BYTES = 1024 * 1024 * 1024
-
 // How long to try writing a single segment to storage for before giving up
 const SEGMENT_WRITE_TIMEOUT = 5 * time.Minute
 

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -36,7 +36,7 @@ type CatalystAPIMetrics struct {
 	VODPipelineMetrics VODPipelineMetrics
 }
 
-var vodLabels = []string{"source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "num_profiles", "stage", "version", "is_fallback_mode", "is_mist_supported"}
+var vodLabels = []string{"source_codec_video", "source_codec_audio", "pipeline", "catalyst_region", "num_profiles", "stage", "version", "is_fallback_mode", "is_livepeer_supported"}
 
 func NewMetrics() *CatalystAPIMetrics {
 	m := &CatalystAPIMetrics{

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -411,7 +411,7 @@ func TestPipelineCollectedMetrics(t *testing.T) {
 
 	dbMock.
 		ExpectExec("insert into \"vod_completed\".*").
-		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "mist", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
+		WithArgs(sqlmock.AnyArg(), 0, sqlmock.AnyArg(), sqlmock.AnyArg(), "vid codec", "audio codec", "stub", "test region", "completed", 1, sqlmock.AnyArg(), 2, 3, 4, 5, sourceFile, "s3+https://user:xxxxx@storage.google.com/bucket/key", false).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 
 	coord.StartUploadJob(job)

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -842,7 +842,7 @@ func Test_checkMistCompatible(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			supported, got := checkMistCompatible("requestID", tt.args.strategy, tt.args.iv)
+			supported, got := checkLivepeerCompatible("requestID", tt.args.strategy, tt.args.iv)
 			require.Equal(t, tt.want, got)
 			require.Equal(t, tt.wantSupported, supported)
 		})

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -730,19 +730,6 @@ func Test_checkMistCompatible(t *testing.T) {
 			},
 		},
 	}
-	largeVideo := video.InputVideo{
-		Tracks: []video.InputTrack{
-			{
-				Codec: "h264",
-				Type:  video.TrackTypeVideo,
-			},
-			{
-				Codec: "aac",
-				Type:  video.TrackTypeAudio,
-			},
-		},
-		SizeBytes: 1074790400, // 1025 Megabytes
-	}
 	tests := []struct {
 		name          string
 		args          args
@@ -826,15 +813,6 @@ func Test_checkMistCompatible(t *testing.T) {
 			args: args{
 				strategy: StrategyFallbackExternal,
 				iv:       videoRotation,
-			},
-			want:          StrategyExternalDominance,
-			wantSupported: false,
-		},
-		{
-			name: "incompatible with mist - large video",
-			args: args{
-				strategy: StrategyFallbackExternal,
-				iv:       largeVideo,
 			},
 			want:          StrategyExternalDominance,
 			wantSupported: false,


### PR DESCRIPTION
There's no reason the FFMPEG pipeline shouldn't be able to handle file sizes up to our maximum, so remove the limit and update logs etc. to refer to the Livepeer pipeline rather than Mist.