### PR TITLE
[VID-258][VID-4] remove CONN_CLOSE

### DIFF
--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -26,7 +26,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.Broker) error {
+func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker) error {
 	router := NewCatalystAPIRouterInternal(ctx, cli, vodEngine, mapic, bal, c, broker)
 	server := http.Server{Addr: cli.HTTPInternalAddress, Handler: router}
 	ctx, cancel := context.WithCancel(ctx)
@@ -53,7 +53,7 @@ func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipe
 	return server.Shutdown(ctx)
 }
 
-func NewCatalystAPIRouterInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.Broker) *httprouter.Router {
+func NewCatalystAPIRouterInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker) *httprouter.Router {
 	router := httprouter.New()
 	withLogging := middleware.LogRequest()
 	withAuth := middleware.IsAuthorized

--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -27,7 +27,7 @@ import (
 )
 
 func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker) error {
-	router := NewCatalystAPIRouterInternal(ctx, cli, vodEngine, mapic, bal, c, broker)
+	router := NewCatalystAPIRouterInternal(cli, vodEngine, mapic, bal, c, broker)
 	server := http.Server{Addr: cli.HTTPInternalAddress, Handler: router}
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -53,7 +53,7 @@ func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipe
 	return server.Shutdown(ctx)
 }
 
-func NewCatalystAPIRouterInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker) *httprouter.Router {
+func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker) *httprouter.Router {
 	router := httprouter.New()
 	withLogging := middleware.LogRequest()
 	withAuth := middleware.IsAuthorized
@@ -110,7 +110,7 @@ func NewCatalystAPIRouterInternal(ctx context.Context, cli config.Cli, vodEngine
 	router.GET("/api/pubkey", withLogging(encryptionHandlers.PublicKeyHandler()))
 
 	// Endpoint to receive "Triggers" (callbacks) from Mist
-	router.POST("/api/mist/trigger", withLogging(mistCallbackHandlers.Trigger(ctx)))
+	router.POST("/api/mist/trigger", withLogging(mistCallbackHandlers.Trigger()))
 
 	// Endpoint to receive segments and manifests that ffmpeg produces
 	router.PUT("/api/ffmpeg/:id/:filename", withLogging(ffmpegSegmentingHandlers.NewFile()))

--- a/handlers/misttriggers/broker.go
+++ b/handlers/misttriggers/broker.go
@@ -33,6 +33,8 @@ func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBufferP
 	return b.streamBufferFuncs.Trigger(ctx, payload)
 }
 
+// a funcGroup represents a collection of callback functions such that we can register new
+// callbacks in a thread-safe manner.
 type funcGroup[T TriggerPayload] struct {
 	mutex sync.RWMutex
 	funcs []func(context.Context, *T) error

--- a/handlers/misttriggers/broker.go
+++ b/handlers/misttriggers/broker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/golang/glog"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -14,7 +15,7 @@ import (
 type Broker interface {
 	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 
-	TriggerStreamBuffer(context.Context, *StreamBufferPayload) error
+	TriggerStreamBuffer(context.Context, *StreamBufferPayload)
 }
 
 func NewBroker() Broker {
@@ -29,8 +30,11 @@ func (b *broker) OnStreamBuffer(cb func(context.Context, *StreamBufferPayload) e
 	b.streamBufferFuncs.Register(cb)
 }
 
-func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBufferPayload) error {
-	return b.streamBufferFuncs.Trigger(ctx, payload)
+func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBufferPayload) {
+	err := b.streamBufferFuncs.Trigger(ctx, payload)
+	if err != nil {
+		glog.Errorf("error handling STREAM_BUFFER trigger: %s", err)
+	}
 }
 
 // a funcGroup represents a collection of callback functions such that we can register new

--- a/handlers/misttriggers/broker.go
+++ b/handlers/misttriggers/broker.go
@@ -12,6 +12,20 @@ import (
 // to respond to Mist trigger events without putting all of the application
 // logic into the trigger handling code itself.
 
+// There are three different cases to account for on Mist triggers; and
+// accordingly the TriggerXXX functions have three different signatures:
+// 1. Purely informative, like STREAM_BUFFER. This can't be rejected back
+//    to Mist, so no error signature necessary. All of the callbacks can
+//    be fired in parallel.
+// 2. Allow/deny, like USER_NEW. We either let the new viewer come in
+//    or we kick them out, but there's no return value other than that.
+//    These handlers can be called in parallel too, but any one of them
+//    returning an error will cause an (immediate) trigger rejection.
+// 3. Triggers with response values, like PUSH_REWRITE. These functions need
+//    to return both an error (for rejections) and a string (for responses).
+//    They can't be called in parallel; there really should only be one
+//    handler for these sorts of triggers.
+
 type Broker interface {
 	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 

--- a/handlers/misttriggers/broker.go
+++ b/handlers/misttriggers/broker.go
@@ -1,0 +1,60 @@
+package misttriggers
+
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// Broker provides an interface for allowing multiple components of the app
+// to respond to Mist trigger events without putting all of the application
+// logic into the trigger handling code itself.
+
+type Broker interface {
+	OnStreamBuffer(func(context.Context, *StreamBuffer) error)
+
+	TriggerStreamBuffer(context.Context, *StreamBuffer) error
+}
+
+func NewBroker() Broker {
+	return &broker{}
+}
+
+type broker struct {
+	streamBufferFuncs funcGroup[StreamBuffer]
+}
+
+func (b *broker) OnStreamBuffer(cb func(context.Context, *StreamBuffer) error) {
+	b.streamBufferFuncs.Register(cb)
+}
+
+func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBuffer) error {
+	return b.streamBufferFuncs.Trigger(ctx, payload)
+}
+
+type funcGroup[T TriggerPayload] struct {
+	mutex sync.RWMutex
+	funcs []func(context.Context, *T) error
+}
+
+func (g *funcGroup[T]) Register(cb func(context.Context, *T) error) {
+	g.mutex.Lock()
+	defer g.mutex.Unlock()
+	g.funcs = append(g.funcs, cb)
+}
+
+func (g *funcGroup[T]) Trigger(ctx context.Context, payload *T) error {
+	g.mutex.RLock()
+	defer g.mutex.RUnlock()
+	group, ctx := errgroup.WithContext(ctx)
+	// ...yuck. Is there a better way?
+	for _, cb := range g.funcs {
+		func(cb func(context.Context, *T) error) {
+			group.Go(func() error {
+				return cb(ctx, payload)
+			})
+		}(cb)
+	}
+	return group.Wait()
+}

--- a/handlers/misttriggers/broker.go
+++ b/handlers/misttriggers/broker.go
@@ -12,9 +12,9 @@ import (
 // logic into the trigger handling code itself.
 
 type Broker interface {
-	OnStreamBuffer(func(context.Context, *StreamBuffer) error)
+	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 
-	TriggerStreamBuffer(context.Context, *StreamBuffer) error
+	TriggerStreamBuffer(context.Context, *StreamBufferPayload) error
 }
 
 func NewBroker() Broker {
@@ -22,14 +22,14 @@ func NewBroker() Broker {
 }
 
 type broker struct {
-	streamBufferFuncs funcGroup[StreamBuffer]
+	streamBufferFuncs funcGroup[StreamBufferPayload]
 }
 
-func (b *broker) OnStreamBuffer(cb func(context.Context, *StreamBuffer) error) {
+func (b *broker) OnStreamBuffer(cb func(context.Context, *StreamBufferPayload) error) {
 	b.streamBufferFuncs.Register(cb)
 }
 
-func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBuffer) error {
+func (b *broker) TriggerStreamBuffer(ctx context.Context, payload *StreamBufferPayload) error {
 	return b.streamBufferFuncs.Trigger(ctx, payload)
 }
 

--- a/handlers/misttriggers/push_end.go
+++ b/handlers/misttriggers/push_end.go
@@ -1,6 +1,7 @@
 package misttriggers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -42,7 +43,7 @@ func ParsePushEndPayload(payload string) (PushEndPayload, error) {
 //	target URI, afterwards, as actually used (string)
 //	last 10 log messages (JSON array string)
 //	most recent push status (JSON object string)
-func (d *MistCallbackHandlersCollection) TriggerPushEnd(w http.ResponseWriter, req *http.Request, payload []byte) {
+func (d *MistCallbackHandlersCollection) TriggerPushEnd(ctx context.Context, w http.ResponseWriter, req *http.Request, payload []byte) {
 	_, err := ParsePushEndPayload(string(payload))
 	if err != nil {
 		errors.WriteHTTPBadRequest(w, "Error parsing PUSH_END payload", err)

--- a/handlers/misttriggers/push_out_start.go
+++ b/handlers/misttriggers/push_out_start.go
@@ -1,6 +1,7 @@
 package misttriggers
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net/http"
@@ -15,7 +16,7 @@ import (
 //
 // stream name (string)
 // push target URI (string)
-func (d *MistCallbackHandlersCollection) TriggerPushOutStart(w http.ResponseWriter, req *http.Request, payload []byte) {
+func (d *MistCallbackHandlersCollection) TriggerPushOutStart(ctx context.Context, w http.ResponseWriter, req *http.Request, payload []byte) {
 	lines := strings.Split(strings.TrimSuffix(string(payload), "\n"), "\n")
 	if len(lines) != 2 {
 		errors.WriteHTTPBadRequest(w, "Bad request payload", fmt.Errorf("unknown payload '%s'", string(payload)))

--- a/handlers/misttriggers/stream_buffer_test.go
+++ b/handlers/misttriggers/stream_buffer_test.go
@@ -144,7 +144,7 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 			StreamHealthHookURL: server.URL,
 			APIToken:            "apiToken",
 		},
-		broker: NewBroker(),
+		broker: NewTriggerBroker(),
 	}
 	rr := httptest.NewRecorder()
 	d.TriggerStreamBuffer(context.Background(), rr, req, streamBufferPayloadIssues)

--- a/handlers/misttriggers/stream_buffer_test.go
+++ b/handlers/misttriggers/stream_buffer_test.go
@@ -2,6 +2,7 @@ package misttriggers
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -138,12 +139,15 @@ func TestTriggerStreamBufferE2E(t *testing.T) {
 	req.Header.Set("X-UUID", "session1")
 
 	// Call the TriggerStreamBuffer function
-	d := MistCallbackHandlersCollection{cli: &config.Cli{
-		StreamHealthHookURL: server.URL,
-		APIToken:            "apiToken",
-	}}
+	d := MistCallbackHandlersCollection{
+		cli: &config.Cli{
+			StreamHealthHookURL: server.URL,
+			APIToken:            "apiToken",
+		},
+		broker: NewBroker(),
+	}
 	rr := httptest.NewRecorder()
-	d.TriggerStreamBuffer(rr, req, streamBufferPayloadIssues)
+	d.TriggerStreamBuffer(context.Background(), rr, req, streamBufferPayloadIssues)
 
 	require.Equal(t, rr.Code, 200)
 	require.Len(t, rr.Body.Bytes(), 0)

--- a/handlers/misttriggers/trigger_broker_test.go
+++ b/handlers/misttriggers/trigger_broker_test.go
@@ -1,0 +1,28 @@
+package misttriggers
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItCallsFunctions(t *testing.T) {
+	broker := NewTriggerBroker()
+	mu := sync.Mutex{}
+	calls := 0
+	increment := func(ctx context.Context, payload *StreamBufferPayload) error {
+		require.Equal(t, payload.StreamName, "TestStream")
+		mu.Lock()
+		defer mu.Unlock()
+		calls += 1
+		return fmt.Errorf("something went wrong")
+	}
+	broker.OnStreamBuffer(increment)
+	broker.OnStreamBuffer(increment)
+	broker.OnStreamBuffer(increment)
+	broker.TriggerStreamBuffer(context.Background(), &StreamBufferPayload{StreamName: "TestStream"})
+	require.Equal(t, calls, 3)
+}

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -24,7 +24,7 @@ type MistCallbackHandlersCollection struct {
 }
 
 type TriggerPayload interface {
-	StreamBuffer | PushEndPayload
+	StreamBufferPayload | PushEndPayload
 }
 
 func NewMistCallbackHandlersCollection(cli config.Cli, b Broker) *MistCallbackHandlersCollection {

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -35,7 +35,7 @@ func NewMistCallbackHandlersCollection(cli config.Cli, b TriggerBroker) *MistCal
 // Only single trigger callback is allowed on Mist.
 // All created streams and our handlers (segmenting, transcoding, et.) must share this endpoint.
 // If handler logic grows more complicated we may consider adding dispatch mechanism here.
-func (d *MistCallbackHandlersCollection) Trigger(ctx context.Context) httprouter.Handle {
+func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 		payload, err := io.ReadAll(req.Body)
 		if err != nil {
@@ -49,6 +49,8 @@ func (d *MistCallbackHandlersCollection) Trigger(ctx context.Context) httprouter
 			"trigger_name", triggerName,
 			"payload", log.RedactLogs(string(payload), "\n"),
 		)
+
+		ctx := context.Background()
 
 		switch triggerName {
 		case TRIGGER_PUSH_OUT_START:

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -20,14 +20,14 @@ const (
 
 type MistCallbackHandlersCollection struct {
 	cli    *config.Cli
-	broker Broker
+	broker TriggerBroker
 }
 
 type TriggerPayload interface {
 	StreamBufferPayload | PushEndPayload
 }
 
-func NewMistCallbackHandlersCollection(cli config.Cli, b Broker) *MistCallbackHandlersCollection {
+func NewMistCallbackHandlersCollection(cli config.Cli, b TriggerBroker) *MistCallbackHandlersCollection {
 	return &MistCallbackHandlersCollection{cli: &cli, broker: b}
 }
 

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/crypto"
+	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	mistapiconnector "github.com/livepeer/catalyst-api/mapic"
 	"github.com/livepeer/catalyst-api/middleware"
 	"github.com/livepeer/catalyst-api/pipeline"
@@ -186,9 +187,11 @@ func main() {
 		defer mistCleanupTick.Stop()
 	}
 
+	broker := misttriggers.NewBroker()
+
 	var mapic mistapiconnector.IMac
 	if cli.ShouldMapic() {
-		mapic = mistapiconnector.NewMapic(&cli)
+		mapic = mistapiconnector.NewMapic(&cli, broker)
 	}
 
 	// Start balancer
@@ -215,7 +218,7 @@ func main() {
 	})
 
 	group.Go(func() error {
-		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c)
+		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c, broker)
 	})
 
 	if cli.ShouldMapic() {

--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func main() {
 		defer mistCleanupTick.Stop()
 	}
 
-	broker := misttriggers.NewBroker()
+	broker := misttriggers.NewTriggerBroker()
 
 	var mapic mistapiconnector.IMac
 	if cli.ShouldMapic() {

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -244,7 +244,7 @@ func (mc *mac) triggerConnClose(w http.ResponseWriter, r *http.Request, lines []
 	// TODO FIXME this was a quick hack to unbreak TSSRT and could break at any time.
 	// The right way to solve this is to "Use the STREAM_BUFFER trigger and look for
 	// the EMPTY state field in the payload."
-	if (protocol == "RTMP" && len(lines[3]) > 0) || (protocol == "TSSRT" && len(lines[1]) > 0) {
+	if (protocol == "WebRTC" || protocol == "RTMP" && len(lines[3]) > 0) || (protocol == "TSSRT" && len(lines[1]) > 0) {
 		playbackID := strings.TrimPrefix(lines[0], streamPlaybackPrefix)
 		if mc.baseStreamName != "" && strings.Contains(playbackID, "+") {
 			playbackID = strings.Split(playbackID, "+")[1]

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -235,8 +235,9 @@ func (mc *mac) triggerLiveBandwidth(w http.ResponseWriter, r *http.Request) bool
 	return false
 }
 
-func (mc *mac) handleStreamBuffer(ctx context.Context, payload *misttriggers.StreamBuffer) error {
-	if payload.State != "EMPTY" {
+func (mc *mac) handleStreamBuffer(ctx context.Context, payload *misttriggers.StreamBufferPayload) error {
+	// We only care about connections ending
+	if !payload.IsEmpty() {
 		return nil
 	}
 

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -128,7 +128,7 @@ type (
 		mistStreamSource          string
 		mistHardcodedBroadcasters string
 		config                    *config.Cli
-		broker                    misttriggers.Broker
+		broker                    misttriggers.TriggerBroker
 	}
 )
 

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -17,6 +17,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/config"
+	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/mapic/apis/mist"
 	mistapi "github.com/livepeer/catalyst-api/mapic/apis/mist"
 	"github.com/livepeer/catalyst-api/mapic/metrics"
@@ -127,6 +128,7 @@ type (
 		mistStreamSource          string
 		mistHardcodedBroadcasters string
 		config                    *config.Cli
+		broker                    misttriggers.Broker
 	}
 )
 
@@ -136,6 +138,8 @@ func (mc *mac) Start(ctx context.Context) error {
 	// todo: you're not supposed to store these...
 	mc.ctx = ctx
 	mc.cancel = cancel
+
+	mc.broker.OnStreamBuffer(mc.handleStreamBuffer)
 
 	lapi, _ := api.NewAPIClientGeolocated(api.ClientOptions{
 		Server:      mc.config.APIServer,
@@ -231,41 +235,30 @@ func (mc *mac) triggerLiveBandwidth(w http.ResponseWriter, r *http.Request) bool
 	return false
 }
 
-func (mc *mac) triggerConnClose(w http.ResponseWriter, r *http.Request, lines []string, rawRequest string) bool {
-	if len(lines) < 3 {
-		glog.Errorf("Expected 3 lines, got %d, request \n%s", len(lines), rawRequest)
-		w.WriteHeader(http.StatusBadRequest)
-		w.Write([]byte("false"))
-		return false
+func (mc *mac) handleStreamBuffer(ctx context.Context, payload *misttriggers.StreamBuffer) error {
+	if payload.State != "EMPTY" {
+		return nil
 	}
-	protocol := lines[2]
-	// RTMP PUSH_END sends CONN_CLOSE too, but it has empty last line
-	// TSSRT PUSH_END also sends CONN_CLOSE, but it has an empty _second_ line.
-	// TODO FIXME this was a quick hack to unbreak TSSRT and could break at any time.
-	// The right way to solve this is to "Use the STREAM_BUFFER trigger and look for
-	// the EMPTY state field in the payload."
-	if (protocol == "WebRTC" || protocol == "RTMP" && len(lines[3]) > 0) || (protocol == "TSSRT" && len(lines[1]) > 0) {
-		playbackID := strings.TrimPrefix(lines[0], streamPlaybackPrefix)
-		if mc.baseStreamName != "" && strings.Contains(playbackID, "+") {
-			playbackID = strings.Split(playbackID, "+")[1]
-		}
-		if info, ok := mc.getStreamInfoLogged(playbackID); ok {
-			glog.Infof("Setting stream's protocol=%s manifestID=%s playbackID=%s active status to false", protocol, info.id, playbackID)
-			_, err := mc.lapi.SetActive(info.id, false, info.startedAt)
-			if err != nil {
-				glog.Error(err)
-			}
-			mc.emitStreamStateEvent(info.stream, data.StreamState{Active: false})
-			info.mu.Lock()
-			info.stopped = true
-			info.mu.Unlock()
-			mc.removeInfoDelayed(playbackID, info.done)
-			metrics.StopStream(true)
-		}
+
+	playbackID := payload.StreamName
+	if mc.baseStreamName != "" && strings.Contains(playbackID, "+") {
+		playbackID = strings.Split(playbackID, "+")[1]
 	}
-	w.WriteHeader(http.StatusOK)
-	w.Write([]byte("yes"))
-	return true
+	if info, ok := mc.getStreamInfoLogged(playbackID); ok {
+		glog.Infof("Setting stream's manifestID=%s playbackID=%s active status to false", info.id, playbackID)
+		_, err := mc.lapi.SetActive(info.id, false, info.startedAt)
+		if err != nil {
+			glog.Error(err)
+		}
+		mc.emitStreamStateEvent(info.stream, data.StreamState{Active: false})
+		info.mu.Lock()
+		info.stopped = true
+		info.mu.Unlock()
+		mc.removeInfoDelayed(playbackID, info.done)
+		metrics.StopStream(true)
+	}
+
+	return nil
 }
 
 func (mc *mac) triggerDefaultStream(w http.ResponseWriter, r *http.Request, lines []string, trigger string) bool {
@@ -672,8 +665,6 @@ func (mc *mac) HandleDefaultStreamTrigger() httprouter.Handle {
 			doLogRequestEnd = mc.triggerDefaultStream(w, r, lines, trigger)
 		case "LIVE_BANDWIDTH":
 			doLogRequestEnd = mc.triggerLiveBandwidth(w, r)
-		case "CONN_CLOSE":
-			doLogRequestEnd = mc.triggerConnClose(w, r, lines, bs)
 		case "PUSH_REWRITE":
 			doLogRequestEnd = mc.triggerPushRewrite(w, r, lines, bs)
 		case "LIVE_TRACK_LIST":
@@ -789,7 +780,6 @@ func (mc *mac) SetupTriggers(ownURI string) error {
 	if mc.checkBandwidth {
 		added = mc.addTrigger(triggers, "LIVE_BANDWIDTH", ownURI, "false", "100000", true) || added
 	}
-	added = mc.addTrigger(triggers, "CONN_CLOSE", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "STREAM_BUFFER", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "LIVE_TRACK_LIST", ownURI, "", "", false) || added
 	added = mc.addTrigger(triggers, "PUSH_OUT_START", ownURI, "", "", false) || added

--- a/mapic/start_mapic.go
+++ b/mapic/start_mapic.go
@@ -2,11 +2,12 @@ package mistapiconnector
 
 import (
 	"github.com/livepeer/catalyst-api/config"
+	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/mapic/metrics"
 	"github.com/livepeer/catalyst-api/mapic/model"
 )
 
-func NewMapic(cli *config.Cli) IMac {
+func NewMapic(cli *config.Cli, broker misttriggers.Broker) IMac {
 	mc := &mac{
 		config:                    cli,
 		nodeID:                    cli.NodeName,
@@ -17,6 +18,7 @@ func NewMapic(cli *config.Cli) IMac {
 		ownRegion:                 cli.OwnRegion,
 		mistStreamSource:          cli.MistStreamSource,
 		mistHardcodedBroadcasters: cli.MistHardcodedBroadcasters,
+		broker:                    broker,
 	}
 	metrics.InitCensus(mc.config.NodeName, model.Version, "mistconnector")
 	return mc

--- a/mapic/start_mapic.go
+++ b/mapic/start_mapic.go
@@ -7,7 +7,7 @@ import (
 	"github.com/livepeer/catalyst-api/mapic/model"
 )
 
-func NewMapic(cli *config.Cli, broker misttriggers.Broker) IMac {
+func NewMapic(cli *config.Cli, broker misttriggers.TriggerBroker) IMac {
 	mc := &mac{
 		config:                    cli,
 		nodeID:                    cli.NodeName,

--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -34,6 +34,11 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.wroteHeader = true
 }
 
+func (rw *responseWriter) Flush() {
+	flusher := rw.ResponseWriter.(http.Flusher)
+	flusher.Flush()
+}
+
 func LogAndMetrics(metric *prometheus.SummaryVec) func(httprouter.Handle) httprouter.Handle {
 	return logRequest(metric)
 }


### PR DESCRIPTION
Adds a `Broker` interface responsible for dispatching Mist events to other parts of the code. If some part (like mapic) needs to handle an event, it can be passed the Broker on initialization and use it something like [this](https://github.com/livepeer/catalyst-api/pull/737/files#diff-07d76f8f8ce6678348918ef729dbe84cf0bea01df42fc4c84e0c2aabf8dd8ce4R142).

Also a bonus commit to once again fix the `reject()` logic for webhooks! I swear I had tested and had it working but apparently not.