### PR TITLE
balancer: use streamstats to determine if a stream is live

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -252,7 +252,7 @@ func (b *BalancerImpl) execBalancer(ctx context.Context, balancerArgs []string) 
 }
 
 func (b *BalancerImpl) queryMistForClosestNode(ctx context.Context, playbackID, lat, lon, prefix string) (string, error) {
-	streamName := fmt.Sprintf("%s+%s", playbackID, prefix)
+	streamName := fmt.Sprintf("%s+%s", prefix, playbackID)
 	// First, check to see if any server has this stream
 	err1 := b.MistUtilLoadStreamStats(ctx, streamName)
 	// Then, check the best playback server

--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -26,7 +26,9 @@ type Balancer interface {
 	Start(ctx context.Context) error
 	UpdateMembers(ctx context.Context, members []cluster.Member) error
 	GetBestNode(ctx context.Context, redirectPrefixes []string, playbackID, lat, lon, fallbackPrefix string) (string, string, error)
-	QueryMistForClosestNodeSource(ctx context.Context, playbackID, lat, lon, prefix string, source bool) (string, error)
+	MistUtilLoadBalance(ctx context.Context, stream, lat, lon string) (string, error)
+	MistUtilLoadSource(ctx context.Context, stream, lat, lon string) (string, error)
+	MistUtilLoadStreamStats(ctx context.Context, stream string) error
 }
 
 type Config struct {
@@ -250,19 +252,20 @@ func (b *BalancerImpl) execBalancer(ctx context.Context, balancerArgs []string) 
 }
 
 func (b *BalancerImpl) queryMistForClosestNode(ctx context.Context, playbackID, lat, lon, prefix string) (string, error) {
+	streamName := fmt.Sprintf("%s+%s", playbackID, prefix)
 	// First, check to see if any server has this stream
-	_, err1 := b.QueryMistForClosestNodeSource(ctx, playbackID, lat, lon, prefix, true)
+	err1 := b.MistUtilLoadStreamStats(ctx, streamName)
 	// Then, check the best playback server
-	node, err2 := b.QueryMistForClosestNodeSource(ctx, playbackID, lat, lon, prefix, false)
+	node, err2 := b.MistUtilLoadBalance(ctx, streamName, lat, lon)
 	// If we can't get a playback server, error
 	if err2 != nil {
 		return "", err2
 	}
-	// If we didn't find the stream but we did find a node, return it with the error for 404s
+	// If we didn't find the stream but we did find a node, return it as the 404 handler
 	if err1 != nil {
 		return node, err1
 	}
-	// Good path, we found the stream and a playback nodew!
+	// Good path, we found the stream and a playback node!
 	return node, nil
 }
 
@@ -312,19 +315,50 @@ func (b *BalancerImpl) GetBestNode(ctx context.Context, redirectPrefixes []strin
 	return "", "", err
 }
 
-func (b *BalancerImpl) QueryMistForClosestNodeSource(ctx context.Context, playbackID, lat, lon, prefix string, source bool) (string, error) {
+// make a balancing request to MistUtilLoad, returns a server suitable for playback
+func (b *BalancerImpl) MistUtilLoadBalance(ctx context.Context, stream, lat, lon string) (string, error) {
+	str, err := b.mistUtilLoadRequest(ctx, "/", stream, lat, lon)
+	if err != nil {
+		return "", err
+	}
+	// Special case: rewrite our local node to our public node url
+	if str == b.config.MistHost {
+		str = b.config.NodeName
+	}
+	return str, nil
+}
+
+// make a source request to MistUtilLoad, returns the DTSC url of the origin server
+func (b *BalancerImpl) MistUtilLoadSource(ctx context.Context, stream, lat, lon string) (string, error) {
+	str, err := b.mistUtilLoadRequest(ctx, "?source=", stream, lat, lon)
+	if err != nil {
+		return "", err
+	}
+	// Special case: rewrite our local node to our public node url
+	u, err := url.Parse(str)
+	if err != nil {
+		return "", err
+	}
+	if u.Hostname() == b.config.MistHost {
+		u.Host = b.config.NodeName
+		str = u.String()
+	}
+	return str, nil
+}
+
+// make a streamStats request to MistUtilLoad; response is opaque but a
+// successful call means the stream is active somewhere in the world
+func (b *BalancerImpl) MistUtilLoadStreamStats(ctx context.Context, stream string) error {
+	_, err := b.mistUtilLoadRequest(ctx, "?streamstats=", stream, "0", "0")
+	return err
+}
+
+// Internal method to make a request to MistUtilLoad
+func (b *BalancerImpl) mistUtilLoadRequest(ctx context.Context, route, stream, lat, lon string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, mistUtilLoadSingleRequestTimeout)
 	defer cancel()
-	if prefix != "" {
-		prefix += "+"
-	}
-	var murl string
-	enc := url.QueryEscape(fmt.Sprintf("%s%s", prefix, playbackID))
-	if source {
-		murl = fmt.Sprintf("%s/?source=%s", b.endpoint, enc)
-	} else {
-		murl = fmt.Sprintf("%s/%s", b.endpoint, enc)
-	}
+	enc := url.QueryEscape(stream)
+	murl := fmt.Sprintf("%s%s%s", b.endpoint, route, enc)
 	glog.V(8).Infof("MistUtilLoad started request=%s", murl)
 	req, err := http.NewRequest("GET", murl, nil)
 	if err != nil {
@@ -353,24 +387,8 @@ func (b *BalancerImpl) QueryMistForClosestNodeSource(ctx context.Context, playba
 	}
 	glog.V(8).Infof("MistUtilLoad responded request=%s response=%s", murl, body)
 	str := string(body)
-	if str == "FULL" {
-		return "", fmt.Errorf("GET request '%s' returned 'FULL'", murl)
-	}
-
-	// Special case: rewrite our local node to our public node url
-	if !source {
-		if str == b.config.MistHost {
-			str = b.config.NodeName
-		}
-	} else {
-		u, err := url.Parse(str)
-		if err != nil {
-			return "", err
-		}
-		if u.Hostname() == b.config.MistHost {
-			u.Host = b.config.NodeName
-		}
-		str = u.String()
+	if str == "FULL" || str == "null" {
+		return "", fmt.Errorf("GET request '%s' returned '%s'", murl, str)
 	}
 
 	return str, nil

--- a/balancer/balancer_stub.go
+++ b/balancer/balancer_stub.go
@@ -4,6 +4,7 @@ package balancer
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/livepeer/catalyst-api/cluster"
 )
@@ -34,4 +35,16 @@ func (b *BalancerStub) GetBestNode(ctx context.Context, redirectPrefixes []strin
 
 func (b *BalancerStub) QueryMistForClosestNodeSource(ctx context.Context, playbackID, lat, lon, prefix string, source bool) (string, error) {
 	return "dtsc://localhost", nil
+}
+
+func (b *BalancerStub) MistUtilLoadBalance(ctx context.Context, stream, lat, lon string) (string, error) {
+	return "127.0.0.1", nil
+}
+
+func (b *BalancerStub) MistUtilLoadSource(ctx context.Context, stream, lat, lon string) (string, error) {
+	return "dtsc://127.0.0.1", nil
+}
+
+func (b *BalancerStub) MistUtilLoadStreamStats(ctx context.Context, stream string) error {
+	return fmt.Errorf("not implemented")
 }

--- a/balancer/balancer_test.go
+++ b/balancer/balancer_test.go
@@ -127,12 +127,13 @@ func TestBalancing(t *testing.T) {
 	mul.BalancedHosts = map[string]string{
 		"http://one.example.com:4242": "Online",
 	}
+	mul.StreamsLive = map[string][]string{"http://one.example.com:4242": {"prefix+fakeid"}}
 
-	node, err := bal.QueryMistForClosestNodeSource(context.Background(), "fakeid", "0", "0", "prefix", false)
+	node, err := bal.MistUtilLoadBalance(context.Background(), "prefix+fakeid", "0", "0")
 	require.NoError(t, err)
 	require.Equal(t, node, "one.example.com")
 
-	source, err := bal.QueryMistForClosestNodeSource(context.Background(), "fakeid", "0", "0", "prefix", true)
+	source, err := bal.MistUtilLoadSource(context.Background(), "prefix+fakeid", "0", "0")
 	require.NoError(t, err)
 	require.Equal(t, source, "dtsc://one.example.com")
 }
@@ -148,19 +149,37 @@ func TestBalancingLocalNode(t *testing.T) {
 		"http://127.0.0.1:4242": "Online",
 	}
 
-	node, err := bal.QueryMistForClosestNodeSource(context.Background(), "fakeid", "0", "0", "prefix", false)
+	node, err := bal.MistUtilLoadBalance(context.Background(), "prefix+fakeid", "0", "0")
 	require.NoError(t, err)
 	require.Equal(t, node, "example.com")
 
-	source, err := bal.QueryMistForClosestNodeSource(context.Background(), "fakeid", "0", "0", "prefix", true)
+	// Should reject local node source request to avoid loops
+	_, err = bal.MistUtilLoadSource(context.Background(), "prefix+fakeid", "0", "0")
+	require.Error(t, err)
+}
+
+func TestStreamStats(t *testing.T) {
+	bal, mul := start(t)
+	defer mul.Close()
+
+	mul.BalancedHosts = map[string]string{
+		"http://one.example.com:4242": "Online",
+		"http://two.example.com:4242": "Online",
+	}
+	mul.StreamsLive = map[string][]string{"http://one.example.com:4242": {"prefix+fakeid"}}
+
+	err := bal.MistUtilLoadStreamStats(context.Background(), "prefix+fakeid")
 	require.NoError(t, err)
-	require.Equal(t, source, "dtsc://example.com")
+
+	err = bal.MistUtilLoadStreamStats(context.Background(), "prefix+notlive")
+	require.Error(t, err)
 }
 
 type mockMistUtilLoad struct {
 	HttpCalls     int
 	BalancedHosts map[string]string
 	Server        *httptest.Server
+	StreamsLive   map[string][]string
 }
 
 func newMockMistUtilLoad(t *testing.T) *mockMistUtilLoad {
@@ -193,18 +212,55 @@ func (mul *mockMistUtilLoad) Handle(t *testing.T) http.HandlerFunc {
 			return
 		}
 
-		// Listing servers - ?source=streamname
+		// Finding the source node for a stream - ?source=streamname
 		if vals, ok := queryVals["source"]; ok {
 			require.Len(t, vals, 1)
+			stream := vals[0]
 			for node := range mul.BalancedHosts {
 				u, err := url.Parse(node)
 				require.NoError(t, err)
+				if u.Hostname() == "127.0.0.1" {
+					// Simulate Mist's loop-avoidance behavior
+					continue
+				}
+				streams, ok := mul.StreamsLive[node]
+				if !ok {
+					continue
+				}
+				found := false
+				for _, s := range streams {
+					if s == stream {
+						found = true
+					}
+				}
+				if !found {
+					continue
+				}
 				resp := fmt.Sprintf("dtsc://%s", u.Hostname())
 				_, err = w.Write([]byte(resp))
 				require.NoError(t, err)
 				return
 			}
 			_, err := w.Write([]byte("FULL"))
+			require.NoError(t, err)
+			return
+		}
+
+		// Evaluating stream stats
+		if vals, ok := queryVals["streamstats"]; ok {
+			require.Len(t, vals, 1)
+			stream := vals[0]
+			for node := range mul.BalancedHosts {
+				for _, s := range mul.StreamsLive[node] {
+					if s == stream {
+						_, err := w.Write([]byte("{}"))
+						require.NoError(t, err)
+						return
+					}
+				}
+			}
+
+			_, err := w.Write([]byte("null"))
 			require.NoError(t, err)
 			return
 		}

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -100,7 +100,7 @@ func (c *GeolocationHandlersCollection) StreamSourceHandler() httprouter.Handle 
 
 		latStr := fmt.Sprintf("%f", lat)
 		lonStr := fmt.Sprintf("%f", lon)
-		dtscURL, err := c.Balancer.QueryMistForClosestNodeSource(context.Background(), streamName, latStr, lonStr, "", true)
+		dtscURL, err := c.Balancer.MistUtilLoadSource(context.Background(), streamName, latStr, lonStr)
 		if err != nil {
 			glog.Errorf("error querying mist for STREAM_SOURCE: %s", err)
 			w.Write([]byte("push://")) // nolint:errcheck


### PR DESCRIPTION
Refactors balancer to use MistUtilLoad's `streamstats` query parameter to determine whether a stream is live anywhere. https://github.com/livepeer/catalyst-api/pull/670 introduced a problem — we successfully avoid balancing to the local node to avoid redirection loops but that also means we broke "stream is live" detection for the local node.

Also includes more tests and some refactoring of the MistUtilLoad calls to make much clearer what's happening; the primary balancing calls are now split off into their own functions with this signature:
```
	MistUtilLoadBalance(ctx context.Context, stream, lat, lon string) (string, error)
	MistUtilLoadSource(ctx context.Context, stream, lat, lon string) (string, error)
	MistUtilLoadStreamStats(ctx context.Context, stream string) error
```