### PR TITLE
mapic: FIx stream_buffer payload parsing

### DIFF
--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -213,7 +213,7 @@ func ParseMistStreamDetails(streamState string, data []byte) (*MistStreamDetails
 
 	var tracks map[string]TrackDetails
 	if err = json.Unmarshal(tracksJSON, &tracks); err != nil {
-		return nil, fmt.Errorf("eror parsing stream details tracks: %w", err)
+		return nil, fmt.Errorf("error parsing stream details tracks: %w", err)
 	}
 
 	return &MistStreamDetails{tracks, issues, humanIssues, extra}, nil

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -70,6 +70,8 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 		streamHealth.IsHealthy = streamHealth.IsHealthy && details.Issues == ""
 		streamHealth.Tracks = details.Tracks
 		streamHealth.Issues = details.Issues
+		streamHealth.HumanIssues = details.HumanIssues
+		streamHealth.Extra = details.Extra
 	}
 
 	err = PostStreamHealthPayload(cli.StreamHealthHookURL, cli.APIToken, streamHealth)
@@ -82,12 +84,16 @@ func TriggerStreamBuffer(cli *config.Cli, req *http.Request, lines []string) err
 }
 
 type StreamHealthPayload struct {
-	StreamName string                  `json:"stream_name"`
-	SessionID  string                  `json:"session_id"`
-	IsActive   bool                    `json:"is_active"`
-	IsHealthy  bool                    `json:"is_healthy"`
-	Tracks     map[string]TrackDetails `json:"tracks,omitempty"`
-	Issues     string                  `json:"issues,omitempty"`
+	StreamName string `json:"stream_name"`
+	SessionID  string `json:"session_id"`
+	IsActive   bool   `json:"is_active"`
+
+	IsHealthy   bool   `json:"is_healthy"`
+	Issues      string `json:"issues,omitempty"`
+	HumanIssues string `json:"human_issues,omitempty"`
+
+	Tracks map[string]TrackDetails `json:"tracks,omitempty"`
+	Extra  map[string]interface{}  `json:"extra,omitempty"`
 }
 
 func PostStreamHealthPayload(url, apiToken string, payload StreamHealthPayload) error {

--- a/mapic/misttriggers/stream_buffer.go
+++ b/mapic/misttriggers/stream_buffer.go
@@ -93,7 +93,7 @@ type StreamHealthPayload struct {
 	HumanIssues string `json:"human_issues,omitempty"`
 
 	Tracks map[string]TrackDetails `json:"tracks,omitempty"`
-	Extra  map[string]interface{}  `json:"extra,omitempty"`
+	Extra  map[string]any          `json:"extra,omitempty"`
 }
 
 func PostStreamHealthPayload(url, apiToken string, payload StreamHealthPayload) error {
@@ -132,12 +132,12 @@ type StreamBufferPayload struct {
 }
 
 type TrackDetails struct {
-	Codec  string                 `json:"codec"`
-	Kbits  int                    `json:"kbits"`
-	Keys   map[string]interface{} `json:"keys"`
-	Fpks   int                    `json:"fpks,omitempty"`
-	Height int                    `json:"height,omitempty"`
-	Width  int                    `json:"width,omitempty"`
+	Codec  string         `json:"codec"`
+	Kbits  int            `json:"kbits"`
+	Keys   map[string]any `json:"keys"`
+	Fpks   int            `json:"fpks,omitempty"`
+	Height int            `json:"height,omitempty"`
+	Width  int            `json:"width,omitempty"`
 }
 
 func ParseStreamBufferPayload(lines []string) (*StreamBufferPayload, error) {
@@ -167,7 +167,7 @@ func ParseStreamBufferPayload(lines []string) (*StreamBufferPayload, error) {
 type MistStreamDetails struct {
 	Tracks              map[string]TrackDetails
 	Issues, HumanIssues string
-	Extra               map[string]interface{}
+	Extra               map[string]any
 }
 
 // Mists saves the tracks and issues in the same JSON object, so we need to
@@ -177,7 +177,7 @@ func ParseMistStreamDetails(streamState string, data []byte) (*MistStreamDetails
 		return nil, nil
 	}
 
-	var tracksAndIssues map[string]interface{}
+	var tracksAndIssues map[string]any
 	err := json.Unmarshal(data, &tracksAndIssues)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing stream details JSON: %w", err)
@@ -185,11 +185,11 @@ func ParseMistStreamDetails(streamState string, data []byte) (*MistStreamDetails
 
 	var (
 		issues, humanIssues string
-		extra               = map[string]interface{}{}
+		extra               = map[string]any{}
 	)
 	for key, val := range tracksAndIssues {
 		switch tval := val.(type) {
-		case map[string]interface{}:
+		case map[string]any:
 			// this is a track, it will be parsed from the serialized obj below
 			continue
 		case string:

--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -19,7 +19,7 @@ var (
 		"stream1", "RECOVER", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"issues":"Stream is feeling under the weather"}`,
 	}
 	streamBufferPayloadInvalid = []string{
-		"stream1", "FULL", `{"track1":{},"issues":false}`,
+		"stream1", "FULL", `{"track1":{},"notatrack":{"codec":2}}`,
 	}
 	streamBufferPayloadEmpty = []string{"stream1", "EMPTY"}
 )
@@ -57,7 +57,7 @@ func TestItCanParseAValidStreamBufferPayloadWithEmptyState(t *testing.T) {
 func TestItFailsToParseAnInvalidStreamBufferPayload(t *testing.T) {
 	_, err := ParseStreamBufferPayload(streamBufferPayloadInvalid)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "issues field is not a string")
+	require.Contains(t, err.Error(), "cannot unmarshal number into Go struct field TrackDetails.codec of type string")
 }
 
 func TestPostStreamHealthPayloadFailsWithInvalidURL(t *testing.T) {

--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -13,10 +13,10 @@ import (
 
 var (
 	streamBufferPayloadFull = []string{
-		"stream1", "FULL", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280}}`,
+		"stream1", "FULL", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"jitter":420}`,
 	}
 	streamBufferPayloadIssues = []string{
-		"stream1", "RECOVER", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"issues":"Stream is feeling under the weather"}`,
+		"stream1", "RECOVER", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"issues":"The aqueous linear entity, in a manner pertaining to its metaphorical state of existence, appears to be experiencing an ostensibly suboptimal condition that is reminiscent of an individual's disposition when subjected to an unfavorable meteorological phenomenon","human_issues":"Stream is feeling under the weather"}`,
 	}
 	streamBufferPayloadInvalid = []string{
 		"stream1", "FULL", `{"track1":{},"notatrack":{"codec":2}}`,
@@ -33,6 +33,7 @@ func TestItCanParseAValidStreamBufferPayload(t *testing.T) {
 	require.Equal(t, p.Details.Issues, "")
 	require.Len(t, p.Details.Tracks, 1)
 	require.Contains(t, p.Details.Tracks, "track1")
+	require.Equal(t, p.Details.Extra["jitter"], float64(420))
 }
 
 func TestItCanParseAStreamBufferPayloadWithStreamIssues(t *testing.T) {
@@ -41,7 +42,8 @@ func TestItCanParseAStreamBufferPayloadWithStreamIssues(t *testing.T) {
 	require.Equal(t, p.StreamName, "stream1")
 	require.Equal(t, p.State, "RECOVER")
 	require.NotNil(t, p.Details)
-	require.Equal(t, p.Details.Issues, "Stream is feeling under the weather")
+	require.Equal(t, p.Details.HumanIssues, "Stream is feeling under the weather")
+	require.Contains(t, p.Details.Issues, "unfavorable meteorological phenomenon")
 	require.Len(t, p.Details.Tracks, 1)
 	require.Contains(t, p.Details.Tracks, "track1")
 }
@@ -140,5 +142,5 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 	require.Equal(t, receivedPayload.IsHealthy, false)
 	require.Len(t, receivedPayload.Tracks, 1)
 	require.Contains(t, receivedPayload.Tracks, "track1")
-	require.Equal(t, receivedPayload.Issues, "Stream is feeling under the weather")
+	require.Equal(t, receivedPayload.HumanIssues, "Stream is feeling under the weather")
 }


### PR DESCRIPTION
Turns out that the Mist docs I used were outdated. Instead of having only the `issues` field
additional on that JSON, we actually have some other int/float metrics that need to be removed
as well so we can parse the rest as track objects. 

Updated the code with the assumption now that any object field is a track, and the rest are
either issues or "extra" fields we don't really care. Still include those in a separate `extra`
object for logging on the API.

For ctx, this is the error the code is getting now: `error parsing stream details tracks: json: cannot unmarshal number into Go value of type misttriggers.TrackDetails`
Which happens because we fields like this in the root object of the payload:
```
  "buffer": 34667,
  "jitter": 51,
  "maxkeepaway": 7500,
```

Also found out that, when issues are present, the actual human friendly message goes under a `human_issues` field,
not just `issues`. Fixed that as well and passing it to the API.