### PR TITLE
balancer: crash if MistUtilLoad exits

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -248,7 +248,11 @@ func (b *BalancerImpl) execBalancer(ctx context.Context, balancerArgs []string) 
 		return err
 	}
 
-	return b.cmd.Wait()
+	err = b.cmd.Wait()
+	if err != nil {
+		return err
+	}
+	return fmt.Errorf("MistUtilLoad exited cleanly")
 }
 
 func (b *BalancerImpl) queryMistForClosestNode(ctx context.Context, playbackID, lat, lon, prefix string) (string, error) {


### PR DESCRIPTION
This is just an `errgroup` fail on my end — I thought _any_ function returning would cause the cancellation of the errgroup context, not just a non-nil error response. This caused situations where MistUtilLoad failed to start but we never found out about it. Changed to ensure an error is always returned.