### PR TITLE
Source playback

### DIFF
--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -97,7 +97,7 @@ func (pcc *PeriodicCallbackClient) SendTranscodeStatus(tsm TranscodeStatusMessag
 
 	// Terminal callbacks are sent here in a sync manner
 	// Non-terminal callbacks are sent periodically, in an async manner
-	if tsm.IsTerminal() {
+	if tsm.IsTerminal() || tsm.SourcePlayback != nil {
 		return pcc.sendCallback(tsm)
 	}
 	return nil

--- a/clients/callback_client_status.go
+++ b/clients/callback_client_status.go
@@ -93,12 +93,17 @@ type TranscodeStatusMessage struct {
 
 // This method will accept the completion ratio of the current stage and will translate that into the overall ratio
 func NewTranscodeStatusProgress(url, requestID string, status TranscodeStatus, currentStageCompletionRatio float64) TranscodeStatusMessage {
+	return NewTranscodeStatusSourcePlayback(url, requestID, status, currentStageCompletionRatio, nil)
+}
+
+func NewTranscodeStatusSourcePlayback(url, requestID string, status TranscodeStatus, currentStageCompletionRatio float64, sourcePlayback *video.OutputVideo) TranscodeStatusMessage {
 	return TranscodeStatusMessage{
 		URL:             url,
 		RequestID:       requestID,
 		CompletionRatio: OverallCompletionRatio(status, currentStageCompletionRatio),
 		Status:          status,
 		Timestamp:       config.Clock.GetTimestampUTC(),
+		SourcePlayback:  sourcePlayback,
 	}
 }
 

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -62,6 +62,10 @@ func GetOSURL(osURL, byteRange string) (*drivers.FileInfoReader, error) {
 }
 
 func UploadToOSURL(osURL, filename string, data io.Reader, timeout time.Duration) error {
+	return UploadToOSURLFields(osURL, filename, data, timeout, nil)
+}
+
+func UploadToOSURLFields(osURL, filename string, data io.Reader, timeout time.Duration, fields *drivers.FileProperties) error {
 	storageDriver, err := drivers.ParseOSURL(osURL, true)
 	if err != nil {
 		return fmt.Errorf("failed to parse OS URL %q: %s", log.RedactURL(osURL), err)
@@ -76,7 +80,8 @@ func UploadToOSURL(osURL, filename string, data io.Reader, timeout time.Duration
 	} else {
 		url = info.S3Info.Host
 	}
-	_, err = sess.SaveData(context.Background(), filename, data, nil, timeout)
+
+	_, err = sess.SaveData(context.Background(), filename, data, fields, timeout)
 
 	if err != nil {
 		metrics.Metrics.ObjectStoreClient.FailureCount.WithLabelValues(url, "write").Inc()

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
 	github.com/livepeer/go-api-client v0.4.7
-	github.com/livepeer/go-tools v0.3.0
+	github.com/livepeer/go-tools v0.3.1
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.7.1
 	github.com/livepeer/m3u8 v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -440,8 +440,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/go-api-client v0.4.7 h1:pJd0Ba7TtDJDUEOiPBx9KmLm+fIB8GRbAurd3lsZUVY=
 github.com/livepeer/go-api-client v0.4.7/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-tools v0.3.0 h1:xK0mJyPWWyvj9Oi9nfLglhCtk0KM8883WB7VO1oPF8g=
-github.com/livepeer/go-tools v0.3.0/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
+github.com/livepeer/go-tools v0.3.1 h1:StK9kR9WHRc2vy/E022sMrfWaqPPHGt30NMwxUBiqWE=
+github.com/livepeer/go-tools v0.3.1/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
 github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.7.1 h1:Iw5OVsvZbygU/Isfj/68nNACVQr2Q0NFs+AMzLnevgc=

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -174,6 +174,7 @@ func sendSourcePlayback(job *JobInfo) {
 		return
 	}
 
+	// source playback won't currently work for token gating so we're excluding the private buckets here
 	for _, blocked := range sourcePlaybackBucketBlocklist {
 		if segmentingBucket == blocked {
 			log.Log(job.RequestID, "source playback not available, not main bucket")

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -3,18 +3,20 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"github.com/grafov/m3u8"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/log"
 	"github.com/livepeer/catalyst-api/transcode"
 	"github.com/livepeer/catalyst-api/video"
+	"github.com/livepeer/go-tools/drivers"
 )
 
 const LocalSourceFilePattern = "sourcevideo*"
@@ -59,6 +61,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	} else {
 		job.SegmentingTargetURL = job.SourceFile
 	}
+	sendSourcePlayback(job)
 	job.ReportProgress(clients.TranscodeStatusPreparingCompleted, 1)
 
 	// Transcode Beginning
@@ -148,6 +151,63 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 			InputVideo: inputInfo,
 			Outputs:    outputs,
 		}}, nil
+}
+
+var sourcePlaybackBucketBlocklist = []string{"lp-us-catalyst-vod-pvt-monster", "lp-us-catalyst-vod-pvt-com"}
+
+func sendSourcePlayback(job *JobInfo) {
+	segmentingTargetURL, err := url.Parse(job.SegmentingTargetURL)
+	if err != nil {
+		log.LogError(job.RequestID, "unable to parse url for source playback", err)
+		return
+	}
+
+	segmentingPath := strings.Split(segmentingTargetURL.Path, "/")
+	if len(segmentingPath) < 3 || segmentingPath[1] == "" {
+		log.Log(job.RequestID, "unable to find bucket for source playback", "segmentingTargetURL", segmentingTargetURL)
+		return
+	}
+	// assume bucket is second element in slice (first element should be an empty string as the path has a leading slash)
+	segmentingBucket := segmentingPath[1]
+	if job.HlsTargetURL == nil || !strings.Contains(job.HlsTargetURL.String(), "/"+segmentingBucket+"/") {
+		log.Log(job.RequestID, "source playback not available, not a studio job", "segmentingTargetURL", segmentingTargetURL)
+		return
+	}
+
+	for _, blocked := range sourcePlaybackBucketBlocklist {
+		if segmentingBucket == blocked {
+			log.Log(job.RequestID, "source playback not available, not main bucket")
+			return
+		}
+	}
+
+	sourceMaster := m3u8.NewMasterPlaylist()
+	videoTrack, err := job.InputFileInfo.GetTrack(video.TrackTypeVideo)
+	if err != nil {
+		log.LogError(job.RequestID, "unable to find a video track for source playback", err)
+		return
+	}
+	sourceMaster.Append("/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
+		Bandwidth:  uint32(videoTrack.Bitrate),
+		Resolution: fmt.Sprintf("%dx%d", videoTrack.Width, videoTrack.Height),
+		Name:       fmt.Sprintf("%dp", videoTrack.Height),
+	})
+	err = clients.UploadToOSURLFields(job.HlsTargetURL.String(), "index.m3u8", sourceMaster.Encode(), 10*time.Minute, &drivers.FileProperties{CacheControl: "max-age=60"})
+	if err != nil {
+		log.LogError(job.RequestID, "failed to write source playback playlist", err)
+		return
+	}
+
+	sourcePlaylist := job.HlsTargetURL.JoinPath("index.m3u8").String()
+	sourceOutput := video.OutputVideo{
+		Manifest: sourcePlaylist,
+	}
+	tsm := clients.NewTranscodeStatusSourcePlayback(job.CallbackURL, job.RequestID, clients.TranscodeStatusPreparingCompleted, 1, &sourceOutput)
+	err = job.statusClient.SendTranscodeStatus(tsm)
+	if err != nil {
+		log.LogError(job.RequestID, "failed to send status message for source playback", err)
+		return
+	}
 }
 
 func probeSourceSegment(requestID string, seg *m3u8.MediaSegment, sourceManifestURL string) error {

--- a/pipeline/ffmpeg_test.go
+++ b/pipeline/ffmpeg_test.go
@@ -1,10 +1,13 @@
 package pipeline
 
 import (
+	"net/url"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/livepeer/catalyst-api/clients"
+	"github.com/livepeer/catalyst-api/video"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,4 +37,105 @@ func TestItCleansUpLocalFiles(t *testing.T) {
 	// Confirm that the ones we expected to not be deleted isn't gone
 	_, err = os.Stat(f4.Name())
 	require.NoError(t, err)
+}
+
+type mockCallbackClient struct {
+	tsm clients.TranscodeStatusMessage
+}
+
+func (s *mockCallbackClient) SendTranscodeStatus(tsm clients.TranscodeStatusMessage) error {
+	s.tsm = tsm
+	return nil
+}
+
+func Test_sendSourcePlayback(t *testing.T) {
+	mustParseUrl := func(u string, t *testing.T) *url.URL {
+		parsed, err := url.Parse(u)
+		require.NoError(t, err)
+		return parsed
+	}
+
+	const (
+		requestID           = "requestID"
+		segmentingTargetURL = "https://google.com/bucket/path"
+	)
+	var (
+		inputVideo = video.InputVideo{
+			Tracks: []video.InputTrack{
+				{
+					Type:    "video",
+					Bitrate: 123,
+					VideoTrack: video.VideoTrack{
+						Width:  10,
+						Height: 10,
+					},
+				},
+			},
+		}
+	)
+	tests := []struct {
+		name                      string
+		job                       *JobInfo
+		shouldWriteSourcePlaylist bool
+	}{
+		{
+			name: "happy",
+			job: &JobInfo{
+				SegmentingTargetURL: segmentingTargetURL,
+				UploadJobPayload: UploadJobPayload{
+					HlsTargetURL: mustParseUrl("/bucket/foo", t),
+				},
+			},
+			shouldWriteSourcePlaylist: true,
+		},
+		{
+			name: "not standard bucket - no source playback",
+			job: &JobInfo{
+				SegmentingTargetURL: segmentingTargetURL,
+				UploadJobPayload: UploadJobPayload{
+					HlsTargetURL: mustParseUrl("/bucketNotMatch/foo", t),
+				},
+			},
+			shouldWriteSourcePlaylist: false,
+		},
+		{
+			name: "private bucket for access control",
+			job: &JobInfo{
+				SegmentingTargetURL: "https://google.com/lp-us-catalyst-vod-pvt-monster/path",
+				UploadJobPayload: UploadJobPayload{
+					HlsTargetURL: mustParseUrl("/lp-us-catalyst-vod-pvt-monster/foo", t),
+				},
+			},
+			shouldWriteSourcePlaylist: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "source-pb-test")
+			require.NoError(t, err)
+			defer os.RemoveAll(tmpDir)
+
+			tt.job.RequestID = requestID
+			tt.job.HlsTargetURL = mustParseUrl(tmpDir, t).JoinPath(tt.job.HlsTargetURL.Path)
+			tt.job.InputFileInfo = inputVideo
+			callbackClient := &mockCallbackClient{}
+			tt.job.statusClient = callbackClient
+			sendSourcePlayback(tt.job)
+
+			if tt.shouldWriteSourcePlaylist {
+				hlsTarget := tt.job.HlsTargetURL.JoinPath("index.m3u8")
+				contents, err := os.ReadFile(hlsTarget.String())
+				require.NoError(t, err)
+				contentsString := string(contents)
+				require.Contains(t, contentsString, "#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=123,RESOLUTION=10x10,NAME=\"10p\"\n")
+				require.Contains(t, contentsString, "/path")
+
+				require.Equal(t, hlsTarget.String(), callbackClient.tsm.SourcePlayback.Manifest)
+			} else {
+				entries, err := os.ReadDir(tmpDir)
+				require.NoError(t, err)
+				require.Empty(t, entries)
+			}
+		})
+	}
 }

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -101,6 +101,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^the gate API call was valid$`, stepContext.CheckGateAPICallValid)
 	ctx.Step(`^the Broadcaster receives "(\d+)" segments for transcoding within "(\d+)" seconds$`, stepContext.BroadcasterReceivesSegmentsWithinSeconds)
 	ctx.Step(`^"(\d+)" transcoded segments and manifests have been written to disk for profiles "([^"]*)" within "(\d+)" seconds$`, stepContext.TranscodedSegmentsWrittenToDiskWithinSeconds)
+	ctx.Step(`^the source playback manifest is written to storage within "(\d+)" seconds$`, stepContext.SourcePlaybackManifestWrittenToDisk)
 	ctx.Step(`^I receive a "([^"]*)" callback within "(\d+)" seconds$`, stepContext.CheckCallback)
 
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -34,6 +34,7 @@ Scenario: Submit a video asset to stream as VOD with the FFMPEG / Livepeer pipel
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And I receive a Request ID in the response body
+    And the source playback manifest is written to storage within "5" seconds
     And my "successful" vod request metrics get recorded
     And "4" source segments are written to storage within "5" seconds
     And the source manifest is written to storage within "3" seconds and contains "4" segments

--- a/test/steps/broadcaster.go
+++ b/test/steps/broadcaster.go
@@ -162,3 +162,17 @@ func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsEx
 
 	return nil
 }
+
+func (s *StepContext) SourcePlaybackManifestWrittenToDisk(secs int) error {
+	masterManifestPath := filepath.Join(s.TranscodedOutputDir, "index.m3u8")
+	var err error
+	for t := 0; t < secs*20; t++ {
+		if contents, err := os.ReadFile(masterManifestPath); err == nil {
+			if strings.Contains(string(contents), "/source/") {
+				break
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	return err
+}

--- a/test/steps/broadcaster.go
+++ b/test/steps/broadcaster.go
@@ -135,8 +135,10 @@ func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsEx
 	masterManifestPath := filepath.Join(s.TranscodedOutputDir, "index.m3u8")
 	var err error
 	for t := 0; t < secs*2; t++ {
-		if _, err = os.Stat(masterManifestPath); err == nil {
-			break
+		if contents, err := os.ReadFile(masterManifestPath); err == nil {
+			if !strings.Contains(string(contents), "/source/") { // ignore fast TTR source playback manifest
+				break
+			}
 		}
 		time.Sleep(500 * time.Millisecond)
 	}


### PR DESCRIPTION
To improve our time to ready we are implementing source playback. We write a master playlist pointing at the segmented source playlist and notify task-runner this is available (which in turn notifies studio). When transcoding is complete this master playlist is overwritten with the final transcoded version.