### PR TITLE
Don't fall over when subtitles track is present

### DIFF
--- a/video/segment.go
+++ b/video/segment.go
@@ -6,7 +6,7 @@ import (
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
-func Segment(requestID string, sourceURL string, outputManifestURL string, targetSegmentSize int64) error {
+func Segment(sourceURL string, outputManifestURL string, targetSegmentSize int64) error {
 	err := ffmpeg.Input(sourceURL).
 		Output(
 			outputManifestURL,

--- a/video/segment.go
+++ b/video/segment.go
@@ -6,12 +6,13 @@ import (
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
-func Segment(sourceURL string, outputManifestURL string, targetSegmentSize int64) error {
+func Segment(requestID string, sourceURL string, outputManifestURL string, targetSegmentSize int64) error {
 	err := ffmpeg.Input(sourceURL).
 		Output(
 			outputManifestURL,
 			ffmpeg.KwArgs{
-				"c":                 "copy",
+				"c:a":               "copy",
+				"c:v":               "copy",
 				"f":                 "hls",
 				"hls_segment_type":  "mpegts",
 				"hls_playlist_type": "vod",


### PR DESCRIPTION
Doing the `copy` without specifying streams gives: 

```[webvtt @ 0x13b607360] Exactly one WebVTT stream is needed.
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Error initializing output stream 0:2 -- 
```
for the following file:
```
Input #0, mov,mp4,m4a,3gp,3g2,mj2, from '1681744560323.mp4':
  Metadata:
    major_brand     : isom
    minor_version   : 512
    compatible_brands: isomiso2avc1mp41
    encoder         : Lavf58.76.100
  Duration: 02:20:36.76, start: 0.000000, bitrate: 456 kb/s
  Stream #0:0[0x1](und): Video: h264 (High) (avc1 / 0x31637661), yuv420p(progressive), 1280x720, 322 kb/s, 25 fps, 25 tbr, 12800 tbn (default)
    Metadata:
      handler_name    : VideoHandler
      vendor_id       : [0][0][0][0]
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, stereo, fltp, 128 kb/s (default)
    Metadata:
      handler_name    : SoundHandler
      vendor_id       : [0][0][0][0]
  Stream #0:2[0x3](eng): Subtitle: mov_text (tx3g / 0x67337874), 0 kb/s (default)
    Metadata:
      handler_name    : SubtitleHandler

```