### PR TITLE
balancer: rewrite local node to 127.0.0.1 in MistUtilLoad

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -174,7 +174,7 @@ func (b *BalancerImpl) changeLoadBalancerServers(ctx context.Context, server, ac
 	return bytes, nil
 }
 
-func (b *BalancerImpl) getMistLoadBalancerServers(ctx context.Context) (map[string]bool, error) {
+func (b *BalancerImpl) getMistLoadBalancerServers(ctx context.Context) (map[string]struct{}, error) {
 	ctx, cancel := context.WithTimeout(ctx, mistUtilLoadSingleRequestTimeout)
 	defer cancel()
 	url := b.endpoint + "?lstservers=1"
@@ -211,15 +211,15 @@ func (b *BalancerImpl) getMistLoadBalancerServers(ctx context.Context) (map[stri
 		return nil, err
 	}
 
-	output := make(map[string]bool, len(mistResponse))
+	output := make(map[string]struct{}, len(mistResponse))
 
 	for k := range mistResponse {
 		if k == mistLocalAddress {
 			// Special case — recognize 127.0.0.1 and transform it to our node address
 			myAddr := b.formatNodeAddress(b.config.NodeName)
-			output[myAddr] = true
+			output[myAddr] = struct{}{}
 		} else {
-			output[k] = true
+			output[k] = struct{}{}
 		}
 	}
 

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -135,14 +135,14 @@ func (b *BalancerImpl) UpdateMembers(ctx context.Context, members []cluster.Memb
 func (b *BalancerImpl) changeLoadBalancerServers(ctx context.Context, server, action string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(ctx, mistUtilLoadSingleRequestTimeout)
 	defer cancel()
-	var serverTmpl string
+	var serverURL string
 	if server == b.config.NodeName {
 		// Special case — make sure the balancer is aware this one is localhost
-		serverTmpl = mistLocalAddress
+		serverURL = mistLocalAddress
 	} else {
-		serverTmpl = b.formatNodeAddress(server)
+		serverURL = b.formatNodeAddress(server)
 	}
-	actionURL := b.endpoint + "?" + action + "server=" + url.QueryEscape(serverTmpl)
+	actionURL := b.endpoint + "?" + action + "server=" + url.QueryEscape(serverURL)
 	req, err := http.NewRequest("POST", actionURL, nil)
 	req = req.WithContext(ctx)
 	if err != nil {

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -213,7 +213,7 @@ func (b *BalancerImpl) getMistLoadBalancerServers(ctx context.Context) (map[stri
 
 	output := make(map[string]bool, len(mistResponse))
 
-	for k, _ := range mistResponse {
+	for k := range mistResponse {
 		if k == mistLocalAddress {
 			// Special case — recognize 127.0.0.1 and transform it to our node address
 			myAddr := b.formatNodeAddress(b.config.NodeName)

--- a/balancer/balancer_test.go
+++ b/balancer/balancer_test.go
@@ -68,7 +68,8 @@ func TestSetMistUtilLoadServers(t *testing.T) {
 		"d.example.com",
 	}
 	for _, host := range hosts {
-		bal.changeLoadBalancerServers(context.Background(), host, "add")
+		_, err := bal.changeLoadBalancerServers(context.Background(), host, "add")
+		require.NoError(t, err)
 	}
 	keys := toSortedKeys(t, mul.BalancedHosts)
 	require.Equal(t, keys, []string{
@@ -78,7 +79,8 @@ func TestSetMistUtilLoadServers(t *testing.T) {
 		"https://d.example.com:4321",
 	})
 
-	bal.changeLoadBalancerServers(context.Background(), "c.example.com", "del")
+	_, err := bal.changeLoadBalancerServers(context.Background(), "c.example.com", "del")
+	require.NoError(t, err)
 	keys = toSortedKeys(t, mul.BalancedHosts)
 	require.Equal(t, keys, []string{
 		"https://a.example.com:4321",
@@ -94,12 +96,14 @@ func TestSetMistUtilLoadLocalServer(t *testing.T) {
 	bal.config.NodeName = "example.com"
 	bal.config.MistLoadBalancerTemplate = "https://%s:1234"
 
-	bal.changeLoadBalancerServers(context.Background(), "example.com", "add")
+	_, err := bal.changeLoadBalancerServers(context.Background(), "example.com", "add")
+	require.NoError(t, err)
 	keys := toSortedKeys(t, mul.BalancedHosts)
 	require.Len(t, keys, 1)
 	require.Equal(t, keys[0], "http://127.0.0.1:4242")
 
-	bal.changeLoadBalancerServers(context.Background(), "example.com", "del")
+	_, err = bal.changeLoadBalancerServers(context.Background(), "example.com", "del")
+	require.NoError(t, err)
 	keys = toSortedKeys(t, mul.BalancedHosts)
 	require.Len(t, keys, 0)
 }
@@ -136,7 +140,8 @@ func (mul *mockMistUtilLoad) Handle(t *testing.T) http.HandlerFunc {
 			require.Equal(t, vals[0], "1")
 			b, err := json.Marshal(mul.BalancedHosts)
 			require.NoError(t, err)
-			w.Write(b)
+			_, err = w.Write(b)
+			require.NoError(t, err)
 			return
 		}
 

--- a/balancer/balancer_test.go
+++ b/balancer/balancer_test.go
@@ -87,6 +87,23 @@ func TestSetMistUtilLoadServers(t *testing.T) {
 	})
 }
 
+func TestSetMistUtilLoadLocalServer(t *testing.T) {
+	bal, mul := start(t)
+	defer mul.Close()
+	bal.mistAddr = "http://127.0.0.1:4242"
+	bal.config.NodeName = "example.com"
+	bal.config.MistLoadBalancerTemplate = "https://%s:1234"
+
+	bal.changeLoadBalancerServers(context.Background(), "example.com", "add")
+	keys := toSortedKeys(t, mul.BalancedHosts)
+	require.Len(t, keys, 1)
+	require.Equal(t, keys[0], "http://127.0.0.1:4242")
+
+	bal.changeLoadBalancerServers(context.Background(), "example.com", "del")
+	keys = toSortedKeys(t, mul.BalancedHosts)
+	require.Len(t, keys, 0)
+}
+
 type mockMistUtilLoad struct {
 	HttpCalls     int
 	BalancedHosts map[string]string

--- a/balancer/balancer_test.go
+++ b/balancer/balancer_test.go
@@ -1,0 +1,119 @@
+package balancer
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func start(t *testing.T) (*BalancerImpl, *mockMistUtilLoad) {
+	mul := newMockMistUtilLoad(t)
+
+	b := &BalancerImpl{
+		config: &Config{
+			MistLoadBalancerTemplate: "http://%s:4242",
+		},
+		cmd:      nil,
+		endpoint: mul.Server.URL,
+	}
+	// Mock startup loop
+	b.startupOnce.Do(func() {})
+	return b, mul
+}
+
+func TestGetMistUtilLoadServers(t *testing.T) {
+	bal, mul := start(t)
+	defer mul.Close()
+	mul.BalancedHosts = map[string]string{
+		"http://one.example.com:4242":   "Online",
+		"http://two.example.com:4242":   "Online",
+		"http://three.example.com:4242": "Online",
+		"http://four.example.com:4242":  "Online",
+	}
+	servers, err := bal.getMistLoadBalancerServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, servers, 4)
+	requireKeysEqual(t, servers, mul.BalancedHosts)
+}
+
+func TestConvertLocalFromMist(t *testing.T) {
+	bal, mul := start(t)
+	defer mul.Close()
+	bal.mistAddr = "http://127.0.0.1:4242"
+	bal.config.NodeName = "example.com"
+	mul.BalancedHosts = map[string]string{}
+	mul.BalancedHosts[bal.mistAddr] = "Online"
+	servers, err := bal.getMistLoadBalancerServers(context.Background())
+	require.NoError(t, err)
+	require.Len(t, servers, 1)
+	_, ok := servers["http://example.com:4242"]
+	require.True(t, ok, "incorrect response from getMistLoadBalancerServers: %v", servers)
+}
+
+type mockMistUtilLoad struct {
+	HttpCalls     int
+	BalancedHosts map[string]string
+	Server        *httptest.Server
+}
+
+func newMockMistUtilLoad(t *testing.T) *mockMistUtilLoad {
+	mul := &mockMistUtilLoad{}
+	ts := httptest.NewServer(mul.Handle(t))
+	mul.Server = ts
+	return mul
+}
+
+func (mul *mockMistUtilLoad) Handle(t *testing.T) http.HandlerFunc {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queryVals := r.URL.Query()
+		if len(queryVals) > 1 {
+			require.Fail(t, "Got more than one query parameter!")
+		}
+		if len(queryVals) == 0 {
+			// Default balancer implementation
+			panic("unimplemented")
+		}
+		// Listing servers - ?lstservers=1
+		if vals, ok := queryVals["lstservers"]; ok {
+			require.Len(t, vals, 1)
+			require.Equal(t, vals[0], "1")
+			b, err := json.Marshal(mul.BalancedHosts)
+			require.NoError(t, err)
+			w.Write(b)
+			return
+		}
+		require.Fail(t, fmt.Sprintf("unimplemented mock query parameter: %s", r.URL.RawQuery))
+	})
+}
+
+func (mul *mockMistUtilLoad) Close() {
+	mul.Server.Close()
+}
+
+func toSortedKeys(t *testing.T, m any) []string {
+	value := reflect.ValueOf(m)
+	if value.Kind() != reflect.Map {
+		require.Fail(t, fmt.Sprintf("argument is not a map: %v", m))
+		return []string{}
+	}
+	s := []string{}
+	for _, key := range value.MapKeys() {
+		s = append(s, key.String())
+	}
+	sort.Strings(s)
+	return s
+}
+
+// Check that two maps have equal keys (values don't matter)
+func requireKeysEqual(t *testing.T, m1, m2 any) {
+	s1 := toSortedKeys(t, m1)
+	s2 := toSortedKeys(t, m2)
+	require.Equal(t, s1, s2)
+}

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func main() {
 		Args:                     cli.BalancerArgs,
 		MistUtilLoadPort:         uint32(cli.MistLoadBalancerPort),
 		MistLoadBalancerTemplate: cli.MistLoadBalancerTemplate,
+		NodeName:                 cli.NodeName,
 	})
 
 	c := cluster.NewCluster(&cli)

--- a/main.go
+++ b/main.go
@@ -159,6 +159,8 @@ func main() {
 		Args:                     cli.BalancerArgs,
 		MistUtilLoadPort:         uint32(cli.MistLoadBalancerPort),
 		MistLoadBalancerTemplate: cli.MistLoadBalancerTemplate,
+		MistHost:                 cli.MistHost,
+		MistPort:                 cli.MistPort,
 		NodeName:                 cli.NodeName,
 	})
 


### PR DESCRIPTION
Originally we were going to not pass the local node to the balancer entirely — we don't want that, because it means Catalyst nodes would never under any circumstances send people to watch a stream on themselves. Single-node clusters wouldn't work at all. Instead, the trick will be to rewrite our own node URL to 127.0.0.1 on the way in and out of the Mist load balancer. MistUtilLoad is already smart enough to ignore source requests coming from the same IP address: https://github.com/DDVTECH/mistserver/blob/6393a5a4cdc86667351f12f93b1e3cd22477a144/src/utils/util_load.cpp#L635-L638 so that will result in source (replication) requests never routing to the local node while playback requests can still do so.