### PR TITLE
Fix recordings

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -29,7 +29,7 @@ func DownloadRenditionManifest(requestID, sourceManifestOSURL string) (m3u8.Medi
 
 	dStorage := NewDStorageDownload()
 	err := backoff.Retry(func() error {
-		rc, err := getFile(context.Background(), requestID, sourceManifestOSURL, dStorage)
+		rc, err := GetFile(context.Background(), requestID, sourceManifestOSURL, dStorage)
 		if err != nil {
 			return fmt.Errorf("error downloading manifest: %s", err)
 		}

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -196,7 +196,7 @@ func UploadRetryBackoff() backoff.BackOff {
 }
 
 func SignURL(u *url.URL) (string, error) {
-	if u.Scheme == "" || u.Scheme == "file" { // not compatible with presigning
+	if u.Scheme == "" || u.Scheme == "file" || u.Scheme == "http" || u.Scheme == "https" { // not an OS url
 		return u.String(), nil
 	}
 	driver, err := drivers.ParseOSURL(u.String(), true)

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -3,6 +3,7 @@ package transcode
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"net/url"
 	"os"
@@ -325,7 +326,9 @@ func transcodeSegment(
 
 	var tr clients.TranscodeResult
 	err := backoff.Retry(func() error {
-		rc, err := clients.DownloadOSURL(segment.Input.URL.String())
+		ctx, cancel := context.WithTimeout(context.Background(), clients.MaxCopyFileDuration)
+		defer cancel()
+		rc, err := clients.GetFile(ctx, transcodeRequest.RequestID, segment.Input.URL.String(), nil)
 		if err != nil {
 			return fmt.Errorf("failed to download source segment %q: %s", segment.Input, err)
 		}


### PR DESCRIPTION
We want to pass the plain HTTP input URL through for recordings because this is the simplest way to allow mediaconvert to read the input (in case of livepeer pipeline failures). Some parts of the code were expecting an OS URL though so this is what is fixed in this PR, to allow plain HTTP URLs to work too.