### PR TITLE
Pull down source file locally before segmenting

### DIFF
--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -49,7 +49,8 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 
 	// Copy the file locally because of issues with ffmpeg segmenting and remote files
 	// We can be aggressive with the timeout because we're copying from cloud storage
-	timeout, _ := context.WithTimeout(context.Background(), 30*time.Minute)
+	timeout, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
 	_, err = clients.CopyFile(timeout, job.SignedSourceURL, localSourceFile.Name(), "", job.RequestID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy file (%s) locally for segmenting: %s", job.SignedSourceURL, err)

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -37,6 +37,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	job.SourceOutputURL = sourceOutputURL.String()
 	job.SegmentingTargetURL = segmentingTargetURL.String()
 	log.AddContext(job.RequestID, "segmented_url", job.SegmentingTargetURL)
+	job.ReportProgress(clients.TranscodeStatusPreparing, 0.3)
 
 	// Create a temporary local file to write to
 	sourceFilename := filepath.Join(os.TempDir(), config.RandomTrailer(8))

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
@@ -47,7 +48,9 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	defer os.Remove(localSourceFile.Name()) // Clean up the file as soon as we're done segmenting
 
 	// Copy the file locally because of issues with ffmpeg segmenting and remote files
-	_, err = clients.CopyFile(context.Background(), job.SignedSourceURL, localSourceFile.Name(), "", job.RequestID)
+	// We can be aggressive with the timeout because we're copying from cloud storage
+	timeout, _ := context.WithTimeout(context.Background(), 30*time.Minute)
+	_, err = clients.CopyFile(timeout, job.SignedSourceURL, localSourceFile.Name(), "", job.RequestID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to copy file (%s) locally for segmenting: %s", job.SignedSourceURL, err)
 	}

--- a/video/segment.go
+++ b/video/segment.go
@@ -6,8 +6,14 @@ import (
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
-func Segment(sourceURL string, outputManifestURL string, targetSegmentSize int64) error {
-	err := ffmpeg.Input(sourceURL).
+// Split a source video URL into segments
+//
+// FFMPEG can use remote files, but depending on the layout of the file can get bogged
+// down and end up making multiple range requests per segment.
+// Because of this, we download first and then clean up at the end.
+func Segment(sourceFilename string, outputManifestURL string, targetSegmentSize int64) error {
+	// Do the segmenting, using the local file as source
+	err := ffmpeg.Input(sourceFilename).
 		Output(
 			outputManifestURL,
 			ffmpeg.KwArgs{
@@ -22,7 +28,7 @@ func Segment(sourceURL string, outputManifestURL string, targetSegmentSize int64
 			},
 		).OverWriteOutput().ErrorToStdOut().Run()
 	if err != nil {
-		return fmt.Errorf("failed to segment source file (%s): %s", sourceURL, err)
+		return fmt.Errorf("failed to segment source file (%s): %s", sourceFilename, err)
 	}
 	return nil
 }


### PR DESCRIPTION
This was due to observed issues where FFMPEG would become very slow to segment and make large numbers of range requests per segment when segmenting remote files.

We now download the file to a local temp directory (with a deferred step to remove it afterwards) before segmenting.