### PR TITLE
video: check video track for duration first

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -97,6 +97,11 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 		}
 	}
 
+	duration, err := strconv.ParseFloat(videoStream.Duration, 64)
+	if err != nil {
+		duration = probeData.Format.DurationSeconds
+	}
+
 	var rotation int64
 	displaySideData, err := videoStream.SideDataList.GetSideData("Display Matrix")
 	if err == nil {
@@ -122,7 +127,7 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 				},
 			},
 		},
-		Duration:  probeData.Format.Duration().Seconds(),
+		Duration:  duration,
 		SizeBytes: size,
 	}
 	iv = addAudioTrack(probeData, iv)

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -77,7 +77,7 @@ func TestProbe(t *testing.T) {
 
 	expectedInput := InputVideo{
 		Format:   "mov,mp4,m4a,3gp,3g2,mj2",
-		Duration: 16.254,
+		Duration: 16.2,
 		Tracks: []InputTrack{
 			{
 				Type:    TrackTypeVideo,


### PR DESCRIPTION
Before this, we were inconsistent between ffmpeg 4 and 6:

```
ffprobe version 6.0 Copyright (c) 2007-2023 the FFmpeg developers
  Duration: 00:00:16.21, start: 0.000000, bitrate: 1372 kb/s

ffprobe version 4.2.7-0ubuntu0.1 Copyright (c) 2007-2022 the FFmpeg developers
  Duration: 00:00:16.25, start: 0.000000, bitrate: 1368 kb/s
```

By looking at the video track directly, we sidestep the issue. Except that fails for the VP9 sample for whatever reason:
```
--- FAIL: TestProbe_VP9 (0.07s)
    probe_test.go:122:
        	Error Trace:	/Users/iameli/code/catalyst-api/video/probe_test.go:122
        	Error:      	Received unexpected error:
        	            	error parsing videoStream.Duration: strconv.ParseFloat: parsing "": invalid syntax
        	Test:       	TestProbe_VP9
FAIL
FAIL	github.com/livepeer/catalyst-api/video	3.177s
FAIL
```

So I added the original duration in there as a fallback.