### PR TITLE
Add field to notfiy task runner about source playback

### DIFF
--- a/clients/callback_client_status.go
+++ b/clients/callback_client_status.go
@@ -87,6 +87,8 @@ type TranscodeStatusMessage struct {
 	Type       string              `json:"type,omitempty"`
 	InputVideo video.InputVideo    `json:"video_spec,omitempty"`
 	Outputs    []video.OutputVideo `json:"outputs,omitempty"`
+
+	SourcePlayback *video.OutputVideo `json:"source_playback,omitempty"`
 }
 
 // This method will accept the completion ratio of the current stage and will translate that into the overall ratio


### PR DESCRIPTION
I'm adding this field on its own initially so that I can update task-runner with it too before using it, thus avoiding any json parse issues