### PR TITLE
mapic: Fix parsing of human_issues field

### DIFF
--- a/mapic/misttriggers/stream_buffer_test.go
+++ b/mapic/misttriggers/stream_buffer_test.go
@@ -16,7 +16,7 @@ var (
 		"stream1", "FULL", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"jitter":420}`,
 	}
 	streamBufferPayloadIssues = []string{
-		"stream1", "RECOVER", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"issues":"The aqueous linear entity, in a manner pertaining to its metaphorical state of existence, appears to be experiencing an ostensibly suboptimal condition that is reminiscent of an individual's disposition when subjected to an unfavorable meteorological phenomenon","human_issues":"Stream is feeling under the weather"}`,
+		"stream1", "RECOVER", `{"track1":{"codec":"h264","kbits":1000,"keys":{"B":"1"},"fpks":30,"height":720,"width":1280},"issues":"The aqueous linear entity, in a manner pertaining to its metaphorical state of existence, appears to be experiencing an ostensibly suboptimal condition that is reminiscent of an individual's disposition when subjected to an unfavorable meteorological phenomenon","human_issues":["Stream is feeling under the weather"]}`,
 	}
 	streamBufferPayloadInvalid = []string{
 		"stream1", "FULL", `{"track1":{},"notatrack":{"codec":2}}`,
@@ -42,7 +42,7 @@ func TestItCanParseAStreamBufferPayloadWithStreamIssues(t *testing.T) {
 	require.Equal(t, p.StreamName, "stream1")
 	require.Equal(t, p.State, "RECOVER")
 	require.NotNil(t, p.Details)
-	require.Equal(t, p.Details.HumanIssues, "Stream is feeling under the weather")
+	require.Equal(t, p.Details.HumanIssues, []string{"Stream is feeling under the weather"})
 	require.Contains(t, p.Details.Issues, "unfavorable meteorological phenomenon")
 	require.Len(t, p.Details.Tracks, 1)
 	require.Contains(t, p.Details.Tracks, "track1")
@@ -142,5 +142,5 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 	require.Equal(t, receivedPayload.IsHealthy, false)
 	require.Len(t, receivedPayload.Tracks, 1)
 	require.Contains(t, receivedPayload.Tracks, "track1")
-	require.Equal(t, receivedPayload.HumanIssues, "Stream is feeling under the weather")
+	require.Equal(t, receivedPayload.HumanIssues, []string{"Stream is feeling under the weather"})
 }


### PR DESCRIPTION
It is undocumented and I assumed it was a string just like the issues. Turns out it is a string array.

If I just changed the types it would make the parsing logic much more convoluted, as the array is actually parsed as a []interface{} and I'd need to check each item. So I changed it once again, making yet another parsing of the input object.