### PR TITLE
cluster: only submit alive nodes to be balanced

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -262,7 +262,7 @@ func (c *ClusterImpl) handleEvents(ctx context.Context) error {
 			return nil
 		}
 
-		members, err := c.MembersFiltered(mediaFilter, "", "")
+		members, err := c.MembersFiltered(mediaFilter, "alive", "")
 
 		if err != nil {
 			glog.Errorf("Error getting serf, crashing: %v\n", err)


### PR DESCRIPTION
When we go to look up a node's metadata, we only look up "alive" nodes, here: https://github.com/livepeer/catalyst-api/blob/b2393ccbadd19da6d2cc76e88b009f35baab59e3/cluster/cluster.go#L217

Unfortunately, until this change, we didn't filter out only "alive" nodes when we were submitting them to be balanced by MistUtilLoad. This meant that broken nodes were sometimes submitted as load balancing targets. Often this didn't matter, as MistUtilLoad wouldn't be able to ping dead nodes, but over the weekend we had a situation where MistController was running successfully but catalyst-api wasn't. This led to a situation where MistUtilLoad attempted to balance to a node that was broken in the Serf cluster, which led to a 500 error attempting to retrieve that node's metadata.