### PR TITLE
mapic/triggers: Make sure stream health URL is present

### DIFF
--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -54,6 +54,10 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 	}
 
 	rawBody, _ := json.Marshal(body)
+	if cli.StreamHealthHookURL == "" {
+		glog.Infof("Stream health hook URL not set, skipping trigger sessionId=%q payload=%s", sessionID, rawBody)
+		return nil
+	}
 	glog.Infof("Got STREAM_BUFFER trigger sessionId=%q payload=%s", sessionID, rawBody)
 
 	streamHealth := StreamHealthPayload{


### PR DESCRIPTION
Let's avoid a bunch of errors when we just haven't configured it.