### PR TITLE
Fix segment counts reported

### DIFF
--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -114,7 +114,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		return nil, fmt.Errorf("error downloading source manifest: %s", err)
 	}
 
-	job.sourceSegments = len(sourceManifest.Segments)
+	job.sourceSegments = len(sourceManifest.GetAllSegments())
 
 	outputs, transcodedSegments, err := transcode.RunTranscodeProcess(transcodeRequest, job.StreamName, inputInfo)
 	if err != nil {

--- a/pipeline/mist.go
+++ b/pipeline/mist.go
@@ -184,7 +184,7 @@ func (m *mist) HandleRecordingEndTrigger(job *JobInfo, p RecordingEndPayload) (*
 		return nil, fmt.Errorf("error downloading source manifest: %s", err)
 	}
 
-	job.sourceSegments = len(sourceManifest.Segments)
+	job.sourceSegments = len(sourceManifest.GetAllSegments())
 
 	outputs, transcodedSegments, err := transcode.RunTranscodeProcess(transcodeRequest, p.StreamName, inputInfo)
 	if err != nil {


### PR DESCRIPTION
Fortunately this value wasn't used for anything affecting end users but we have been reporting incorrect source segment counts for a long time. The m3u8 library pre-allocates space in its segments slice so we were seeing values of `1024` for the vast majority of jobs. Using the `GetAllSegments()` helper function fixes this issue and gets you the true value.

Example from prod `vod_completed` table:
```
 request_id | source_segment_count | transcoded_segment_count
------------+----------------------+--------------------------
 gahabehh   |                 1024 |                        2
```