### PR TITLE
More random stream names

### DIFF
--- a/config/stream_names.go
+++ b/config/stream_names.go
@@ -22,13 +22,14 @@ func SegmentingStreamName(requestID string) string {
 	return fmt.Sprintf("%s%s", SEGMENTING_PREFIX, requestID)
 }
 
+var r = rand.New(rand.NewSource(time.Now().UnixNano()))
+
 func RandomTrailer(length int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	res := make([]byte, length)
 	for i := 0; i < length; i++ {
-		res[i] = charset[r.Intn(length)]
+		res[i] = charset[r.Intn(len(charset))]
 	}
 	return string(res)
 }

--- a/config/stream_names_test.go
+++ b/config/stream_names_test.go
@@ -1,0 +1,18 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItCanGenerateRandomStreamNames(t *testing.T) {
+	r := RandomTrailer(50000)
+	require.Equal(t, 50000, len(r))
+
+	// Each letter in our set should be present in a random string this long
+	charset := "abcdefghijklmnopqrstuvwxyz0123456789"
+	for _, char := range charset {
+		require.Contains(t, r, string(char))
+	}
+}

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -93,6 +93,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	if err != nil {
 		return outputs, segmentsCount, fmt.Errorf("error generating source segment URLs: %s", err)
 	}
+	log.Log(transcodeRequest.RequestID, "Fetched Source Segments URLs", "num_urls", len(sourceSegmentURLs))
 
 	// Use RequestID as part of manifestID when talking to the Broadcaster
 	manifestID := "manifest-" + transcodeRequest.RequestID


### PR DESCRIPTION
We previously were only using the first X characters from our charset (where X is the length of the requested random string) and were also reinitialising the random generator on each request.