### PR TITLE
Single download pipeline - implement request param to make a source file copy

### DIFF
--- a/clients/input_copy_test.go
+++ b/clients/input_copy_test.go
@@ -74,7 +74,7 @@ func Test_isHLSInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			inputURL, err := url.Parse(tt.inputFile)
 			require.NoError(t, err)
-			require.Equal(t, tt.want, isHLSInput(inputURL))
+			require.Equal(t, tt.want, IsHLSInput(inputURL))
 		})
 	}
 }

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -23,8 +23,9 @@ import (
 )
 
 type UploadVODRequestOutputLocationOutputs struct {
-	HLS string `json:"hls"`
-	MP4 string `json:"mp4"`
+	HLS       string `json:"hls"`
+	MP4       string `json:"mp4"`
+	SourceMp4 bool   `json:"source_mp4"`
 }
 
 type UploadVODRequestOutputLocation struct {
@@ -90,6 +91,15 @@ func (r UploadVODRequest) getTargetMp4Output() (UploadVODRequestOutputLocation, 
 		}
 	}
 	return UploadVODRequestOutputLocation{}, false
+}
+
+func (r UploadVODRequest) getSourceCopyEnabled() bool {
+	for _, o := range r.OutputLocations {
+		if o.Outputs.SourceMp4 {
+			return true
+		}
+	}
+	return false
 }
 
 func (d *CatalystAPIHandlersCollection) UploadVOD() httprouter.Handle {
@@ -183,6 +193,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 		PipelineStrategy:      uploadVODRequest.PipelineStrategy,
 		TargetSegmentSizeSecs: uploadVODRequest.TargetSegmentSizeSecs,
 		Encryption:            uploadVODRequest.Encryption,
+		SourceCopy:            uploadVODRequest.getSourceCopyEnabled(),
 	})
 
 	respBytes, err := json.Marshal(UploadVODResponse{RequestID: requestID})

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -151,6 +151,28 @@ func TestCoordinatorCatalystDominance(t *testing.T) {
 	require.Zero(len(calls))
 }
 
+func TestCoordinatorSourceCopy(t *testing.T) {
+	require := require.New(t)
+
+	ffmpeg, calls := recordingHandler(nil)
+	external := allFailingHandler(t)
+	coord := NewStubCoordinatorOpts(StrategyCatalystFfmpegDominance, nil, ffmpeg, external, "")
+
+	inputFile, _, cleanup := setupTransferDir(t, coord)
+	defer cleanup()
+	job := testJob
+	job.SourceFile = "file://" + inputFile.Name()
+	job.SourceCopy = true
+	job.HlsTargetURL = coord.SourceOutputURL
+	coord.StartUploadJob(job)
+
+	j := requireReceive(t, calls, 1*time.Second)
+	require.Equal("123", j.RequestID)
+
+	time.Sleep(1 * time.Second)
+	require.Zero(len(calls))
+}
+
 func TestCoordinatorBackgroundJobsStrategies(t *testing.T) {
 	require := require.New(t)
 

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -103,6 +103,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^"(\d+)" transcoded segments and manifests have been written to disk for profiles "([^"]*)" within "(\d+)" seconds$`, stepContext.TranscodedSegmentsWrittenToDiskWithinSeconds)
 	ctx.Step(`^the source playback manifest is written to storage within "(\d+)" seconds$`, stepContext.SourcePlaybackManifestWrittenToDisk)
 	ctx.Step(`^I receive a "([^"]*)" callback within "(\d+)" seconds$`, stepContext.CheckCallback)
+	ctx.Step(`^a source copy (has|has not) been written to disk$`, stepContext.SourceCopyWrittenToDisk)
 
 	ctx.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
 		if app != nil && app.Process != nil {

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -29,8 +29,8 @@ Feature: VOD Streaming
     Then I get an HTTP response with code "400"
     And my "failed" vod request metrics get recorded
 
-Scenario: Submit a video asset for ingestion with the FFMPEG / Livepeer pipeline
-    When I submit to the internal "/api/vod" endpoint with "a valid ffmpeg upload vod request with a custom segment size"
+  Scenario Outline: Submit a video asset for ingestion with the FFMPEG / Livepeer pipeline
+    When I submit to the internal "/api/vod" endpoint with "<payload>"
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And I receive a Request ID in the response body
@@ -40,14 +40,26 @@ Scenario: Submit a video asset for ingestion with the FFMPEG / Livepeer pipeline
     And the source manifest is written to storage within "3" seconds and contains "4" segments
     And the Broadcaster receives "4" segments for transcoding within "10" seconds
     And "4" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "5" seconds
+    And a source copy <source_copy> been written to disk
     And I receive a "success" callback within "20" seconds
 
-Scenario: Submit an HLS manifest for ingestion with the FFMPEG / Livepeer pipeline
-    When I submit to the internal "/api/vod" endpoint with "a valid ffmpeg upload vod request with a source manifest"
+    Examples:
+      | payload                                                                         | source_copy |
+      | a valid ffmpeg upload vod request with a custom segment size                    | has not     |
+      | a valid ffmpeg upload vod request with a custom segment size and source copying | has         |
+
+  Scenario Outline: Submit an HLS manifest for ingestion with the FFMPEG / Livepeer pipeline
+    When I submit to the internal "/api/vod" endpoint with "<payload>"
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And I receive a Request ID in the response body
     And my "successful" vod request metrics get recorded
     And the Broadcaster receives "3" segments for transcoding within "10" seconds
     And "3" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "5" seconds
+    And a source copy has not been written to disk
     And I receive a "success" callback within "20" seconds
+
+    Examples:
+      | payload                                                                     |
+      | a valid ffmpeg upload vod request with a source manifest                    |
+      | a valid ffmpeg upload vod request with a source manifest and source copying |

--- a/test/steps/broadcaster.go
+++ b/test/steps/broadcaster.go
@@ -3,6 +3,7 @@ package steps
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
@@ -160,6 +161,17 @@ func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsEx
 		}
 	}
 
+	return nil
+}
+
+func (s *StepContext) SourceCopyWrittenToDisk(hasBeenWritten string) error {
+	sourceCopyExpected := hasBeenWritten == "has"
+	_, err := os.Stat(filepath.Join(s.TranscodedOutputDir, "video"))
+	if err != nil && sourceCopyExpected {
+		return err
+	} else if err == nil && !sourceCopyExpected {
+		return errors.New("source copy should not have been written")
+	}
 	return nil
 }
 

--- a/test/steps/http.go
+++ b/test/steps/http.go
@@ -96,7 +96,7 @@ func (s *StepContext) postRequest(baseURL, endpoint, payload string) error {
 			return fmt.Errorf("failed to build upload request JSON: %s", err)
 		}
 	}
-	if payload == "a valid ffmpeg upload vod request with a custom segment size" {
+	if strings.HasPrefix(payload, "a valid ffmpeg upload vod request with a custom segment size") {
 		req := DefaultUploadRequest
 		req.URL = "file://" + sourceFile.Name()
 		req.PipelineStrategy = "catalyst_ffmpeg"
@@ -106,7 +106,8 @@ func (s *StepContext) postRequest(baseURL, endpoint, payload string) error {
 				Type: "object_store",
 				URL:  "file://" + destinationDir,
 				Outputs: Output{
-					HLS: "enabled",
+					HLS:       "enabled",
+					SourceMp4: strings.Contains(payload, "and source copying"),
 				},
 			},
 		}
@@ -114,7 +115,7 @@ func (s *StepContext) postRequest(baseURL, endpoint, payload string) error {
 			return fmt.Errorf("failed to build upload request JSON: %s", err)
 		}
 	}
-	if payload == "a valid ffmpeg upload vod request with a source manifest" {
+	if strings.HasPrefix(payload, "a valid ffmpeg upload vod request with a source manifest") {
 		req := DefaultUploadRequest
 		req.URL = "file://" + filepath.Join(sourceManifestDir, "tiny.m3u8")
 		req.PipelineStrategy = "catalyst_ffmpeg"
@@ -123,7 +124,8 @@ func (s *StepContext) postRequest(baseURL, endpoint, payload string) error {
 				Type: "object_store",
 				URL:  "file://" + destinationDir,
 				Outputs: Output{
-					HLS: "enabled",
+					HLS:       "enabled",
+					SourceMp4: strings.Contains(payload, "and source copying"),
 				},
 			},
 		}

--- a/test/steps/upload_request.go
+++ b/test/steps/upload_request.go
@@ -5,8 +5,9 @@ import (
 )
 
 type Output struct {
-	HLS string `json:"hls,omitempty"`
-	MP4 string `json:"mp4,omitempty"`
+	HLS       string `json:"hls,omitempty"`
+	MP4       string `json:"mp4,omitempty"`
+	SourceMp4 bool   `json:"source_mp4"`
 }
 
 type OutputLocation struct {

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -58,7 +58,7 @@ func init() {
 }
 
 func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName string, inputInfo video.InputVideo) ([]video.OutputVideo, int, error) {
-	log.AddContext(transcodeRequest.RequestID, "source", transcodeRequest.SourceFile, "source_manifest", transcodeRequest.SourceManifestURL, "stream_name", streamName)
+	log.AddContext(transcodeRequest.RequestID, "source_manifest", transcodeRequest.SourceManifestURL, "stream_name", streamName)
 	log.Log(transcodeRequest.RequestID, "RunTranscodeProcess (v2) Beginning")
 
 	var segmentsCount = 0

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -84,9 +84,10 @@ func TestProbe(t *testing.T) {
 				Codec:   "h264",
 				Bitrate: 1234521,
 				VideoTrack: VideoTrack{
-					Width:  576,
-					Height: 1024,
-					FPS:    30,
+					Width:       576,
+					Height:      1024,
+					FPS:         30,
+					PixelFormat: "yuv420p",
 				},
 			},
 			{
@@ -94,7 +95,8 @@ func TestProbe(t *testing.T) {
 				Codec:   "aac",
 				Bitrate: 128248,
 				AudioTrack: AudioTrack{
-					Channels: 2,
+					Channels:   2,
+					SampleRate: 44100,
 				},
 			},
 		},

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -48,6 +48,7 @@ type AudioTrack struct {
 	Channels   int `json:"channels,omitempty"`
 	SampleRate int `json:"sample_rate,omitempty"`
 	SampleBits int `json:"sample_bits,omitempty"`
+	BitDepth   int `json:"bit_depth,omitempty"`
 }
 
 type InputTrack struct {


### PR DESCRIPTION
- Moved a few lines of code that decide the copy destination out of `clients/input_copy.go` and into `pipeline/coordinator.go` to be able to reference the `SourceCopy` flag on the job object. If the flag is set we will now copy the source file to the `video` location which task-runner and studio expect.
- Set some missing probe fields so that we can then remove the probing from task-runner