### PR TITLE
test: avoid port collisions

### DIFF
--- a/clients/broadcaster_local.go
+++ b/clients/broadcaster_local.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/video"
 )
 
@@ -20,17 +19,17 @@ type LocalBroadcasterClient struct {
 	broadcasterURL url.URL
 }
 
-func NewLocalBroadcasterClient(broadcasterURL string) (LocalBroadcasterClient, error) {
+func NewLocalBroadcasterClient(broadcasterURL string) (BroadcasterClient, error) {
 	u, err := url.Parse(broadcasterURL)
 	if err != nil {
-		return LocalBroadcasterClient{}, fmt.Errorf("error parsing local broadcaster URL %q: %s", config.DefaultBroadcasterURL, err)
+		return &LocalBroadcasterClient{}, fmt.Errorf("error parsing local broadcaster URL %q: %s", broadcasterURL, err)
 	}
-	return LocalBroadcasterClient{
+	return &LocalBroadcasterClient{
 		broadcasterURL: *u,
 	}, nil
 }
 
-func (c LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error) {
+func (c *LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error) {
 	conf := LivepeerTranscodeConfiguration{
 		TimeoutMultiplier: 10,
 	}

--- a/config/cli.go
+++ b/config/cli.go
@@ -55,6 +55,7 @@ type Cli struct {
 	VodDecryptPrivateKey      string
 	GateURL                   string
 	StreamHealthHookURL       string
+	BroadcasterURL            string
 }
 
 // Return our own URL for callback trigger purposes

--- a/main.go
+++ b/main.go
@@ -56,6 +56,7 @@ func main() {
 	config.URLSliceVarFlag(fs, &cli.ImportIPFSGatewayURLs, "import-ipfs-gateway-urls", "https://vod-import-gtw.mypinata.cloud/ipfs/?pinataGatewayToken={{secrets.LP_PINATA_GATEWAY_TOKEN}},https://w3s.link/ipfs/,https://ipfs.io/ipfs/,https://cloudflare-ipfs.com/ipfs/", "Comma delimited ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from")
 	config.URLSliceVarFlag(fs, &cli.ImportArweaveGatewayURLs, "import-arweave-gateway-urls", "https://arweave.net/", "Comma delimited ordered list of arweave gateways")
 	fs.BoolVar(&cli.MistCleanup, "run-mist-cleanup", true, "Run mist cleanup script")
+	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 
 	// mist-api-connector parameters
 	fs.IntVar(&cli.MistPort, "mist-port", 4242, "Port to connect to Mist")
@@ -168,7 +169,7 @@ func main() {
 
 	// Start the "co-ordinator" that determines whether to send jobs to the Catalyst transcoding pipeline
 	// or an external one
-	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey)
+	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey, cli.BroadcasterURL)
 	if err != nil {
 		glog.Fatalf("Error creating VOD pipeline coordinator: %v", err)
 	}

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -24,6 +24,8 @@ const LocalSourceFilePattern = "sourcevideo*"
 type ffmpeg struct {
 	// The base of where to output source segments to
 	SourceOutputUrl string
+	// Broadcaster for local transcoding
+	Broadcaster clients.BroadcasterClient
 }
 
 func init() {
@@ -139,7 +141,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		}
 	}
 
-	outputs, transcodedSegments, err := transcode.RunTranscodeProcess(transcodeRequest, job.StreamName, inputInfo)
+	outputs, transcodedSegments, err := transcode.RunTranscodeProcess(transcodeRequest, job.StreamName, inputInfo, f.Broadcaster)
 	if err != nil {
 		log.LogError(job.RequestID, "RunTranscodeProcess returned an error", err)
 		return nil, fmt.Errorf("transcoding failed: %w", err)

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/livepeer/catalyst-api/test/steps"
 )
 
-var baseURL = "http://127.0.0.1:8989"
-var baseInternalURL = "http://127.0.0.1:7979"
+var baseURL = "http://127.0.0.1:18989"
+var baseInternalURL = "http://127.0.0.1:17979"
 var sourceOutputDir string
 var app *exec.Cmd
 
@@ -48,7 +48,19 @@ func init() {
 
 func startApp() error {
 	sourceOutputDir = fmt.Sprintf("file://%s/%s/", os.TempDir(), "livepeer/source")
-	app = exec.Command("./app", "-private-bucket", "fixtures/playback-bucket", "-gate-url", "http://localhost:13000/api/access-control/gate", "-source-output", sourceOutputDir)
+	app = exec.Command(
+		"./app",
+		"-http-addr=127.0.0.1:18989",
+		"-http-internal-addr=127.0.0.1:17979",
+		"-cluster-addr=127.0.0.1:19935",
+		"-broadcaster-url=http://127.0.0.1:18935",
+		"-private-bucket",
+		"fixtures/playback-bucket",
+		"-gate-url=http://localhost:13000/api/access-control/gate",
+		"-source-output",
+		sourceOutputDir,
+	)
+
 	outfile, err := os.Create("logs/app.log")
 	if err != nil {
 		return err

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -48,7 +48,7 @@ func init() {
 
 func startApp() error {
 	sourceOutputDir = fmt.Sprintf("file://%s/%s/", os.TempDir(), "livepeer/source")
-	app = exec.Command("./app", "-private-bucket", "fixtures/playback-bucket", "-gate-url", "http://localhost:3000/api/access-control/gate", "-source-output", sourceOutputDir)
+	app = exec.Command("./app", "-private-bucket", "fixtures/playback-bucket", "-gate-url", "http://localhost:13000/api/access-control/gate", "-source-output", sourceOutputDir)
 	outfile, err := os.Create("logs/app.log")
 	if err != nil {
 		return err

--- a/test/features/playback.feature
+++ b/test/features/playback.feature
@@ -2,7 +2,7 @@ Feature: Playback
 
   Background: The app is running
     Given the VOD API is running
-    Given Studio API server is running at "localhost:3000"
+    Given Studio API server is running at "localhost:13000"
 
   Scenario: Master playlist requests
     Given the gate API will allow playback

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -7,7 +7,7 @@ Feature: VOD Streaming
     Given the VOD API is running
     And the Client app is authenticated
     And an object store is available
-    And Studio API server is running at "localhost:3000"
+    And Studio API server is running at "localhost:13000"
     And a Broadcaster is running at "localhost:8935"
     And a callback server is running at "localhost:3333"
     And ffmpeg is available

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -8,7 +8,7 @@ Feature: VOD Streaming
     And the Client app is authenticated
     And an object store is available
     And Studio API server is running at "localhost:13000"
-    And a Broadcaster is running at "localhost:8935"
+    And a Broadcaster is running at "localhost:18935"
     And a callback server is running at "localhost:3333"
     And ffmpeg is available
 

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -116,7 +116,7 @@ func TestItCanTranscode(t *testing.T) {
 	}
 	// Set up a fake Broadcaster that returns the rendition segments we'd expect based on the
 	// transcode request we send in the next step
-	LocalBroadcasterClient = StubBroadcasterClient{
+	localBroadcaster := StubBroadcasterClient{
 		tr: clients.TranscodeResult{
 			Renditions: []*clients.RenditionSegment{
 				{
@@ -155,6 +155,7 @@ func TestItCanTranscode(t *testing.T) {
 				},
 			},
 		},
+		&localBroadcaster,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
The integration tests were making use of ports 3000, 7979, 8989, and 8935. This obviously needs to port conflicts if you try and run `make integration-test` while running a node locally, which is a shame.

I thought it would be a small change, but it turns out making the local broadcaster URL configurable is a little bit larger - needed to update the flow of how that URL and clients are passed down. Not very familiar with those parts of the code, let me know if there's a better way to do it