### PR TITLE
mapic: Add STREAM_BUFFER handling for stream health reporting

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -52,6 +52,7 @@ type Cli struct {
 	RetryJoin                 []string
 	EncryptKey                string
 	GateURL                   string
+	StreamHealthHookURL       string
 }
 
 // Return our own URL for callback trigger purposes

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func main() {
 	fs.StringVar(&cli.APIServer, "api-server", "", "Livepeer API server to use")
 	fs.StringVar(&cli.AMQPURL, "amqp-url", "", "RabbitMQ url")
 	fs.StringVar(&cli.OwnRegion, "own-region", "", "Identifier of the region where the service is running, used for mapping external data back to current region")
+	fs.StringVar(&cli.StreamHealthHookURL, "stream-health-hook-url", "http://localhost:3004/api/stream/hook/health", "Address to POST stream health payloads to (response is ignored)")
 
 	// catalyst-node parameters
 	hostname, _ := os.Hostname()

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -270,7 +270,7 @@ func (mc *mac) triggerConnClose(w http.ResponseWriter, r *http.Request, lines []
 }
 
 func (mc *mac) triggerStreamBuffer(w http.ResponseWriter, r *http.Request, lines []string, rawRequest string) bool {
-	err := misttriggers.TriggerStreamBuffer(r, lines)
+	err := misttriggers.TriggerStreamBuffer(mc.config, r, lines)
 	if err != nil {
 		glog.Errorf("Error handling stream buffer trigger error=%q", err)
 		w.WriteHeader(http.StatusInternalServerError)

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -137,7 +137,10 @@ func ParseStreamBufferPayload(lines []string) (*StreamBufferPayload, error) {
 
 	streamName := lines[0]
 	streamState := lines[1]
-	streamDetailsStr := lines[2]
+	var streamDetailsStr string
+	if len(lines) == 3 {
+		streamDetailsStr = lines[2]
+	}
 
 	streamDetails, err := ParseMistStreamDetails(streamState, []byte(streamDetailsStr))
 	if err != nil {

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -102,7 +102,7 @@ func PostStreamHealthPayload(url, apiToken string, payload StreamHealthPayload) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		respBody, err := ioutil.ReadAll(resp.Body)
+		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return fmt.Errorf("error reading stream health hook response: %w", err)
 		}

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -79,8 +79,8 @@ type StreamHealthPayload struct {
 	StreamName string                  `json:"streamName"`
 	SessionID  string                  `json:"sessionId"`
 	State      string                  `json:"state"`
-	Tracks     map[string]TrackDetails `json:"tracks"`
-	Issues     string                  `json:"issues"`
+	Tracks     map[string]TrackDetails `json:"tracks,omitempty"`
+	Issues     string                  `json:"issues,omitempty"`
 }
 
 func PostStreamHealthPayload(url, apiToken string, payload StreamHealthPayload) error {

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -59,9 +59,11 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 	streamHealth := StreamHealthPayload{
 		StreamName: body.StreamName,
 		SessionID:  sessionID,
-		State:      body.State,
+		IsActive:   body.State != "EMPTY",
+		IsHealthy:  body.State == "FULL" || body.State == "RECOVER",
 	}
 	if details := body.Details; details != nil {
+		streamHealth.IsHealthy = streamHealth.IsHealthy && details.Issues == ""
 		streamHealth.Tracks = details.Tracks
 		streamHealth.Issues = details.Issues
 	}
@@ -78,7 +80,8 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 type StreamHealthPayload struct {
 	StreamName string                  `json:"streamName"`
 	SessionID  string                  `json:"sessionId"`
-	State      string                  `json:"state"`
+	IsActive   bool                    `json:"isActive"`
+	IsHealthy  bool                    `json:"isHealthy"`
 	Tracks     map[string]TrackDetails `json:"tracks,omitempty"`
 	Issues     string                  `json:"issues,omitempty"`
 }

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -78,10 +78,10 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 }
 
 type StreamHealthPayload struct {
-	StreamName string                  `json:"streamName"`
-	SessionID  string                  `json:"sessionId"`
-	IsActive   bool                    `json:"isActive"`
-	IsHealthy  bool                    `json:"isHealthy"`
+	StreamName string                  `json:"stream_name"`
+	SessionID  string                  `json:"session_id"`
+	IsActive   bool                    `json:"is_active"`
+	IsHealthy  bool                    `json:"is_healthy"`
 	Tracks     map[string]TrackDetails `json:"tracks,omitempty"`
 	Issues     string                  `json:"issues,omitempty"`
 }

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -1,0 +1,117 @@
+package misttriggers
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/livepeer/catalyst-api/errors"
+	"github.com/livepeer/catalyst-api/log"
+)
+
+// This is written as catalalyst-api-native code, since that's where it's
+// supposed to go. Currently, catalyst-api has no connection with Mist anymore
+// though, so it's easier to plug this into mist-api-connector instead for now.
+// TODO: Move this to catalyst-api when its got the Mist plumbing back.
+
+// This trigger is run whenever the live buffer state of a stream changes. It is
+// not ran for VoD streams. This trigger is stream-specific and non-blocking.
+//
+// The payload for this trigger is multiple lines, each separated by a single
+// newline character (without an ending newline), containing data as such:
+//
+// stream name
+// stream state (one of: FULL, EMPTY, DRY, RECOVER)
+// {JSON object with stream details, only when state is not EMPTY}
+//
+// Read the Mist documentation for more details on each of the stream states.
+func TriggerStreamBuffer(w http.ResponseWriter, req *http.Request, payload []byte) {
+	body, err := ParseStreamBufferPayload(string(payload))
+	if err != nil {
+		log.LogNoRequestID("Error parsing STREAM_BUFFER payload", "error", err, "payload", string(payload))
+		errors.WriteHTTPBadRequest(w, "Error parsing STREAM_BUFFER payload", err)
+		return
+	}
+
+	headers := req.Header
+	headersStr := ""
+	for key, values := range headers {
+		headersStr += fmt.Sprintf("%s=%v;, ", key, values)
+	}
+	rawBody, _ := json.Marshal(body)
+	log.LogNoRequestID("Got STREAM_BUFFER trigger", "headers", headersStr, "payload", rawBody)
+}
+
+type StreamBufferPayload struct {
+	StreamName    string
+	StreamState   string
+	StreamDetails *StreamDetails
+}
+
+func ParseStreamBufferPayload(payload string) (*StreamBufferPayload, error) {
+	lines := strings.Split(strings.TrimSuffix(payload, "\n"), "\n")
+
+	if len(lines) < 2 || len(lines) > 3 {
+		return nil, fmt.Errorf("invalid payload: expected 2 or 3 lines but got %d", len(lines))
+	}
+
+	streamName := lines[0]
+	streamState := lines[1]
+	streamDetailsStr := lines[2]
+
+	streamDetails, err := ParseStreamDetails(streamState, []byte(streamDetailsStr))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing stream details JSON: %w", err)
+	}
+
+	return &StreamBufferPayload{
+		StreamName:    streamName,
+		StreamState:   streamState,
+		StreamDetails: streamDetails,
+	}, nil
+}
+
+type TrackDetails struct {
+	Codec  string                 `json:"codec"`
+	Kbits  int                    `json:"kbits"`
+	Keys   map[string]interface{} `json:"keys"`
+	Fpks   int                    `json:"fpks,omitempty"`
+	Height int                    `json:"height,omitempty"`
+	Width  int                    `json:"width,omitempty"`
+}
+
+type StreamDetails struct {
+	Tracks map[string]TrackDetails
+	Issues string
+}
+
+func ParseStreamDetails(streamState string, data []byte) (*StreamDetails, error) {
+	if streamState == "EMPTY" {
+		return nil, nil
+	}
+
+	var tracksAndIssues map[string]interface{}
+	err := json.Unmarshal(data, &tracksAndIssues)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing stream details JSON: %w", err)
+	}
+
+	issues, ok := tracksAndIssues["issues"].(string)
+	if raw, keyExists := tracksAndIssues["issues"]; keyExists && !ok {
+		return nil, fmt.Errorf("issues field is not a string: %v", raw)
+	}
+	delete(tracksAndIssues, "issues")
+
+	tracksJSON, err := json.Marshal(tracksAndIssues) // only tracks now
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling stream details tracks: %w", err)
+	}
+
+	var tracks map[string]TrackDetails
+	if err = json.Unmarshal(tracksJSON, &tracks); err != nil {
+		return nil, fmt.Errorf("eror parsing stream details tracks: %w", err)
+	}
+
+	return &StreamDetails{tracks, issues}, nil
+}

--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -62,7 +62,8 @@ func TestPostStreamHealthPayloadFailsWithInvalidURL(t *testing.T) {
 	streamHealthPayload := StreamHealthPayload{
 		StreamName: "stream1",
 		SessionID:  "session1",
-		State:      "FULL",
+		IsActive:   true,
+		IsHealthy:  true,
 		Tracks:     nil,
 		Issues:     "",
 	}
@@ -84,7 +85,8 @@ func TestPostStreamHealthPayloadWithTestServer(t *testing.T) {
 	streamHealthPayload := StreamHealthPayload{
 		StreamName: "stream1",
 		SessionID:  "session1",
-		State:      "FULL",
+		IsActive:   true,
+		IsHealthy:  true,
 		Tracks:     nil,
 		Issues:     "No issues",
 	}
@@ -123,15 +125,16 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 		StreamHealthHookURL: server.URL,
 		APIToken:            "apiToken",
 	}
-	err = TriggerStreamBuffer(cli, req, strings.Split(streamBufferPayloadFull, "\n"))
+	err = TriggerStreamBuffer(cli, req, strings.Split(streamBufferPayloadIssues, "\n"))
 	require.NoError(t, err)
 
 	// Check the payload received by the test server
 	require.Equal(t, receivedAuthHeader, "Bearer apiToken")
 	require.Equal(t, receivedPayload.StreamName, "stream1")
 	require.Equal(t, receivedPayload.SessionID, "session1")
-	require.Equal(t, receivedPayload.State, "FULL")
+	require.Equal(t, receivedPayload.IsActive, true)
+	require.Equal(t, receivedPayload.IsHealthy, false)
 	require.Len(t, receivedPayload.Tracks, 1)
 	require.Contains(t, receivedPayload.Tracks, "track1")
-	require.Equal(t, receivedPayload.Issues, "")
+	require.Equal(t, receivedPayload.Issues, "Stream is feeling under the weather")
 }

--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -1,0 +1,137 @@
+package misttriggers
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/livepeer/catalyst-api/config"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	streamBufferPayloadFull    = "stream1\nFULL\n{\"track1\":{\"codec\":\"h264\",\"kbits\":1000,\"keys\":{\"B\":\"1\"},\"fpks\":30,\"height\":720,\"width\":1280}}"
+	streamBufferPayloadIssues  = "stream1\nRECOVER\n{\"track1\":{\"codec\":\"h264\",\"kbits\":1000,\"keys\":{\"B\":\"1\"},\"fpks\":30,\"height\":720,\"width\":1280},\"issues\":\"Stream is feeling under the weather\"}"
+	streamBufferPayloadEmpty   = "stream1\nEMPTY\n"
+	streamBufferPayloadInvalid = "stream1\nFULL\n{\"track1\":{\"codec\":\"h264\",\"kbits\":1000,\"keys\":{\"B\":\"1\"},\"fpks\":30,\"height\":720,\"width\":1280},\"issues\":false}"
+)
+
+func TestItCanParseAValidStreamBufferPayload(t *testing.T) {
+	lines := strings.Split(streamBufferPayloadFull, "\n")
+	p, err := ParseStreamBufferPayload(lines)
+	require.NoError(t, err)
+	require.Equal(t, p.StreamName, "stream1")
+	require.Equal(t, p.State, "FULL")
+	require.NotNil(t, p.Details)
+	require.Equal(t, p.Details.Issues, "")
+	require.Len(t, p.Details.Tracks, 1)
+	require.Contains(t, p.Details.Tracks, "track1")
+}
+
+func TestItCanParseAStreamBufferPayloadWithStreamIssues(t *testing.T) {
+	lines := strings.Split(streamBufferPayloadIssues, "\n")
+	p, err := ParseStreamBufferPayload(lines)
+	require.NoError(t, err)
+	require.Equal(t, p.StreamName, "stream1")
+	require.Equal(t, p.State, "RECOVER")
+	require.NotNil(t, p.Details)
+	require.Equal(t, p.Details.Issues, "Stream is feeling under the weather")
+	require.Len(t, p.Details.Tracks, 1)
+	require.Contains(t, p.Details.Tracks, "track1")
+}
+
+func TestItCanParseAValidStreamBufferPayloadWithEmptyState(t *testing.T) {
+	lines := strings.Split(streamBufferPayloadEmpty, "\n")
+	p, err := ParseStreamBufferPayload(lines)
+	require.NoError(t, err)
+	require.Equal(t, p.StreamName, "stream1")
+	require.Equal(t, p.State, "EMPTY")
+	require.Nil(t, p.Details)
+}
+
+func TestItFailsToParseAnInvalidStreamBufferPayload(t *testing.T) {
+	lines := strings.Split(streamBufferPayloadInvalid, "\n")
+	_, err := ParseStreamBufferPayload(lines)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "issues field is not a string")
+}
+
+func TestPostStreamHealthPayloadFailsWithInvalidURL(t *testing.T) {
+	streamHealthPayload := StreamHealthPayload{
+		StreamName: "stream1",
+		SessionID:  "session1",
+		State:      "FULL",
+		Tracks:     nil,
+		Issues:     "",
+	}
+
+	err := PostStreamHealthPayload("http://invalid.url", "apiToken", streamHealthPayload)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "error pushing stream health to hook")
+}
+
+func TestPostStreamHealthPayloadWithTestServer(t *testing.T) {
+	// Start an HTTP test server to simulate the webhook endpoint
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	streamHealthPayload := StreamHealthPayload{
+		StreamName: "stream1",
+		SessionID:  "session1",
+		State:      "FULL",
+		Tracks:     nil,
+		Issues:     "No issues",
+	}
+
+	err := PostStreamHealthPayload(server.URL, "apiToken", streamHealthPayload)
+	require.NoError(t, err)
+	require.Equal(t, 1, callCount)
+}
+
+func TestTriggerStreamBufferE2E(t *testing.T) {
+	// Start an HTTP test server to simulate the webhook endpoint
+	var receivedPayload StreamHealthPayload
+	var receivedAuthHeader string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedAuthHeader = r.Header.Get("Authorization")
+
+		defer r.Body.Close()
+		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
+		if err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte("error unmarshalling payload"))
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer server.Close()
+
+	// Prepare the request and payload
+	req, err := http.NewRequest("GET", "http://example.com", strings.NewReader(streamBufferPayloadFull))
+	require.NoError(t, err)
+	req.Header.Set("X-UUID", "session1")
+
+	// Call the TriggerStreamBuffer function
+	cli := &config.Cli{
+		StreamHealthHookURL: server.URL,
+		APIToken:            "apiToken",
+	}
+	err = TriggerStreamBuffer(cli, req, strings.Split(streamBufferPayloadFull, "\n"))
+	require.NoError(t, err)
+
+	// Check the payload received by the test server
+	require.Equal(t, receivedAuthHeader, "Bearer apiToken")
+	require.Equal(t, receivedPayload.StreamName, "stream1")
+	require.Equal(t, receivedPayload.SessionID, "session1")
+	require.Equal(t, receivedPayload.State, "FULL")
+	require.Len(t, receivedPayload.Tracks, 1)
+	require.Contains(t, receivedPayload.Tracks, "track1")
+	require.Equal(t, receivedPayload.Issues, "")
+}

--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -109,7 +109,8 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&receivedPayload)
 		if err != nil {
 			w.WriteHeader(http.StatusBadRequest)
-			w.Write([]byte("error unmarshalling payload"))
+			_, err := w.Write([]byte("error unmarshalling payload"))
+			require.NoError(t, err)
 			return
 		}
 


### PR DESCRIPTION
Basically works by parsing the Mist STREAM_BUFFER payload into a single
JSON object and pushing it to a "stream heath hook url" configured on cli.
The Studio API will handle updating the stream health with what comes in
that trigger (e.g. can easily start handling the END trigger soon).

This was meant to be catalyst-api code, but in the midst of the implementation
I realized it has no connection with Mist anymore, so it's easier to plug this into 
mist-api-connector instead for now (especially due to code/config familiarity).
Nice that it's all in the same repo which makes it easier. I also implemented it
in a way that makes sense for catalyst-api (no hard deps on Studio API) so
it's easy to migrate in the future.