### PR TITLE
Fix recordings source playback

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -95,6 +95,9 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile *url.URL, decrypto
 
 func getSignedURL(osTransferURL *url.URL) (string, error) {
 	// check if plain https is accessible, if not then the bucket must be private and we need to generate a signed url
+	// in most cases signed urls work fine as input but in the edge case where we have to fall back to mediaconvert
+	// for an hls input (for recordings) the signed url will fail because mediaconvert tries to append the same
+	// signing queryparams from the manifest url for the segment requests
 	httpURL := *osTransferURL
 	httpURL.User = nil
 	httpURL.Scheme = "https"

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -59,7 +59,7 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile *url.URL, decrypto
 		}
 		log.Log(requestID, "Copied", "bytes", size, "source", inputFile.String(), "dest", osTransferURL.String())
 
-		signedURL, err = SignURL(osTransferURL)
+		signedURL, err = getSignedURL(osTransferURL)
 		if err != nil {
 			return
 		}
@@ -91,6 +91,21 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile *url.URL, decrypto
 	log.Log(requestID, "probed video track:", "container", inputVideoProbe.Format, "codec", videoTrack.Codec, "bitrate", videoTrack.Bitrate, "duration", videoTrack.DurationSec, "w", videoTrack.Width, "h", videoTrack.Height, "pix-format", videoTrack.PixelFormat, "FPS", videoTrack.FPS)
 	log.Log(requestID, "probed audio track", "codec", audioTrack.Codec, "bitrate", audioTrack.Bitrate, "duration", audioTrack.DurationSec, "channels", audioTrack.Channels)
 	return
+}
+
+func getSignedURL(osTransferURL *url.URL) (string, error) {
+	// check if plain https is accessible, if not then the bucket must be private and we need to generate a signed url
+	httpURL := *osTransferURL
+	httpURL.User = nil
+	httpURL.Scheme = "https"
+	signedURL := httpURL.String()
+
+	resp, err := http.Head(signedURL)
+	if err == nil && resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusBadRequest {
+		return signedURL, nil
+	}
+
+	return SignURL(osTransferURL)
 }
 
 func isHLSInput(inputFile *url.URL) bool {
@@ -187,6 +202,7 @@ func CopyAllInputFiles(requestID string, srcInputUrl, dstOutputUrl *url.URL, dec
 
 func isDirectUpload(inputFile *url.URL) bool {
 	return strings.HasSuffix(inputFile.Host, "storage.googleapis.com") &&
+		strings.HasPrefix(inputFile.Path, "/directUpload") &&
 		(inputFile.Scheme == "https" || inputFile.Scheme == "http")
 }
 

--- a/clients/input_copy_test.go
+++ b/clients/input_copy_test.go
@@ -21,7 +21,7 @@ func Test_isDirectUpload(t *testing.T) {
 		{
 			name:      "direct upload w/o directUpload in path",
 			inputFile: "https://lp-us-vod-com.storage.googleapis.com/2697c12g97x2sxn4",
-			want:      true,
+			want:      false,
 		},
 		{
 			name:      "not direct upload w/ directUpload in path",


### PR DESCRIPTION
We need to go back to copying the recording manifest and segments to the playback bucket to allow source playback to work, the playback urls are pointed at this bucket not the recordings one.

To get around the issue we had with mediaconvert reading a signed hls input url (appending the signing queryparams to the segment urls) I am now only generating a signed url when the unsigned version is not accessible.