### PR TITLE
Return 200s for push rewrite trigger if stream is deleted or not found

### DIFF
--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -409,7 +409,11 @@ func (mc *mac) triggerPushRewrite(w http.ResponseWriter, r *http.Request, lines 
 	glog.V(model.VVERBOSE).Infof("Requested stream key is '%s'", streamKey)
 	// ask API
 	stream, err := mc.lapi.GetStreamByKey(streamKey)
-	if err != nil || stream == nil {
+	if errors.Is(err, api.ErrNotExists) {
+		glog.Errorf("Stream not found for push rewrite streamKey=%s err=%v", streamKey, err)
+		w.Write([]byte(""))
+		return false
+	} else if err != nil || stream == nil {
 		glog.Errorf("Error getting stream info from Livepeer API streamKey=%s err=%v", streamKey, err)
 		w.WriteHeader(http.StatusNotFound)
 		w.Write([]byte("false"))
@@ -427,8 +431,7 @@ func (mc *mac) triggerPushRewrite(w http.ResponseWriter, r *http.Request, lines 
 			}
 			mc.mapi.DeleteStreams(streamKey)
 		}
-		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("false"))
+		w.Write([]byte(""))
 		return false
 	}
 

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -468,8 +468,7 @@ func (mc *mac) triggerPushRewrite(w http.ResponseWriter, r *http.Request, lines 
 		} else if !ok {
 			glog.Infof("Stream id=%s streamKey=%s playbackId=%s forbidden by webhook, rejecting", stream.ID, stream.StreamKey, stream.PlaybackID)
 			mc.removeInfo(stream.PlaybackID)
-			w.WriteHeader(http.StatusNotFound)
-			w.Write([]byte("false"))
+			w.Write([]byte(""))
 			return true
 		}
 	} else {


### PR DESCRIPTION
https://linear.app/livepeer/issue/VID-49/catalyst-api-return-200s-for-push-rewrite-triggers