### PR TITLE
Fail job if sending the final callback fails

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -171,7 +171,10 @@ func (pcc *PeriodicCallbackClient) SendCallbacks() {
 		// Send non-terminal callbacks here in an async manner
 		// Terminal callbacks are sent when the job is finished in the sync manner
 		if !tsm.IsTerminal() {
-			go pcc.sendCallback(tsm)
+			go func(tsm TranscodeStatusMessage) {
+				// Ignore errors during async callback sending
+				_ = pcc.sendCallback(tsm)
+			}(tsm)
 		}
 	}
 }

--- a/clients/callback_client_test.go
+++ b/clients/callback_client_test.go
@@ -48,7 +48,8 @@ func TestItRetriesOnFailedCallbacks(t *testing.T) {
 	client := NewPeriodicCallbackClient(100*time.Hour, map[string]string{"Foo": "bar"})
 
 	// Send the status in, but it shouldn't get sent yet because we haven't started the client
-	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusCompleted, 1))
+	err := client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusCompleted, 1))
+	require.NoError(t, err)
 
 	// Trigger the callback client to send any pending callbacks
 	client.SendCallbacks()
@@ -81,7 +82,8 @@ func TestItSendsPeriodicHeartbeats(t *testing.T) {
 
 	// Send the callback and confirm the number of times we retried
 	client := NewPeriodicCallbackClient(100*time.Millisecond, map[string]string{}).Start()
-	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusCompleted, 1))
+	err := client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusCompleted, 1))
+	require.NoError(t, err)
 
 	time.Sleep(400 * time.Millisecond)
 
@@ -109,7 +111,8 @@ func TestTranscodeStatusErrorNotifcation(t *testing.T) {
 
 	// Send the callback and confirm the number of times we retried
 	client := NewPeriodicCallbackClient(100*time.Millisecond, map[string]string{}).Start()
-	client.SendTranscodeStatus(NewTranscodeStatusError(svr.URL, "example-request-id", "something went wrong", false))
+	err := client.SendTranscodeStatus(NewTranscodeStatusError(svr.URL, "example-request-id", "something went wrong", false))
+	require.NoError(t, err)
 
 	time.Sleep(200 * time.Millisecond)
 
@@ -148,8 +151,10 @@ func TestItDoesntSendOutOfOrderUpdates(t *testing.T) {
 
 	// Send the callback and confirm the number of times we retried
 	client := NewPeriodicCallbackClient(100*time.Millisecond, map[string]string{}).Start()
-	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusTranscoding, 1))
-	client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusPreparing, 1))
+	err := client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusTranscoding, 1))
+	require.NoError(t, err)
+	err = client.SendTranscodeStatus(NewTranscodeStatusProgress(svr.URL, "example-request-id", TranscodeStatusPreparing, 1))
+	require.NoError(t, err)
 	time.Sleep(400 * time.Millisecond)
 
 	// Sanity check that the client has sent multiple callbacks in this timeframe

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -135,7 +135,8 @@ type JobInfo struct {
 
 func (j *JobInfo) ReportProgress(stage clients.TranscodeStatus, completionRatio float64) {
 	tsm := clients.NewTranscodeStatusProgress(j.CallbackURL, j.RequestID, stage, completionRatio)
-	j.statusClient.SendTranscodeStatus(tsm)
+	// Ignore errors, send the progress next time
+	_ = j.statusClient.SendTranscodeStatus(tsm)
 }
 
 // Coordinator provides the main interface to handle the pipelines. It should be

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -554,12 +554,13 @@ func allFailingHandler(t *testing.T) Handler {
 
 func callbacksRecorder() (clients.TranscodeStatusClient, <-chan clients.TranscodeStatusMessage) {
 	callbacks := make(chan clients.TranscodeStatusMessage, 10)
-	handler := func(msg clients.TranscodeStatusMessage) {
+	handler := func(msg clients.TranscodeStatusMessage) error {
 		// background jobs send updates without a callback URL, which are ignored by
 		// the callbacks client. Only record the real ones here.
 		if msg.URL != "" {
 			callbacks <- msg
 		}
+		return nil
 	}
 	return clients.TranscodeStatusFunc(handler), callbacks
 }

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -116,7 +116,8 @@ func TestItCanTranscode(t *testing.T) {
 			CallbackURL:       callbackServer.URL,
 			SourceManifestURL: manifestFile.Name(),
 			ReportProgress: func(stage clients.TranscodeStatus, completionRatio float64) {
-				statusClient.SendTranscodeStatus(clients.NewTranscodeStatusProgress(callbackServer.URL, "", stage, completionRatio))
+				err := statusClient.SendTranscodeStatus(clients.NewTranscodeStatusProgress(callbackServer.URL, "", stage, completionRatio))
+				require.NoError(t, err)
 			},
 			HlsTargetURL: topLevelDir,
 		},


### PR DESCRIPTION
Send final callbacks (status: `TranscodeStatusError` and `TranscodeStatusCompleted`) in a sync manner and wait until the result. If sending the callback fails, then set the status of the job to `failed`.

It prevents the situation in which:
1. Catalyst successfully completed its job
2. It failed on sending the callback to task-runner
3. In studio we see the job as `failed`
4. In Catalyst metrics DB we see the job as `completed`

Note that from now on the opposite situation will be possible, so recording the job as `failed` in metrics DB and having task `complated` in task-runner.