### PR TITLE
pod-mon: add script to monitor system usage in-line with catalyst-api

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -32,6 +32,7 @@ type Cli struct {
 	MistLoadBalancerPort      int
 	MistLoadBalancerTemplate  string
 	MistCleanup               bool
+	LogSysUsage               bool
 	AMQPURL                   string
 	OwnRegion                 string
 	APIToken                  string
@@ -84,6 +85,11 @@ func (cli *Cli) ShouldMapic() bool {
 // Should we enable mist-cleanup script to run periodically and delete leaky shm?
 func (cli *Cli) ShouldMistCleanup() bool {
 	return cli.MistCleanup
+}
+
+// Should we enable pod-mon script to run periodically and log system usage stats?
+func (cli *Cli) ShouldLogSysUsage() bool {
+	return cli.LogSysUsage
 }
 
 // Handle some legacy environment variables for zero-downtime catalyst-node migration

--- a/main.go
+++ b/main.go
@@ -57,7 +57,8 @@ func main() {
 	fs.StringVar(&cli.MetricsDBConnectionString, "metrics-db-connection-string", "", "Connection string to use for the metrics Postgres DB. Takes the form: host=X port=X user=X password=X dbname=X")
 	config.URLSliceVarFlag(fs, &cli.ImportIPFSGatewayURLs, "import-ipfs-gateway-urls", "https://vod-import-gtw.mypinata.cloud/ipfs/?pinataGatewayToken={{secrets.LP_PINATA_GATEWAY_TOKEN}},https://w3s.link/ipfs/,https://ipfs.io/ipfs/,https://cloudflare-ipfs.com/ipfs/", "Comma delimited ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from")
 	config.URLSliceVarFlag(fs, &cli.ImportArweaveGatewayURLs, "import-arweave-gateway-urls", "https://arweave.net/", "Comma delimited ordered list of arweave gateways")
-	fs.BoolVar(&cli.MistCleanup, "run-mist-cleanup", true, "Run mist cleanup script")
+	fs.BoolVar(&cli.MistCleanup, "run-mist-cleanup", true, "Run mist-cleanup.sh to cleanup shm")
+	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
 
@@ -186,8 +187,8 @@ func main() {
 		glog.Fatalf("Error creating VOD pipeline coordinator: %v", err)
 	}
 
+	// Start cron style apps to run periodically
 	if cli.ShouldMistCleanup() {
-		// Start cron style apps to run periodically
 		app := "mist-cleanup.sh"
 		// schedule mist-cleanup every 2hrs with a timeout of 15min
 		mistCleanup, err := middleware.NewShell(2*60*60*time.Second, 15*60*time.Second, app)
@@ -196,6 +197,16 @@ func main() {
 		}
 		mistCleanupTick := mistCleanup.RunBg()
 		defer mistCleanupTick.Stop()
+	}
+	if cli.ShouldLogSysUsage() {
+		app := "pod-mon.sh"
+		// schedule pod-mon every 60s with timeout of 15s
+		podMon, err := middleware.NewShell(60*time.Second, 15*time.Second, app)
+		if err != nil {
+			glog.Info("Failed to shell out:", app, err)
+		}
+		podMonTick := podMon.RunBg()
+		defer podMonTick.Stop()
 	}
 
 	broker := misttriggers.NewTriggerBroker()

--- a/scripts/pod-mon.sh
+++ b/scripts/pod-mon.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# pod-mon (aka pod-monitor) is used to log all system level metrics. This script is called
+# periodically via catalyst-api so that resource usage is logged "in-line" with catalyst-api logs.
+# This should make debug usage issues in relation to what catalyst-api is currently doing.
+
+loglevel=1 # 0=debug, 1=info
+script=$(basename "$0")
+pidfile="/var/run/${script}"
+
+# lock so that multiple instances of this script cannot run in parallel
+exec 200>"$pidfile"
+flock -n 200 || exit 1
+pid=$$
+echo $pid 1>&200
+
+log () {
+  local msg="$1"
+  local level="$2"
+  if [ -z "$level" ] || [ "$level" -ge "$loglevel" ] ; then
+    echo "$msg" | sed 's/^/[pod-mon] /' 2>&1
+  fi
+}
+
+# get cpu/mem usage
+top=$(top -b -n 1 -H -o %CPU | head -n 15)
+free=$(free -h)
+# get disk usage
+df=$(df -h)
+tmpusage=$(du -ch --max-depth=1 /tmp | sort -hr)
+
+log "System usage --------"
+log "$top"
+log "Mem usage --------"
+log "$free"
+log "Disk usage --------"
+log "$df"
+log "/tmp usage --------"
+log "$tmpusage"


### PR DESCRIPTION
`pod-mon` (aka pod-monitor) is used to log all system level metrics. This script is called periodically via catalyst-api so that resource usage is logged "in-line" with catalyst-api logs. This should make debug usage issues in relation to what catalyst-api is currently doing.

#\Fix VID-293