### PR TITLE
re-add handlers/misttriggers

### DIFF
--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -18,6 +18,7 @@ import (
 	"github.com/livepeer/catalyst-api/handlers/admin"
 	"github.com/livepeer/catalyst-api/handlers/ffmpeg"
 	"github.com/livepeer/catalyst-api/handlers/geolocation"
+	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/log"
 	mistapiconnector "github.com/livepeer/catalyst-api/mapic"
 	"github.com/livepeer/catalyst-api/middleware"
@@ -71,6 +72,7 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 	accessControlHandlers := accesscontrol.NewAccessControlHandlersCollection(cli)
 	encryptionHandlers := accesscontrol.NewEncryptionHandlersCollection(cli, spkiPublicKey)
 	adminHandlers := &admin.AdminHandlersCollection{Cluster: c}
+	mistCallbackHandlers := &misttriggers.MistCallbackHandlersCollection{}
 
 	// Simple endpoint for healthchecks
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
@@ -106,6 +108,9 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 
 	// Public GET handler to retrieve the public key for vod encryption
 	router.GET("/api/pubkey", withLogging(encryptionHandlers.PublicKeyHandler()))
+
+	// Endpoint to receive "Triggers" (callbacks) from Mist
+	router.POST("/api/mist/trigger", withLogging(mistCallbackHandlers.Trigger()))
 
 	// Endpoint to receive segments and manifests that ffmpeg produces
 	router.PUT("/api/ffmpeg/:id/:filename", withLogging(ffmpegSegmentingHandlers.NewFile()))

--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -72,7 +72,7 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 	accessControlHandlers := accesscontrol.NewAccessControlHandlersCollection(cli)
 	encryptionHandlers := accesscontrol.NewEncryptionHandlersCollection(cli, spkiPublicKey)
 	adminHandlers := &admin.AdminHandlersCollection{Cluster: c}
-	mistCallbackHandlers := &misttriggers.MistCallbackHandlersCollection{}
+	mistCallbackHandlers := misttriggers.NewMistCallbackHandlersCollection(cli)
 
 	// Simple endpoint for healthchecks
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))

--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -1,0 +1,471 @@
+package clients
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"sync"
+
+	"github.com/livepeer/catalyst-api/metrics"
+)
+
+type MistAPIClient interface {
+	AddStream(streamName, sourceUrl string) error
+	PushStart(streamName, targetURL string) error
+	DeleteStream(streamName string) error
+	AddTrigger(streamName, triggerName string) error
+	DeleteTrigger(streamName, triggerName string) error
+	GetStreamInfo(streamName string) (MistStreamInfo, error)
+}
+
+type MistClient struct {
+	ApiUrl          string
+	HttpReqUrl      string
+	TriggerCallback string
+	SourceOutputUrl string
+	configMu        sync.Mutex
+}
+
+type MistStreamInfoTrack struct {
+	Codec   string `json:"codec,omitempty"`
+	Firstms int64  `json:"firstms,omitempty"`
+	Idx     int    `json:"idx,omitempty"`
+	Init    string `json:"init,omitempty"`
+	Lastms  int64  `json:"lastms,omitempty"`
+	Maxbps  int    `json:"maxbps,omitempty"`
+	Trackid int    `json:"trackid,omitempty"`
+	Type    string `json:"type,omitempty"`
+	Bps     int    `json:"bps,omitempty"`
+
+	// Audio Only Fields
+	Channels int `json:"channels,omitempty"`
+	Rate     int `json:"rate,omitempty"`
+	Size     int `json:"size,omitempty"`
+
+	// Video Only Fields
+	Bframes int `json:"bframes,omitempty"`
+	Fpks    int `json:"fpks,omitempty"`
+	Height  int `json:"height,omitempty"`
+	Width   int `json:"width,omitempty"`
+}
+
+type MistStreamInfoSource struct {
+	Hrn          string `json:"hrn,omitempty"`
+	Priority     int    `json:"priority,omitempty"`
+	Relurl       string `json:"relurl,omitempty"`
+	SimulTracks  int    `json:"simul_tracks,omitempty"`
+	TotalMatches int    `json:"total_matches,omitempty"`
+	Type         string `json:"type,omitempty"`
+	URL          string `json:"url,omitempty"`
+	PlayerURL    string `json:"player_url,omitempty"`
+}
+
+type MistStreamInfoMetadata struct {
+	Bframes int                            `json:"bframes,omitempty"`
+	Tracks  map[string]MistStreamInfoTrack `json:"tracks,omitempty"`
+	Version int                            `json:"version,omitempty"`
+	Vod     int                            `json:"vod,omitempty"`
+}
+
+type MistStreamInfo struct {
+	Height int                    `json:"height,omitempty"`
+	Meta   MistStreamInfoMetadata `json:"meta,omitempty"`
+	Selver int                    `json:"selver,omitempty"`
+	Source []MistStreamInfoSource `json:"source,omitempty"`
+	Type   string                 `json:"type,omitempty"`
+	Width  int                    `json:"width,omitempty"`
+	Error  string                 `json:"error,omitempty"`
+}
+
+var mistRetryableClient = newRetryableClient(nil)
+
+func (mc *MistClient) AddStream(streamName, sourceUrl string) error {
+	c := commandAddStream(streamName, sourceUrl)
+	return wrapErr(validateAddStream(mc.sendCommand(c)), streamName)
+}
+
+func (mc *MistClient) PushStart(streamName, targetURL string) error {
+	c := commandPushStart(streamName, targetURL)
+	return wrapErr(validatePushStart(mc.sendCommand(c)), streamName)
+}
+
+func (mc *MistClient) DeleteStream(streamName string) error {
+	// Need to send both 'deletestream' and 'nuke_stream' in order to remove stream with all configuration and processes
+	deleteErr := wrapErr(validateDeleteStream(mc.sendCommand(commandDeleteStream(streamName))), streamName)
+	nukeErr := wrapErr(validateNukeStream(mc.sendCommand(commandNukeStream(streamName))), streamName)
+	if deleteErr != nil || nukeErr != nil {
+		return fmt.Errorf("deleting stream failed, 'deletestream' command err: %v, 'nuke_stream' command err: %v", deleteErr, nukeErr)
+	}
+	return nil
+}
+
+// AddTrigger adds a trigger `triggerName` for the stream `streamName`.
+// Note that Mist API supports only overriding the whole trigger configuration, therefore this function needs to:
+// 1. Acquire a lock
+// 2. Get current triggers
+// 3. Add a new trigger (or update the existing one)
+// 4. Override the triggers
+// 5. Release the lock
+func (mc *MistClient) AddTrigger(streamName, triggerName string) error {
+	mc.configMu.Lock()
+	defer mc.configMu.Unlock()
+
+	triggers, err := mc.getCurrentTriggers()
+	if err != nil {
+		return err
+	}
+	c := commandAddTrigger(streamName, triggerName, mc.TriggerCallback, triggers)
+	resp, err := mc.sendCommand(c)
+	return validateAddTrigger(streamName, triggerName, resp, err)
+}
+
+// DeleteTrigger deletes triggers with the name `triggerName` for the stream `streamName`.
+// Note that Mist API supports only overriding the whole trigger configuration, therefore this function needs to:
+// 1. Acquire a lock
+// 2. Get current triggers
+// 3. Add a new trigger (or update the existing one)
+// 4. Override the triggers
+// 5. Release the lock
+func (mc *MistClient) DeleteTrigger(streamName, triggerName string) error {
+	mc.configMu.Lock()
+	defer mc.configMu.Unlock()
+
+	triggers, err := mc.getCurrentTriggers()
+	if err != nil {
+		return err
+	}
+	c := commandDeleteTrigger(streamName, triggerName, triggers)
+	resp, err := mc.sendCommand(c)
+	return validateDeleteTrigger(streamName, triggerName, resp, err)
+}
+
+func (mc *MistClient) getCurrentTriggers() (Triggers, error) {
+	c := commandGetTriggers()
+	resp, err := mc.sendCommand(c)
+	if err := validateAuth(resp, err); err != nil {
+		return nil, err
+	}
+
+	cc := MistConfig{}
+	if err := json.Unmarshal([]byte(resp), &cc); err != nil {
+		return nil, err
+	}
+
+	if cc.Config.Triggers == nil {
+		return Triggers{}, nil
+	}
+
+	return cc.Config.Triggers, nil
+}
+
+func (mc *MistClient) sendCommand(command interface{}) (string, error) {
+	c, err := commandToString(command)
+	if err != nil {
+		return "", err
+	}
+	payload := payloadFor(c)
+	req, err := http.NewRequest(http.MethodPost, mc.ApiUrl, bytes.NewBuffer([]byte(payload)))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := metrics.MonitorRequest(metrics.Metrics.MistClient, mistRetryableClient, req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), err
+}
+
+func commandToString(command interface{}) (string, error) {
+	res, err := json.Marshal(command)
+	if err != nil {
+		return "", err
+	}
+	return string(res), nil
+}
+
+func payloadFor(command string) string {
+	return fmt.Sprintf("command=%s", url.QueryEscape(command))
+}
+
+func (mc *MistClient) sendHttpRequest(streamName string) (string, error) {
+	jsonStreamInfoUrl := mc.HttpReqUrl + "/json_" + streamName + ".js"
+
+	req, err := http.NewRequest(http.MethodGet, jsonStreamInfoUrl, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := metrics.MonitorRequest(metrics.Metrics.MistClient, mistRetryableClient, req)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode >= 400 {
+		return "", fmt.Errorf("got HTTP Status %d from Mist StreamInfo API", resp.StatusCode)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), err
+}
+
+func (mc *MistClient) GetStreamInfo(streamName string) (MistStreamInfo, error) {
+	resp, err := mc.sendHttpRequest(streamName)
+	if err != nil {
+		return MistStreamInfo{}, fmt.Errorf("error making GetStreamInfo HTTP request for %q: %s", streamName, err)
+	}
+
+	var msi MistStreamInfo
+	if err := json.Unmarshal([]byte(resp), &msi); err != nil {
+		return MistStreamInfo{}, fmt.Errorf("error unmarshalling MistStreamInfo JSON for %q: %s\nResponse Body: %s", streamName, err, resp)
+	}
+
+	if msi.Error != "" {
+		return msi, fmt.Errorf("%s", msi.Error)
+	}
+
+	return msi, nil
+}
+
+type addStreamCommand struct {
+	Addstream map[string]Stream `json:"addstream"`
+}
+
+type Stream struct {
+	Source string `json:"source"`
+}
+
+func commandAddStream(name, url string) interface{} {
+	return addStreamCommand{
+		Addstream: map[string]Stream{
+			name: {
+				Source: url,
+			},
+		},
+	}
+}
+
+type deleteStreamCommand struct {
+	Deletestream map[string]interface{} `json:"deletestream"`
+}
+
+func commandDeleteStream(name string) deleteStreamCommand {
+	return deleteStreamCommand{
+		Deletestream: map[string]interface{}{name: nil},
+	}
+}
+
+type nukeStreamCommand struct {
+	Nukestream string `json:"nuke_stream"`
+}
+
+func commandNukeStream(name string) nukeStreamCommand {
+	return nukeStreamCommand{
+		Nukestream: name,
+	}
+}
+
+type pushStartCommand struct {
+	PushStart PushStart `json:"push_start"`
+}
+
+type PushStart struct {
+	Stream string `json:"stream"`
+	Target string `json:"target"`
+}
+
+func commandPushStart(streamName, target string) pushStartCommand {
+	return pushStartCommand{
+		PushStart: PushStart{
+			Stream: streamName,
+			Target: target,
+		},
+	}
+}
+
+type MistConfig struct {
+	Config Config `json:"config"`
+}
+
+type ConfigTrigger struct {
+	Handler string   `json:"handler"`
+	Streams []string `json:"streams"`
+	Sync    bool     `json:"sync"`
+}
+
+type Triggers map[string][]ConfigTrigger
+
+type Config struct {
+	Triggers map[string][]ConfigTrigger `json:"triggers,omitempty"`
+}
+
+func commandAddTrigger(streamName, triggerName, handlerUrl string, currentTriggers Triggers) MistConfig {
+	newTrigger := ConfigTrigger{
+		Handler: handlerUrl,
+		Streams: []string{streamName},
+		Sync:    false,
+	}
+	return commandUpdateTrigger(streamName, triggerName, currentTriggers, newTrigger)
+}
+
+func commandDeleteTrigger(streamName, triggerName string, currentTriggers Triggers) MistConfig {
+	return commandUpdateTrigger(streamName, triggerName, currentTriggers, ConfigTrigger{})
+}
+
+func commandUpdateTrigger(streamName, triggerName string, currentTriggers Triggers, replaceTrigger ConfigTrigger) MistConfig {
+	triggersMap := currentTriggers
+
+	triggers := triggersMap[triggerName]
+	triggers = deleteAllTriggersFor(triggers, streamName)
+	if len(replaceTrigger.Streams) != 0 {
+		triggers = append(triggers, replaceTrigger)
+	}
+
+	triggersMap[triggerName] = triggers
+	return MistConfig{Config{Triggers: triggersMap}}
+}
+
+func deleteAllTriggersFor(triggers []ConfigTrigger, streamName string) []ConfigTrigger {
+	var res []ConfigTrigger
+	for _, t := range triggers {
+		f := false
+		for _, s := range t.Streams {
+			if s == streamName {
+				f = true
+				break
+			}
+		}
+		if !f {
+			res = append(res, t)
+		}
+	}
+	return res
+}
+
+func commandGetTriggers() MistConfig {
+	// send an empty config struct returns the current Mist configuration
+	return MistConfig{}
+}
+
+func validateAddStream(resp string, err error) error {
+	if err != validateAuth(resp, err) {
+		return err
+	}
+
+	r := struct {
+		Streams map[string]interface{} `json:"streams"`
+	}{}
+	if err := json.Unmarshal([]byte(resp), &r); err != nil {
+		return err
+	}
+	if len(r.Streams) == 0 {
+		return errors.New("adding stream failed")
+	}
+	return nil
+}
+
+func validatePushStart(resp string, err error) error {
+	// nothing other than auth to validate, Mist always returns the same response
+	return validateAuth(resp, err)
+}
+
+func validateDeleteStream(resp string, err error) error {
+	// nothing other than auth to validate, Mist always returns the same response
+	return validateAuth(resp, err)
+}
+
+func validateNukeStream(resp string, err error) error {
+	// nothing other than auth to validate, Mist always returns the same response
+	return validateAuth(resp, err)
+}
+
+func validateAddTrigger(streamName, triggerName, resp string, err error) error {
+	if err != validateAuth(resp, err) {
+		return err
+	}
+
+	r := MistConfig{}
+	if err := json.Unmarshal([]byte(resp), &r); err != nil {
+		return err
+	}
+
+	if r.Config.Triggers == nil {
+		return errors.New("adding trigger failed, nil triggers value in response")
+	}
+	ts, ok := r.Config.Triggers[triggerName]
+	if !ok {
+		return fmt.Errorf("adding trigger failed, no trigger '%s' in response", triggerName)
+	}
+	for _, t := range ts {
+		for _, s := range t.Streams {
+			if s == streamName {
+				return nil
+			}
+		}
+	}
+	return fmt.Errorf("adding trigger failed, no stream '%s' found in trigger '%s'", streamName, triggerName)
+}
+
+func validateDeleteTrigger(streamName, triggerName, resp string, err error) error {
+	if err := validateAuth(resp, err); err != nil {
+		return err
+	}
+
+	r := MistConfig{}
+	if err := json.Unmarshal([]byte(resp), &r); err != nil {
+		return err
+	}
+
+	if r.Config.Triggers == nil {
+		return nil
+	}
+	ts, ok := r.Config.Triggers[triggerName]
+	if !ok {
+		return nil
+	}
+	for _, t := range ts {
+		for _, s := range t.Streams {
+			if s == streamName {
+				return fmt.Errorf("deleting trigger failed, stream '%s' found in trigger '%s'", streamName, triggerName)
+			}
+		}
+	}
+	return nil
+}
+
+func validateAuth(resp string, err error) error {
+	if err != nil {
+		return err
+	}
+	r := struct {
+		Authorize struct {
+			Status string `json:"status"`
+		} `json:"authorize"`
+	}{}
+
+	if err := json.Unmarshal([]byte(resp), &r); err != nil {
+		return err
+	}
+	if r.Authorize.Status != "OK" {
+		return errors.New("authorization to Mist API failed")
+	}
+	return nil
+}
+
+func wrapErr(err error, streamName string) error {
+	if err != nil {
+		return fmt.Errorf("error in processing stream '%s': %w", streamName, err)
+	}
+	return nil
+}

--- a/clients/mist_client_mock.go
+++ b/clients/mist_client_mock.go
@@ -1,0 +1,68 @@
+package clients
+
+type StubMistClient struct{}
+
+func (s StubMistClient) AddStream(streamName, sourceUrl string) error {
+	return nil
+}
+
+func (s StubMistClient) PushStart(streamName, targetURL string) error {
+	return nil
+}
+
+func (s StubMistClient) DeleteStream(streamName string) error {
+	return nil
+}
+
+func (s StubMistClient) GetStreamInfo(streamName string) (MistStreamInfo, error) {
+	// Populate media information for testing purposes
+	return MistStreamInfo{
+		Height: 720,
+		Meta: MistStreamInfoMetadata{
+			Version: 4,
+			Vod:     1,
+			Tracks: map[string]MistStreamInfoTrack{
+				"video_H264_1280x720_24fps_0": {
+					Trackid: 1,
+					Firstms: 0,
+					Lastms:  10000,
+					Bps:     495816,
+					Maxbps:  680386,
+					Init:    "\u0001d\u0000\u001F\u00FF\u00E1\u0000\u0019gd\u0000\u001F\u00AC\u00D9@P\u0005\u00BA\u0010\u0000\u0000\u0003\u0000\u0010\u0000\u0000\u0003\u0003\u0000\u00F1\u0083\u0019`\u0001\u0000\u0006h\u00EA\u00E1\u00B2\u00C8\u00B0",
+					Codec:   "H264",
+					Type:    "video",
+					Width:   1280,
+					Height:  720,
+					Fpks:    24000,
+				},
+				"audio_AAC_2ch_44100hz_1": {
+					Trackid:  2,
+					Firstms:  0,
+					Lastms:   10000,
+					Bps:      14025,
+					Maxbps:   14246,
+					Init:     "\u0012\u0010",
+					Codec:    "AAC",
+					Type:     "audio",
+					Rate:     44100,
+					Size:     16,
+					Channels: 2,
+				},
+			},
+		},
+		Type:  "video",
+		Width: 1280,
+	}, nil
+}
+
+func (s StubMistClient) AddTrigger(streamName, triggerName string) error {
+	return nil
+}
+
+func (s StubMistClient) DeleteTrigger(streamName, triggerName string) error {
+	return nil
+}
+
+func (s StubMistClient) CreateDTSH(requestID, source, destination string) error {
+	return nil
+}

--- a/clients/mist_client_test.go
+++ b/clients/mist_client_test.go
@@ -1,0 +1,402 @@
+package clients
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestPayload(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		expected string
+		command  interface{}
+	}{
+		{
+			"command=%7B%22addstream%22%3A%7B%22somestream%22%3A%7B%22source%22%3A%22http%3A%2F%2Fsome-storage-url.com%2Fvod.mp4%22%7D%7D%7D",
+			commandAddStream("somestream", "http://some-storage-url.com/vod.mp4"),
+		},
+		{
+			"command=%7B%22push_start%22%3A%7B%22stream%22%3A%22somestream%22%2C%22target%22%3A%22http%3A%2F%2Fsome-target-url.com%2Ftarget.mp4%22%7D%7D",
+			commandPushStart("somestream", "http://some-target-url.com/target.mp4"),
+		},
+		{
+			"command=%7B%22deletestream%22%3A%7B%22somestream%22%3Anull%7D%7D",
+			commandDeleteStream("somestream"),
+		},
+		{
+			"command=%7B%22nuke_stream%22%3A%22somestream%22%7D",
+			commandNukeStream("somestream"),
+		},
+		{
+			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3A%5B%7B%22handler%22%3A%22http%3A%2F%2Flocalhost%2Fapi%22%2C%22streams%22%3A%5B%22somestream%22%5D%2C%22sync%22%3Afalse%7D%5D%7D%7D%7D",
+			commandAddTrigger("somestream", "PUSH_END", "http://localhost/api", Triggers{}),
+		},
+		{
+			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3Anull%7D%7D%7D",
+			commandDeleteTrigger("somestream", "PUSH_END", Triggers{}),
+		},
+	}
+
+	for _, tt := range tests {
+		c, err := commandToString(tt.command)
+		require.NoError(err)
+		p := payloadFor(c)
+		require.Equal(tt.expected, p)
+	}
+}
+
+func TestCommandAddTrigger(t *testing.T) {
+	require := require.New(t)
+
+	// given
+	h := "http://localhost:8080/mist/api"
+	s := "somestream"
+	tr := "PUSH_END"
+	currentTriggers := Triggers{}
+
+	// when
+	c := commandAddTrigger(s, tr, h, currentTriggers)
+
+	// then
+
+	require.Len(c.Config.Triggers, 1)
+	require.Len(c.Config.Triggers[tr], 1)
+	require.Len(c.Config.Triggers[tr][0].Streams, 1)
+}
+
+func TestCommandAddTrigger_AlreadyExists(t *testing.T) {
+	require := require.New(t)
+
+	// given
+	h := "http://localhost:8080/mist/api"
+	s := "somestream"
+	tr := "PUSH_END"
+	currentTriggers := Triggers{
+		tr: []ConfigTrigger{
+			{
+				Handler: "http://otherstream.com/",
+				Streams: []string{"otherstream"},
+			},
+			{
+				Handler: "http://somestreamhandler",
+				Streams: []string{s},
+			},
+			{
+				Handler: "http://onemoreotherstream.com/",
+				Streams: []string{"onemoreotherstream"},
+			},
+		},
+	}
+
+	// when
+	c := commandAddTrigger(s, tr, h, currentTriggers)
+
+	// then
+	require.Len(c.Config.Triggers, 1)
+	require.Len(c.Config.Triggers[tr], 3)
+	require.Equal(h, c.Config.Triggers[tr][2].Handler)
+	require.Equal(s, c.Config.Triggers[tr][2].Streams[0])
+}
+
+func TestCommandDeleteTrigger(t *testing.T) {
+	require := require.New(t)
+
+	// given
+	s := "somestream"
+	tr := "PUSH_END"
+	currentTriggers := Triggers{
+		tr: []ConfigTrigger{
+			{
+				Handler: "http://otherstream.com/",
+				Streams: []string{"otherstream"},
+			},
+			{
+				Handler: "http://somestreamhandler",
+				Streams: []string{s},
+			},
+			{
+				Handler: "http://onemoreotherstream.com/",
+				Streams: []string{"onemoreotherstream"},
+			},
+		},
+	}
+
+	// when
+	c := commandDeleteTrigger(s, tr, currentTriggers)
+
+	// then
+
+	require.Len(c.Config.Triggers, 1)
+	require.Len(c.Config.Triggers[tr], 2)
+}
+
+func TestResponseValidation(t *testing.T) {
+	require := require.New(t)
+
+	// correct responses
+	require.NoError(validateAddStream(`{"LTS":1,"authorize":{"status":"OK"},"streams":{"catalyst_vod_gedhbdhc":{"name":"catalyst_vod_gedhbdhc","source":"http://some-storage-url.com/vod.mp4"},"incomplete list":1}}`, nil))
+	require.NoError(validatePushStart(`{"LTS":1,"authorize":{"status":"OK"}}`, nil))
+	require.NoError(validateDeleteStream(`{"LTS":1,"authorize":{"status":"OK"},"streams":{"incomplete list":1}}`, nil))
+	require.NoError(validateNukeStream(`{"LTS":1,"authorize":{"local":true,"status":"OK"}}`, nil))
+	require.NoError(validateAddTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027761,"triggers":{"PUSH_END":[{"handler":"http://host.docker.internal:8080/api/mist/trigger","streams":["catalyst_vod_gedhbdhc"],"sync":false}],"RECORDING_END":null},"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+	require.NoError(validateDeleteTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027771,"triggers":{"PUSH_END":null,"RECORDING_END":null},"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+
+	// incorrect responses
+	require.Error(validateAuth(`{"authorize":{"challenge":"4fafe590402244d09aaa1f51952ec99a","status":"CHALL"}}`, nil))
+	require.Error(validateAuth(`{"LTS":1,"authorize":{"status":"OK"},"streams":{"catalyst_vod_gedhbdhc":{"name":"catalyst_vod_gedhbdhc","source":"http://some-storage-url.com/vod.mp4"},"incomplete list":1}}`, errors.New("HTTP request failed")))
+	require.Error(validateAddTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027761,"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+	require.Error(validateAddTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027761,"triggers":{"RECORDING_END":[{"handler":"http://host.docker.internal:8080/api/mist/trigger","streams":["some-other-stream"],"sync":false}]},"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+	require.Error(validateAddTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027761,"triggers":{"PUSH_END":[{"handler":"http://host.docker.internal:8080/api/mist/trigger","streams":["some-other-stream"],"sync":false}],"RECORDING_END":null},"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+	require.Error(validateDeleteTrigger("catalyst_vod_gedhbdhc", "PUSH_END", `{"LTS":1,"authorize":{"status":"OK"},"config":{"accesslog":"LOG","controller":{"interface":null,"port":null,"username":null},"debug":null,"defaultStream":null,"iid":"IIcEj|Z\\|^lbDbjg","limits":null,"location":{"lat":0.0000000000,"lon":0.0000000000,"name":""},"prometheus":"koekjes","protocols":[{"connector":"AAC","online":"Enabled"},{"connector":"CMAF","online":"Enabled"},{"connector":"DTSC","online":1},{"connector":"EBML","online":"Enabled"},{"connector":"FLV","online":"Enabled"},{"connector":"H264","online":"Enabled"},{"connector":"HDS","online":"Enabled"},{"connector":"HLS","online":1},{"connector":"HTTP","online":1},{"connector":"HTTPTS","online":"Enabled"},{"connector":"JSON","online":"Enabled"},{"connector":"MP3","online":"Enabled"},{"connector":"MP4","online":"Enabled"},{"connector":"OGG","online":"Enabled"},{"connector":"RTMP","online":1},{"connector":"RTSP","online":1},{"connector":"SDP","online":"Enabled"},{"connector":"SRT","online":"Enabled"},{"connector":"TSSRT","online":1},{"connector":"WAV","online":"Enabled"},{"connector":"WebRTC","online":"Enabled"},{"connector":null,"online":"Missing connector name"}],"serverid":null,"sessionInputMode":"14","sessionOutputMode":"14","sessionStreamInfoMode":"1","sessionUnspecifiedMode":"0","sessionViewerMode":"14","sidMode":"0","time":1660027761,"triggers":{"PUSH_END":[{"handler":"http://host.docker.internal:8080/api/mist/trigger","streams":["catalyst_vod_gedhbdhc"],"sync":false}],"RECORDING_END":null},"trustedproxy":[],"version":"eb84bc4ba743885734c60b312ca97ed07311d86f Generic_64"}}`, nil))
+}
+
+func TestItCanParseAMistStreamStatus(t *testing.T) {
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/json_some-stream-name.js", r.URL.Path)
+
+		_, err := w.Write([]byte(mistResponse))
+		require.NoError(t, err)
+	}))
+	defer svr.Close()
+
+	mc := &MistClient{
+		HttpReqUrl: svr.URL,
+	}
+
+	msi, err := mc.GetStreamInfo("some-stream-name")
+	require.NoError(t, err)
+
+	// Check a few fields to confirm the JSON parsing has worked
+	require.Equal(t, msi.Height, 720)
+	require.Equal(t, msi.Meta.Tracks["audio_AAC_2ch_44100hz_1"].Bps, 14000)
+	require.Equal(t, msi.Source[0].Relurl, "catalyst_vod_dhggaaab.sdp?tkn=2369431652")
+}
+
+func TestItCanParseAMistStreamErrorStatus(t *testing.T) {
+	status := `{"error":"Stream is booting"}`
+
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/json_some-stream-name.js", r.URL.Path)
+
+		_, err := w.Write([]byte(status))
+		require.NoError(t, err)
+	}))
+	defer svr.Close()
+
+	mc := &MistClient{
+		HttpReqUrl: svr.URL,
+	}
+
+	_, err := mc.GetStreamInfo("some-stream-name")
+	require.EqualError(t, err, "Stream is booting")
+}
+
+func TestItRetriesFailingRequests(t *testing.T) {
+	var retries = 0
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/json_some-stream-name.js", r.URL.Path)
+
+		var response string
+
+		if retries < 2 {
+			response = ""
+			retries++
+			w.WriteHeader(http.StatusBadGateway)
+		} else {
+			response = mistResponse
+		}
+
+		_, err := w.Write([]byte(response))
+		require.NoError(t, err)
+	}))
+	defer svr.Close()
+
+	mc := &MistClient{
+		HttpReqUrl: svr.URL,
+	}
+
+	_, err := mc.GetStreamInfo("some-stream-name")
+	require.NoError(t, err)
+	require.Equal(t, 2, retries)
+}
+
+func TestItFailsWhenMaxRetriesReached(t *testing.T) {
+	var retries = 0
+	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/json_some-stream-name.js", r.URL.Path)
+
+		retries++
+		w.WriteHeader(http.StatusBadGateway)
+		_, err := w.Write([]byte(""))
+		require.NoError(t, err)
+	}))
+	defer svr.Close()
+
+	mc := &MistClient{
+		HttpReqUrl: svr.URL,
+	}
+
+	_, err := mc.GetStreamInfo("some-stream-name")
+	require.Equal(t, 3, retries)
+	require.Error(t, err)
+}
+
+var mistResponse = `{
+	"height": 720,
+	"meta": {
+		"bframes": 1,
+		"tracks": {
+		"audio_AAC_2ch_44100hz_1": {
+			"bps": 14000,
+			"channels": 2,
+			"codec": "AAC",
+			"firstms": 0,
+			"idx": 1,
+			"init": "\u0012\u0010",
+			"lastms": 596450,
+			"maxbps": 14247,
+			"rate": 44100,
+			"size": 16,
+			"trackid": 2,
+			"type": "audio"
+		},
+		"video_H264_1280x720_0fps_0": {
+			"bframes": 1,
+			"bps": 296627,
+			"codec": "H264",
+			"firstms": 0,
+			"fpks": 0,
+			"height": 720,
+			"idx": 0,
+			"init": "\u0001d\u0000",
+			"lastms": 596416,
+			"maxbps": 814800,
+			"trackid": 1,
+			"type": "video",
+			"width": 1280
+		}
+		},
+		"version": 4,
+		"vod": 1
+	},
+	"selver": 2,
+	"source": [
+		{
+		"priority": 11,
+		"relurl": "catalyst_vod_dhggaaab.sdp?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "html5/application/sdp",
+		"url": "https://localhost/catalyst_vod_dhggaaab.sdp?tkn=2369431652"
+		},
+		{
+		"hrn": "HLS (TS)",
+		"priority": 9,
+		"relurl": "hls/catalyst_vod_dhggaaab/index.m3u8?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "html5/application/vnd.apple.mpegurl",
+		"url": "http://localhost:8081/hls/catalyst_vod_dhggaaab/index.m3u8?tkn=2369431652"
+		},
+		{
+		"hrn": "MKV progressive",
+		"priority": 9,
+		"relurl": "catalyst_vod_dhggaaab.webm?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "html5/video/webm",
+		"url": "https://localhost/catalyst_vod_dhggaaab.webm?tkn=2369431652"
+		},
+		{
+		"hrn": "HLS (TS)",
+		"priority": 9,
+		"relurl": "hls/catalyst_vod_dhggaaab/index.m3u8?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "html5/application/vnd.apple.mpegurl",
+		"url": "https://localhost/hls/catalyst_vod_dhggaaab/index.m3u8?tkn=2369431652"
+		},
+		{
+		"hrn": "RTMP",
+		"player_url": "/flashplayer.swf",
+		"priority": 7,
+		"relurl": "play/catalyst_vod_dhggaaab?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "flash/10",
+		"url": "rtmp://localhost/play/catalyst_vod_dhggaaab?tkn=2369431652"
+		},
+		{
+		"hrn": "Flash Dynamic (HDS)",
+		"player_url": "/flashplayer.swf",
+		"priority": 6,
+		"relurl": "dynamic/catalyst_vod_dhggaaab/manifest.f4m?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "flash/11",
+		"url": "https://localhost/dynamic/catalyst_vod_dhggaaab/manifest.f4m?tkn=2369431652"
+		},
+		{
+		"hrn": "FLV progressive",
+		"player_url": "/oldflashplayer.swf",
+		"priority": 5,
+		"relurl": "catalyst_vod_dhggaaab.flv?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "flash/7",
+		"url": "https://localhost/catalyst_vod_dhggaaab.flv?tkn=2369431652"
+		},
+		{
+		"hrn": "RTSP",
+		"priority": 2,
+		"relurl": "catalyst_vod_dhggaaab?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "rtsp",
+		"url": "rtsp://localhost:5554/catalyst_vod_dhggaaab?tkn=2369431652"
+		},
+		{
+		"hrn": "TS HTTP progressive",
+		"priority": 1,
+		"relurl": "catalyst_vod_dhggaaab.ts?tkn=2369431652",
+		"simul_tracks": 2,
+		"total_matches": 2,
+		"type": "html5/video/mpeg",
+		"url": "https://localhost/catalyst_vod_dhggaaab.ts?tkn=2369431652"
+		},
+		{
+		"hrn": "AAC progressive",
+		"priority": 8,
+		"relurl": "catalyst_vod_dhggaaab.aac?tkn=2369431652",
+		"simul_tracks": 1,
+		"total_matches": 1,
+		"type": "html5/audio/aac",
+		"url": "https://localhost/catalyst_vod_dhggaaab.aac?tkn=2369431652"
+		},
+		{
+		"hrn": "Raw WebSocket",
+		"priority": 2,
+		"relurl": "catalyst_vod_dhggaaab.h264?tkn=2369431652",
+		"simul_tracks": 1,
+		"total_matches": 1,
+		"type": "ws/video/raw",
+		"url": "wss://localhost/catalyst_vod_dhggaaab.h264?tkn=2369431652"
+		},
+		{
+		"hrn": "Raw progressive",
+		"priority": 1,
+		"relurl": "catalyst_vod_dhggaaab.h264?tkn=2369431652",
+		"simul_tracks": 1,
+		"total_matches": 1,
+		"type": "html5/video/raw",
+		"url": "https://localhost/catalyst_vod_dhggaaab.h264?tkn=2369431652"
+		}
+	],
+	"type": "vod",
+	"width": 1280
+	}`

--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -1,0 +1,51 @@
+package misttriggers
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/livepeer/catalyst-api/errors"
+)
+
+type PushEndPayload struct {
+	StreamName        string
+	Destination       string
+	ActualDestination string
+	Last10LogLines    string
+	PushStatus        string
+}
+
+func ParsePushEndPayload(payload string) (PushEndPayload, error) {
+	lines := strings.Split(strings.TrimSuffix(payload, "\n"), "\n")
+	if len(lines) != 6 {
+		return PushEndPayload{}, fmt.Errorf("expected 6 lines in PUSH_END payload but got %d. Payload: %s", len(lines), payload)
+	}
+
+	return PushEndPayload{
+		StreamName:        lines[1],
+		Destination:       lines[2],
+		ActualDestination: lines[3],
+		Last10LogLines:    lines[4],
+		PushStatus:        lines[5],
+	}, nil
+}
+
+// TriggerPushEnd responds to PUSH_END trigger
+// This trigger is run whenever an outgoing push stops, for any reason.
+// This trigger is stream-specific and non-blocking. The payload for this trigger is multiple lines,
+// each separated by a single newline character (without an ending newline), containing data:
+//
+//	push ID (integer)
+//	stream name (string)
+//	target URI, before variables/triggers affected it (string)
+//	target URI, afterwards, as actually used (string)
+//	last 10 log messages (JSON array string)
+//	most recent push status (JSON object string)
+func (d *MistCallbackHandlersCollection) TriggerPushEnd(w http.ResponseWriter, req *http.Request, payload []byte) {
+	_, err := ParsePushEndPayload(string(payload))
+	if err != nil {
+		errors.WriteHTTPBadRequest(w, "Error parsing PUSH_END payload", err)
+		return
+	}
+}

--- a/handlers/misttriggers/push_end_test.go
+++ b/handlers/misttriggers/push_end_test.go
@@ -1,0 +1,24 @@
+package misttriggers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItErrorsOnBadPushEndPayload(t *testing.T) {
+	_, err := ParsePushEndPayload("only\nthree\nlines\n")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected 6 lines in PUSH_END payload but got 3")
+}
+
+func TestItCanParseAValidPushEndPayload(t *testing.T) {
+	var payload = "1\n2\n3\n4\n5\n6"
+	p, err := ParsePushEndPayload(payload)
+	require.NoError(t, err)
+	require.Equal(t, p.StreamName, "2")
+	require.Equal(t, p.Destination, "3")
+	require.Equal(t, p.ActualDestination, "4")
+	require.Equal(t, p.Last10LogLines, "5")
+	require.Equal(t, p.PushStatus, "6")
+}

--- a/handlers/misttriggers/push_out_start.go
+++ b/handlers/misttriggers/push_out_start.go
@@ -1,0 +1,30 @@
+package misttriggers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/livepeer/catalyst-api/errors"
+)
+
+// TriggerPushOutStart responds to PUSH_OUT_START trigger
+// This trigger is run right before an outgoing push is started. This trigger is stream-specific and must be blocking.
+// The payload for this trigger is multiple lines, each separated by a single newline character (without an ending newline), containing data:
+//
+// stream name (string)
+// push target URI (string)
+func (d *MistCallbackHandlersCollection) TriggerPushOutStart(w http.ResponseWriter, req *http.Request, payload []byte) {
+	lines := strings.Split(strings.TrimSuffix(string(payload), "\n"), "\n")
+	if len(lines) != 2 {
+		errors.WriteHTTPBadRequest(w, "Bad request payload", fmt.Errorf("unknown payload '%s'", string(payload)))
+		return
+	}
+	// streamName := lines[0]
+	destination := lines[1]
+	var destinationToReturn = destination
+	if _, err := w.Write([]byte(destinationToReturn)); err != nil {
+		log.Printf("TriggerPushOutStart failed to send rewritten url: %v", err)
+	}
+}

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 )
@@ -13,9 +14,16 @@ import (
 const (
 	TRIGGER_PUSH_END       = "PUSH_END"
 	TRIGGER_PUSH_OUT_START = "PUSH_OUT_START"
+	TRIGGER_STREAM_BUFFER  = "STREAM_BUFFER"
 )
 
-type MistCallbackHandlersCollection struct{}
+type MistCallbackHandlersCollection struct {
+	cli *config.Cli
+}
+
+func NewMistCallbackHandlersCollection(cli config.Cli) *MistCallbackHandlersCollection {
+	return &MistCallbackHandlersCollection{cli: &cli}
+}
 
 // Trigger dispatches request to mapped method according to trigger name
 // Only single trigger callback is allowed on Mist.
@@ -41,6 +49,8 @@ func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
 			d.TriggerPushOutStart(w, req, payload)
 		case TRIGGER_PUSH_END:
 			d.TriggerPushEnd(w, req, payload)
+		case TRIGGER_STREAM_BUFFER:
+			d.TriggerStreamBuffer(w, req, payload)
 		default:
 			errors.WriteHTTPBadRequest(w, "Unsupported X-Trigger", fmt.Errorf("unknown trigger '%s'", triggerName))
 			return

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -1,0 +1,49 @@
+package misttriggers
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/errors"
+	"github.com/livepeer/catalyst-api/log"
+)
+
+const (
+	TRIGGER_PUSH_END       = "PUSH_END"
+	TRIGGER_PUSH_OUT_START = "PUSH_OUT_START"
+)
+
+type MistCallbackHandlersCollection struct{}
+
+// Trigger dispatches request to mapped method according to trigger name
+// Only single trigger callback is allowed on Mist.
+// All created streams and our handlers (segmenting, transcoding, et.) must share this endpoint.
+// If handler logic grows more complicated we may consider adding dispatch mechanism here.
+func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		payload, err := io.ReadAll(req.Body)
+		if err != nil {
+			errors.WriteHTTPBadRequest(w, "Cannot read trigger payload", err)
+			return
+		}
+
+		triggerName := req.Header.Get("X-Trigger")
+		log.LogNoRequestID(
+			"Received Mist Trigger",
+			"trigger_name", triggerName,
+			"payload", log.RedactLogs(string(payload), "\n"),
+		)
+
+		switch triggerName {
+		case TRIGGER_PUSH_OUT_START:
+			d.TriggerPushOutStart(w, req, payload)
+		case TRIGGER_PUSH_END:
+			d.TriggerPushEnd(w, req, payload)
+		default:
+			errors.WriteHTTPBadRequest(w, "Unsupported X-Trigger", fmt.Errorf("unknown trigger '%s'", triggerName))
+			return
+		}
+	}
+}

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -20,7 +20,6 @@ import (
 	"github.com/livepeer/catalyst-api/mapic/apis/mist"
 	mistapi "github.com/livepeer/catalyst-api/mapic/apis/mist"
 	"github.com/livepeer/catalyst-api/mapic/metrics"
-	"github.com/livepeer/catalyst-api/mapic/misttriggers"
 	"github.com/livepeer/catalyst-api/mapic/model"
 	"github.com/livepeer/catalyst-api/mapic/utils"
 	"github.com/livepeer/go-api-client"
@@ -266,16 +265,6 @@ func (mc *mac) triggerConnClose(w http.ResponseWriter, r *http.Request, lines []
 	}
 	w.WriteHeader(http.StatusOK)
 	w.Write([]byte("yes"))
-	return true
-}
-
-func (mc *mac) triggerStreamBuffer(w http.ResponseWriter, r *http.Request, lines []string, rawRequest string) bool {
-	err := misttriggers.TriggerStreamBuffer(mc.config, r, lines)
-	if err != nil {
-		glog.Errorf("Error handling stream buffer trigger error=%q", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		return false
-	}
 	return true
 }
 
@@ -688,8 +677,6 @@ func (mc *mac) HandleDefaultStreamTrigger() httprouter.Handle {
 			doLogRequestEnd = mc.triggerLiveBandwidth(w, r)
 		case "CONN_CLOSE":
 			doLogRequestEnd = mc.triggerConnClose(w, r, lines, bs)
-		case "STREAM_BUFFER":
-			doLogRequestEnd = mc.triggerStreamBuffer(w, r, lines, bs)
 		case "PUSH_REWRITE":
 			doLogRequestEnd = mc.triggerPushRewrite(w, r, lines, bs)
 		case "LIVE_TRACK_LIST":


### PR DESCRIPTION
Needed for multistreaming improvements and other planned integrations with Mist. Brings back the PUSH_OUT_START and PUSH_END triggers, and moves the STREAM_BUFFER trigger over to the `handlers/misttriggers` folder where it's needed.

I originally did a more comprehensive refactor where `streamHealthClient` became its own thing in the `clients` directory but got stuck on a circular dependency; streamHealthClient needed to know about `misttriggers.StreamHealthPayload` and the stream buffer handler needed to know about the `streamHealthClient`. I still thing a refactor along those lines is more better, but this is an incremental improvement in the meantime.