### PR TITLE
Don't impose a timeout as part of the retry mechanism

### DIFF
--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -181,6 +181,7 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 	backOff := backoff.NewExponentialBackOff()
 	backOff.InitialInterval = 200 * time.Millisecond
 	backOff.MaxInterval = maxRetryInterval
+	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
 
 	return backOff
 }

--- a/video/probe.go
+++ b/video/probe.go
@@ -35,6 +35,7 @@ func (p Probe) ProbeFile(url string, ffProbeOptions ...string) (iv InputVideo, e
 	backOff := backoff.NewExponentialBackOff()
 	backOff.InitialInterval = 500 * time.Millisecond
 	backOff.MaxInterval = 2 * time.Second
+	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
 	err = backoff.Retry(operation, backoff.WithMaxRetries(backOff, 3))
 	if err != nil {
 		return InputVideo{}, fmt.Errorf("error probing: %w", err)


### PR DESCRIPTION
I found the backoff library had a default maximum elapsed time of 15 minutes which meant failed copies for larger files were never retried