### PR TITLE
Probe more segments after segmenting

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -22,7 +22,12 @@ import (
 
 const MaxCopyFileDuration = 2 * time.Hour
 const PresignDuration = 24 * time.Hour
-const LocalSourceFilePattern = "sourcevideo*"
+
+// These probe errors were found in the past on mist recordings but still process fine so we are ignoring them
+var ignoreProbeErrs = []string{
+	"parametric stereo signaled to be not-present but was found in the bitstream",
+	"non-existing pps 0 referenced",
+}
 
 type InputCopier interface {
 	CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL, decryptor *crypto.DecryptionKeys) (video.InputVideo, string, error)
@@ -31,6 +36,12 @@ type InputCopier interface {
 type InputCopy struct {
 	S3    S3
 	Probe video.Prober
+}
+
+func NewInputCopy() *InputCopy {
+	return &InputCopy{
+		Probe: video.Probe{IgnoreErrMessages: ignoreProbeErrs},
+	}
 }
 
 // CopyInputToS3 copies the input video to our S3 transfer bucket and probes the file.

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -174,7 +174,7 @@ func (d *CatalystAPIHandlersCollection) handleUploadVOD(w http.ResponseWriter, r
 		return false, errors.WriteHTTPBadRequest(w, "Invalid request payload", fmt.Errorf("invalid value provided for pipeline strategy: %q", uploadVODRequest.PipelineStrategy))
 	}
 
-	log.Log(requestID, "Received VOD Upload request", "pipeline_strategy", uploadVODRequest.PipelineStrategy, "num_profiles", len(uploadVODRequest.Profiles))
+	log.Log(requestID, "Received VOD Upload request", "pipeline_strategy", uploadVODRequest.PipelineStrategy, "num_profiles", len(uploadVODRequest.Profiles), "hlsTargetURL", hlsTargetURL)
 
 	// Once we're happy with the request, do the rest of the Segmenting stage asynchronously to allow us to
 	// from the API call and free up the HTTP connection

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -200,13 +200,12 @@ func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string,
 		pipeFfmpeg: &ffmpeg{
 			SourceOutputUrl: sourceOutputURL,
 			Broadcaster:     broadcaster,
+			probe:           video.Probe{},
 		},
-		pipeExternal: &external{extTranscoder},
-		Jobs:         cache.New[*JobInfo](),
-		MetricsDB:    metricsDB,
-		InputCopy: &clients.InputCopy{
-			Probe: video.Probe{},
-		},
+		pipeExternal:         &external{extTranscoder},
+		Jobs:                 cache.New[*JobInfo](),
+		MetricsDB:            metricsDB,
+		InputCopy:            clients.NewInputCopy(),
 		VodDecryptPrivateKey: VodDecryptPrivateKey,
 		SourceOutputURL:      sourceOutput,
 	}, nil
@@ -224,7 +223,7 @@ func NewStubCoordinatorOpts(strategy Strategy, statusClient clients.TranscodeSta
 		statusClient = clients.TranscodeStatusFunc(func(tsm clients.TranscodeStatusMessage) error { return nil })
 	}
 	if pipeFfmpeg == nil {
-		pipeFfmpeg = &ffmpeg{SourceOutputUrl: sourceOutputUrl}
+		pipeFfmpeg = &ffmpeg{SourceOutputUrl: sourceOutputUrl, probe: video.Probe{}}
 	}
 	if pipeExternal == nil {
 		pipeExternal = &external{}

--- a/video/probe.go
+++ b/video/probe.go
@@ -15,16 +15,13 @@ import (
 
 var unsupportedVideoCodecList = []string{"mjpeg", "jpeg", "png"}
 
-var ignoreErrMessages = []string{
-	"parametric stereo signaled to be not-present but was found in the bitstream",
-	"non-existing pps 0 referenced",
-}
-
 type Prober interface {
 	ProbeFile(requestID, url string, ffProbeOptions ...string) (InputVideo, error)
 }
 
-type Probe struct{}
+type Probe struct {
+	IgnoreErrMessages []string
+}
 
 func (p Probe) ProbeFile(requestID string, url string, ffProbeOptions ...string) (InputVideo, error) {
 	iv, err := p.runProbe(url, ffProbeOptions...)
@@ -34,7 +31,7 @@ func (p Probe) ProbeFile(requestID string, url string, ffProbeOptions ...string)
 
 	// ignore these probing errors if found and re-run with fatal loglevel to obtain the probe data
 	errMsg := strings.ToLower(err.Error())
-	for _, ignoreMsg := range ignoreErrMessages {
+	for _, ignoreMsg := range p.IgnoreErrMessages {
 		if strings.Contains(errMsg, ignoreMsg) {
 			log.Log(requestID, "ignoring probe error", "err", err)
 			return p.runProbe(url, "-loglevel", "fatal")

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -125,8 +125,8 @@ func TestProbe_VP9(t *testing.T) {
 }
 
 func TestProbe_IgnoreSomeErrors(t *testing.T) {
-	_, err := Probe{}.ProbeFile("requestID", "./fixtures/parametric-stereo-error.mp4")
+	_, err := Probe{IgnoreErrMessages: []string{"parametric stereo signaled to be not-present but was found in the bitstream"}}.ProbeFile("requestID", "./fixtures/parametric-stereo-error.mp4")
 	require.NoError(t, err)
-	_, err = Probe{}.ProbeFile("requestID", "./fixtures/non-existing-pps.ts")
+	_, err = Probe{IgnoreErrMessages: []string{"non-existing pps 0 referenced"}}.ProbeFile("requestID", "./fixtures/non-existing-pps.ts")
 	require.NoError(t, err)
 }

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -198,12 +198,12 @@ func TestCheckUpdatedAlgo(t *testing.T) {
 }
 
 func TestPopulateOutput(t *testing.T) {
-	out, err := PopulateOutput("requestID", Probe{}, "fixtures/parametric-stereo-error.mp4", OutputVideoFile{})
+	out, err := PopulateOutput("requestID", Probe{}, "fixtures/bbb-180rotated.mov", OutputVideoFile{})
 	require.NoError(t, err)
 	require.Equal(t, OutputVideoFile{
-		SizeBytes: 275075,
-		Width:     576,
-		Height:    1024,
-		Bitrate:   315733,
+		SizeBytes: 123542,
+		Width:     416,
+		Height:    240,
+		Bitrate:   414661,
 	}, out)
 }


### PR DESCRIPTION
- We found another case of bad (non-existing PPS 0 referenced) segments so we need to expand the checks to more segments https://linear.app/livepeer/issue/VID-270
- I found that we were ignoring the pps 0 error so I've refactored that to only apply to input videos, since the intention there was to ignore mist recording probe errors
- Included the fix for the other segmenting issue that has been found (audio corruption) https://linear.app/livepeer/issue/VID-287