### PR TITLE
Fix callback stale check

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -15,8 +15,6 @@ import (
 	"github.com/livepeer/catalyst-api/metrics"
 )
 
-const MaxTimeWithoutUpdate = 30 * time.Minute
-
 // The default client is only used for the recording event. This is to avoid
 // misusing the singleton client to send transcode status updates, which should
 // be sent through the JobInfo.ReportStatus function instead.
@@ -61,7 +59,7 @@ func NewPeriodicCallbackClient(callbackInterval time.Duration, headers map[strin
 		requestIDToLatestMessage: map[string]TranscodeStatusMessage{},
 		mapLock:                  sync.RWMutex{},
 		headers:                  headers,
-		staleTimeout:             MaxTimeWithoutUpdate,
+		staleTimeout:             MaxCopyFileDuration,
 	}
 }
 

--- a/clients/callback_client_status.go
+++ b/clients/callback_client_status.go
@@ -3,6 +3,7 @@ package clients
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/video"
@@ -77,7 +78,7 @@ type TranscodeStatusMessage struct {
 	RequestID       string          `json:"request_id"`
 	CompletionRatio float64         `json:"completion_ratio"` // No omitempty or we lose this for 0% completion case
 	Status          TranscodeStatus `json:"status"`
-	Timestamp       int64           `json:"timestamp"`
+	Timestamp       time.Time       `json:"timestamp"`
 
 	// Only used for the "Error" status message
 	Error       string `json:"error,omitempty"`
@@ -96,7 +97,7 @@ func NewTranscodeStatusProgress(url, requestID string, status TranscodeStatus, c
 		RequestID:       requestID,
 		CompletionRatio: OverallCompletionRatio(status, currentStageCompletionRatio),
 		Status:          status,
-		Timestamp:       config.Clock.GetTimestampUTC(),
+		Timestamp:       config.Clock.GetTime(),
 	}
 }
 
@@ -107,7 +108,7 @@ func NewTranscodeStatusError(url, requestID, errorMsg string, unretriable bool) 
 		Error:       errorMsg,
 		Unretriable: unretriable,
 		Status:      TranscodeStatusError,
-		Timestamp:   config.Clock.GetTimestampUTC(),
+		Timestamp:   config.Clock.GetTime(),
 	}
 }
 
@@ -118,7 +119,7 @@ func NewTranscodeStatusCompleted(url, requestID string, iv video.InputVideo, ov 
 		CompletionRatio: OverallCompletionRatio(TranscodeStatusCompleted, 1),
 		RequestID:       requestID,
 		Status:          TranscodeStatusCompleted,
-		Timestamp:       config.Clock.GetTimestampUTC(),
+		Timestamp:       config.Clock.GetTime(),
 		Type:            "video", // Assume everything is a video for now
 		InputVideo:      iv,
 		Outputs:         ov,

--- a/config/timestamp.go
+++ b/config/timestamp.go
@@ -3,19 +3,19 @@ package config
 import "time"
 
 type TimestampGenerator interface {
-	GetTimestampUTC() int64
+	GetTime() time.Time
 }
 
 type RealTimestampGenerator struct{}
 
-func (t RealTimestampGenerator) GetTimestampUTC() int64 {
-	return time.Now().Unix()
+func (t RealTimestampGenerator) GetTime() time.Time {
+	return time.Now()
 }
 
 type FixedTimestampGenerator struct {
-	Timestamp int64
+	Timestamp time.Time
 }
 
-func (t FixedTimestampGenerator) GetTimestampUTC() int64 {
+func (t FixedTimestampGenerator) GetTime() time.Time {
 	return t.Timestamp
 }


### PR DESCRIPTION
Previously we were comparing seconds to milliseconds so stale callback messages were essentially never timing out with this check. I've fixed the check by switching to `time.Time` types to make it clearer.