### PR TITLE
clients/mist: speak json to the mist api

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"reflect"
 	"sort"
 	"sync"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/metrics"
 )
 
@@ -34,7 +34,7 @@ type MistClient struct {
 
 func NewMistAPIClient(user, password, host string, port int, ownURL string) MistAPIClient {
 	mist := &MistClient{
-		ApiUrl:          fmt.Sprintf("http://%s:%d", host, port),
+		ApiUrl:          fmt.Sprintf("http://%s:%d/api2", host, port),
 		TriggerCallback: ownURL,
 	}
 	return mist
@@ -235,12 +235,12 @@ func (mc *MistClient) sendCommand(command interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	payload := payloadFor(c)
-	req, err := http.NewRequest(http.MethodPost, mc.ApiUrl, bytes.NewBuffer([]byte(payload)))
+	req, err := http.NewRequest(http.MethodPost, mc.ApiUrl, bytes.NewBuffer([]byte(c)))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Add("Content-Type", "application/json")
+	glog.Infof("Mist request url=%s, payload=%s", mc.ApiUrl, c)
 	resp, err := metrics.MonitorRequest(metrics.Metrics.MistClient, mistRetryableClient, req)
 	if err != nil {
 		return "", err
@@ -250,6 +250,7 @@ func (mc *MistClient) sendCommand(command interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	glog.Infof("Mist response: %s", string(body))
 	return string(body), err
 }
 
@@ -259,10 +260,6 @@ func commandToString(command interface{}) (string, error) {
 		return "", err
 	}
 	return string(res), nil
-}
-
-func payloadFor(command string) string {
-	return fmt.Sprintf("command=%s", url.QueryEscape(command))
 }
 
 func (mc *MistClient) sendHttpRequest(streamName string) (string, error) {

--- a/clients/mist_client_test.go
+++ b/clients/mist_client_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -20,27 +19,27 @@ func TestRequestPayload(t *testing.T) {
 		command  interface{}
 	}{
 		{
-			"command=%7B%22addstream%22%3A%7B%22somestream%22%3A%7B%22source%22%3A%22http%3A%2F%2Fsome-storage-url.com%2Fvod.mp4%22%7D%7D%7D",
+			`{"addstream":{"somestream":{"source":"http://some-storage-url.com/vod.mp4"}}}`,
 			commandAddStream("somestream", "http://some-storage-url.com/vod.mp4"),
 		},
 		{
-			"command=%7B%22push_start%22%3A%7B%22stream%22%3A%22somestream%22%2C%22target%22%3A%22http%3A%2F%2Fsome-target-url.com%2Ftarget.mp4%22%7D%7D",
+			`{"push_start":{"stream":"somestream","target":"http://some-target-url.com/target.mp4"}}`,
 			commandPushStart("somestream", "http://some-target-url.com/target.mp4"),
 		},
 		{
-			"command=%7B%22deletestream%22%3A%7B%22somestream%22%3Anull%7D%7D",
+			`{"deletestream":{"somestream":null}}`,
 			commandDeleteStream("somestream"),
 		},
 		{
-			"command=%7B%22nuke_stream%22%3A%22somestream%22%7D",
+			`{"nuke_stream":"somestream"}`,
 			commandNukeStream("somestream"),
 		},
 		{
-			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3A%5B%7B%22handler%22%3A%22http%3A%2F%2Flocalhost%2Fapi%22%2C%22streams%22%3A%5B%22somestream%22%5D%2C%22sync%22%3Afalse%7D%5D%7D%7D%7D",
+			`{"config":{"triggers":{"PUSH_END":[{"handler":"http://localhost/api","streams":["somestream"],"sync":false}]}}}`,
 			commandAddTrigger([]string{"somestream"}, "PUSH_END", "http://localhost/api", Triggers{}, false),
 		},
 		{
-			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3Anull%7D%7D%7D",
+			`{"config":{"triggers":{"PUSH_END":null}}}`,
 			commandDeleteTrigger([]string{"somestream"}, "PUSH_END", Triggers{}),
 		},
 	}
@@ -48,8 +47,7 @@ func TestRequestPayload(t *testing.T) {
 	for _, tt := range tests {
 		c, err := commandToString(tt.command)
 		require.NoError(err)
-		p := payloadFor(c)
-		require.Equal(tt.expected, p)
+		require.Equal(tt.expected, c)
 	}
 }
 
@@ -304,7 +302,7 @@ func TestItCanGetStreamStats(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, string(body), "command="+url.QueryEscape(`{"stats_streams":["clients","lastms"],"push_list":true}`))
+		require.Equal(t, string(body), `{"stats_streams":["clients","lastms"],"push_list":true}`)
 
 		_, err = w.Write([]byte(mistStatsResponse))
 		require.NoError(t, err)


### PR DESCRIPTION
So the bug that we had was actually here

https://github.com/livepeer/catalyst-api/blob/7e08a7d4df0af33c7e371e5f28745571903caa31/clients/mist_client.go#L243

That line was a lie. It wasn't an `application/json` body, it was an `application/x-www-form-urlencoded` body.

But JSON is easier to work with anyway, so @Thulinma [implemented support for JSON bodies on these API calls](https://github.com/livepeer/mistserver/commit/1967f52bfa18e0504e506531760c42e1394be1e6) and this PR switches us to making JSON calls. This needs to roll out at the same time as livepeer/mistserver@1967f52bfa18e0504e506531760c42e1394be1e6.