### PR TITLE
Retry through different Dstorage gateways when download failures occur

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -19,7 +19,7 @@ const SCHEME_ARWEAVE = "ar"
 
 func CopyDStorageToS3(url, s3URL string, requestID string) error {
 	return backoff.Retry(func() error {
-		content, err := DownloadDStorageFromGatewayList(url, requestID)
+		content, err := DownloadDStorageFromGatewayList(url, requestID, 0)
 		if err != nil {
 			return err
 		}
@@ -33,7 +33,7 @@ func CopyDStorageToS3(url, s3URL string, requestID string) error {
 	}, DStorageRetryBackoff())
 }
 
-func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser, error) {
+func DownloadDStorageFromGatewayList(u, requestID string, retry int) (io.ReadCloser, error) {
 	var err error
 	var gateways []*url.URL
 	dStorageURL, err := url.Parse(u)
@@ -69,7 +69,8 @@ func DownloadDStorageFromGatewayList(u string, requestID string) (io.ReadCloser,
 		}
 	}
 
-	for _, gateway := range gateways {
+	for i := retry; i < len(gateways); i++ {
+		gateway := gateways[i]
 		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
 		if opContent != nil {
 			return opContent, nil

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -18,7 +18,7 @@ const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
 type DStorageDownload struct {
-	gatewaysAttempted []*url.URL
+	gatewaysAttempted []string
 }
 
 func NewDStorageDownload() *DStorageDownload {
@@ -62,10 +62,10 @@ func (d *DStorageDownload) DownloadDStorageFromGatewayList(u, requestID string) 
 	}
 
 	for _, gateway := range gateways {
-		if contains(gateway, d.gatewaysAttempted) {
+		if contains(gateway.String(), d.gatewaysAttempted) {
 			continue
 		}
-		d.gatewaysAttempted = append(d.gatewaysAttempted, gateway)
+		d.gatewaysAttempted = append(d.gatewaysAttempted, gateway.String())
 		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
 		if opContent != nil {
 			return opContent, nil

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -18,7 +18,7 @@ const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
 type DStorageDownload struct {
-	gatewaysAttempted []string
+	gatewaysListPosition int
 }
 
 func NewDStorageDownload() *DStorageDownload {
@@ -61,11 +61,12 @@ func (d *DStorageDownload) DownloadDStorageFromGatewayList(u, requestID string) 
 		}
 	}
 
-	for _, gateway := range gateways {
-		if contains(gateway.String(), d.gatewaysAttempted) {
-			continue
-		}
-		d.gatewaysAttempted = append(d.gatewaysAttempted, gateway.String())
+	defer func() { d.gatewaysListPosition++ }()
+	length := len(gateways)
+	until := d.gatewaysListPosition + length
+	for i := d.gatewaysListPosition; i < until; i++ {
+		d.gatewaysListPosition = i % length
+		gateway := gateways[d.gatewaysListPosition]
 		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
 		if opContent != nil {
 			return opContent, nil

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -17,22 +17,6 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-func CopyDStorageToS3(url, s3URL string, requestID string) error {
-	return backoff.Retry(func() error {
-		content, err := DownloadDStorageFromGatewayList(url, requestID, 0)
-		if err != nil {
-			return err
-		}
-
-		err = UploadToOSURL(s3URL, "", content, MaxCopyFileDuration)
-		if err != nil {
-			return err
-		}
-
-		return nil
-	}, DStorageRetryBackoff())
-}
-
 func DownloadDStorageFromGatewayList(u, requestID string, retry int) (io.ReadCloser, error) {
 	var err error
 	var gateways []*url.URL

--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -17,7 +17,15 @@ import (
 const SCHEME_IPFS = "ipfs"
 const SCHEME_ARWEAVE = "ar"
 
-func DownloadDStorageFromGatewayList(u, requestID string, retry int) (io.ReadCloser, error) {
+type DStorageDownload struct {
+	gatewaysAttempted []*url.URL
+}
+
+func NewDStorageDownload() *DStorageDownload {
+	return &DStorageDownload{}
+}
+
+func (d *DStorageDownload) DownloadDStorageFromGatewayList(u, requestID string) (io.ReadCloser, error) {
 	var err error
 	var gateways []*url.URL
 	dStorageURL, err := url.Parse(u)
@@ -53,8 +61,11 @@ func DownloadDStorageFromGatewayList(u, requestID string, retry int) (io.ReadClo
 		}
 	}
 
-	for i := retry; i < len(gateways); i++ {
-		gateway := gateways[i]
+	for _, gateway := range gateways {
+		if contains(gateway, d.gatewaysAttempted) {
+			continue
+		}
+		d.gatewaysAttempted = append(d.gatewaysAttempted, gateway)
 		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
 		if opContent != nil {
 			return opContent, nil

--- a/clients/arweave_ipfs_s3_test.go
+++ b/clients/arweave_ipfs_s3_test.go
@@ -172,7 +172,7 @@ func TestDownloadDStorageFromGatewayListRetries(t *testing.T) {
 	require.Equal(t, 0, gatewayCallCount)
 
 	gatewayCallCount = 0
-	dStorage.gatewaysAttempted = config.ImportIPFSGatewayURLs[:2]
+	dStorage.gatewaysAttempted = []string{config.ImportIPFSGatewayURLs[0].String(), config.ImportIPFSGatewayURLs[2].String()}
 	_, err = dStorage.DownloadDStorageFromGatewayList("ipfs://Qme7ss3ARVgxv6rXqVPiikMJ8u2NLgmgszg13pYrDKEoiu", "reqID")
 	require.Error(t, err)
 	require.Equal(t, 2, gatewayCallCount)

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -188,9 +188,8 @@ func isDirectUpload(inputFile *url.URL) bool {
 }
 
 func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string) (writtenBytes int64, err error) {
-	retry := 0
+	dStorage := NewDStorageDownload()
 	err = backoff.Retry(func() error {
-		defer func() { retry++ }()
 		// currently this timeout is only used for http downloads in the getFileHTTP function when it calls http.NewRequestWithContext
 		ctx, cancel := context.WithTimeout(ctx, MaxCopyFileDuration)
 		defer cancel()
@@ -198,7 +197,7 @@ func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID
 		byteAccWriter := ByteAccumulatorWriter{count: 0}
 		defer func() { writtenBytes = byteAccWriter.count }()
 
-		c, err := getFile(ctx, requestID, sourceURL, retry)
+		c, err := getFile(ctx, requestID, sourceURL, dStorage)
 		if err != nil {
 			return fmt.Errorf("download error: %w", err)
 		}
@@ -215,12 +214,12 @@ func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID
 	return
 }
 
-func getFile(ctx context.Context, requestID, url string, retry int) (io.ReadCloser, error) {
+func getFile(ctx context.Context, requestID, url string, dStorage *DStorageDownload) (io.ReadCloser, error) {
 	_, err := drivers.ParseOSURL(url, true)
 	if err == nil {
 		return DownloadOSURL(url)
 	} else if IsDStorageResource(url) {
-		return DownloadDStorageFromGatewayList(url, requestID, retry)
+		return dStorage.DownloadDStorageFromGatewayList(url, requestID)
 	} else {
 		return getFileHTTP(ctx, url)
 	}

--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -27,10 +27,9 @@ func DownloadRenditionManifest(requestID, sourceManifestOSURL string) (m3u8.Medi
 	var playlist m3u8.Playlist
 	var playlistType m3u8.ListType
 
-	retry := 0
+	dStorage := NewDStorageDownload()
 	err := backoff.Retry(func() error {
-		defer func() { retry++ }()
-		rc, err := getFile(context.Background(), requestID, sourceManifestOSURL, retry)
+		rc, err := getFile(context.Background(), requestID, sourceManifestOSURL, dStorage)
 		if err != nil {
 			return fmt.Errorf("error downloading manifest: %s", err)
 		}

--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -27,8 +27,10 @@ func DownloadRenditionManifest(requestID, sourceManifestOSURL string) (m3u8.Medi
 	var playlist m3u8.Playlist
 	var playlistType m3u8.ListType
 
+	retry := 0
 	err := backoff.Retry(func() error {
-		rc, err := getFile(context.Background(), requestID, sourceManifestOSURL)
+		defer func() { retry++ }()
+		rc, err := getFile(context.Background(), requestID, sourceManifestOSURL, retry)
 		if err != nil {
 			return fmt.Errorf("error downloading manifest: %s", err)
 		}


### PR DESCRIPTION
Previously different gateways were only used when the request to the gateway simply failed, not for the case when we fail to read data from it.

Example log showing the same gateway `vod-import-gtw.mypinata.cloud` being used when read EOFs occur:
```
2023-04-04 15:45:42.115	
[2023-04-04 15:45:42] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:45:42.11471537Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="Copy attempt failed" source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a dest=s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer err="failed to write to OS URL \"s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer\": ReadRequestBody: read upload data failed\ncaused by: unexpected EOF"
2023-04-04 15:42:15.049	
[2023-04-04 15:42:15] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:42:15.048745092Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="downloading from gateway" resourceID=bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a url="https://vod-import-gtw.mypinata.cloud/ipfs/bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a?pinataGatewayToken="
2023-04-04 15:42:14.760	
[2023-04-04 15:42:14] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:42:14.760143925Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="Copy attempt failed" source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a dest=s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer err="failed to write to OS URL \"s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer\": ReadRequestBody: read upload data failed\ncaused by: unexpected EOF"
2023-04-04 15:39:26.962	
[2023-04-04 15:39:26] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:39:26.962059663Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="downloading from gateway" resourceID=bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a url="https://vod-import-gtw.mypinata.cloud/ipfs/bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a?pinataGatewayToken="
2023-04-04 15:39:26.699	
[2023-04-04 15:39:26] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:39:26.699037295Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="Copy attempt failed" source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a dest=s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer err="failed to write to OS URL \"s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer\": ReadRequestBody: read upload data failed\ncaused by: unexpected EOF"
2023-04-04 15:37:39.671	
[2023-04-04 15:37:39] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:37:39.671194508Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="downloading from gateway" resourceID=bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a url="https://vod-import-gtw.mypinata.cloud/ipfs/bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a?pinataGatewayToken="
2023-04-04 15:37:39.551	
[2023-04-04 15:37:39] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:37:39.550605801Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="Copy attempt failed" source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a dest=s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer err="failed to write to OS URL \"s3+https:/GOOG1EKMFSJCOIK6YM7FDZBYKZ2COZDX6MYQBT4PC6LF2SHARA3WO55EHHPPY:xxxx@storage.googleapis.com/lp-us-catalyst-vod-com/hls/source/fcgbfdbh/transfer\": ReadRequestBody: read upload data failed\ncaused by: unexpected EOF"
2023-04-04 15:34:08.688	
[2023-04-04 15:34:08] livepeer-catalyst-api (3749675) INFO: ts=2023-04-04T15:34:08.687561855Z request_id=fcgbfdbh source=ipfs://bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a target_segment_size_secs=10 msg="downloading from gateway" resourceID=bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a url="https://vod-import-gtw.mypinata.cloud/ipfs/bafybeihztylfsfn4ezyz753r5t4qdd2g67auynut2ciai6ll57l6spka3a?pinataGatewayToken="
```