### PR TITLE
Fix display aspect ratio check

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -385,7 +385,7 @@ func checkDisplayAspectRatio(track video.InputTrack, requestID string) bool {
 	resRatio := float64(track.Width) / float64(track.Height)
 
 	// calculate the difference between the aspect ratio and the real ratio of the resolution, allow up to 20%
-	diff := dar - resRatio
+	diff := math.Abs(dar - resRatio)
 	if (diff / dar) < 0.2 {
 		return true
 	}

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -798,6 +798,27 @@ func Test_checkMistCompatible(t *testing.T) {
 			wantSupported: false,
 		},
 		{
+			name: "incompatible with ffmpeg - display aspect ratio",
+			args: args{
+				strategy: StrategyFallbackExternal,
+				iv: video.InputVideo{
+					Tracks: []video.InputTrack{
+						{
+							Codec: "h264",
+							Type:  video.TrackTypeVideo,
+							VideoTrack: video.VideoTrack{
+								Width:              1920,
+								Height:             1080,
+								DisplayAspectRatio: "9:16",
+							},
+						},
+					},
+				},
+			},
+			want:          StrategyExternalDominance,
+			wantSupported: false,
+		},
+		{
 			name: "compatible with ffmpeg - display aspect ratio only slightly mismatched",
 			args: args{
 				strategy: StrategyFallbackExternal,


### PR DESCRIPTION
This fixes the check to account for negative differences. I should have added the customer example into the unit tests the first time around