### PR TITLE
Don't fail to write postgres metrics in fallback pipeline

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -574,6 +574,12 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo, out *HandlerOutput) {
 		return
 	}
 
+	// If it's a fallback, we want a unique Request ID so that it doesn't clash with the row that's already been created for the first pipeline
+	metricsRequestID := job.RequestID
+	if job.InFallbackMode {
+		metricsRequestID = "fb_" + metricsRequestID
+	}
+
 	targetURL := ""
 	if job.HlsTargetURL != nil {
 		targetURL = job.HlsTargetURL.Redacted()
@@ -606,7 +612,7 @@ func (c *Coordinator) sendDBMetrics(job *JobInfo, out *HandlerOutput) {
 		insertDynStmt,
 		time.Now().Unix(),
 		job.startTime.Unix(),
-		job.RequestID,
+		metricsRequestID,
 		job.ExternalID,
 		job.sourceCodecVideo,
 		job.sourceCodecAudio,


### PR DESCRIPTION
We'd swapped from using a different Request ID across primary / fallback becuase of issues with cleaning up the job cache, but this meant we started hitting unique key conflicts when writing the status of the fallback job to Postgres.