### PR TITLE
Remove fb_ prefix from Request ID when falling back

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -333,9 +333,6 @@ func (c *Coordinator) startOneUploadJob(p UploadJobPayload, handler Handler, for
 		// this will prevent the callbacks for this job from actually being sent
 		p.CallbackURL = ""
 	}
-	if p.InFallbackMode {
-		p.RequestID = fmt.Sprintf("fb_%s", p.RequestID)
-	}
 	streamName := config.SegmentingStreamName(p.RequestID)
 	log.AddContext(p.RequestID, "stream_name", streamName)
 	log.AddContext(p.RequestID, "handler", handler.Name())

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -275,22 +275,22 @@ func TestCoordinatorFallbackStrategyFailure(t *testing.T) {
 
 	// External provider pipeline will trigger the initial preparing trigger as well
 	msg = requireReceive(t, callbacks, 1*time.Second)
-	require.Equal("fb_123", msg.RequestID)
+	require.Equal("123", msg.RequestID)
 	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 
 	meconJob := requireReceive(t, externalCalls, 1*time.Second)
-	require.Equal("fb_123", meconJob.RequestID)
-	require.Equal(config.SEGMENTING_PREFIX+"fb_123", meconJob.StreamName)
+	require.Equal("123", meconJob.RequestID)
+	require.Equal(config.SEGMENTING_PREFIX+"123", meconJob.StreamName)
 
 	// Check that the progress reported in the fallback handler is still reported
 	msg = requireReceive(t, callbacks, 1*time.Second)
 	require.NotZero(msg.URL)
-	require.Equal("fb_123", msg.RequestID)
+	require.Equal("123", msg.RequestID)
 	require.Equal(clients.TranscodeStatusPreparing, msg.Status)
 	require.Equal(clients.OverallCompletionRatio(clients.TranscodeStatusPreparing, 0.2), msg.CompletionRatio)
 
 	msg = requireReceive(t, callbacks, 1*time.Second)
-	require.Equal("fb_123", msg.RequestID)
+	require.Equal("123", msg.RequestID)
 	require.Equal(clients.TranscodeStatusCompleted, msg.Status)
 
 	time.Sleep(1 * time.Second)

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -55,7 +55,6 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 
 	// Transcode Beginning
 	log.Log(job.RequestID, "Beginning transcoding via FFMPEG/Livepeer pipeline")
-	job.ReportProgress(clients.TranscodeStatusTranscoding, 0.1)
 
 	transcodeRequest := transcode.TranscodeSegmentRequest{
 		SourceFile:        job.SourceFile,


### PR DESCRIPTION
This was causing issues when the foreground pipeline failed but we continued trying to send callbacks