### PR TITLE
TEMP BRANCH: use application/x-www-form-urlencoded

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -240,7 +240,7 @@ func (mc *MistClient) sendCommand(command interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req.Header.Add("Content-Type", "application/json")
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	resp, err := metrics.MonitorRequest(metrics.Metrics.MistClient, mistRetryableClient, req)
 	if err != nil {
 		return "", err

--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"reflect"
 	"sort"
 	"sync"
 
-	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/metrics"
 )
 
@@ -34,7 +34,7 @@ type MistClient struct {
 
 func NewMistAPIClient(user, password, host string, port int, ownURL string) MistAPIClient {
 	mist := &MistClient{
-		ApiUrl:          fmt.Sprintf("http://%s:%d/api2", host, port),
+		ApiUrl:          fmt.Sprintf("http://%s:%d", host, port),
 		TriggerCallback: ownURL,
 	}
 	return mist
@@ -235,12 +235,12 @@ func (mc *MistClient) sendCommand(command interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	req, err := http.NewRequest(http.MethodPost, mc.ApiUrl, bytes.NewBuffer([]byte(c)))
+	payload := payloadFor(c)
+	req, err := http.NewRequest(http.MethodPost, mc.ApiUrl, bytes.NewBuffer([]byte(payload)))
 	if err != nil {
 		return "", err
 	}
 	req.Header.Add("Content-Type", "application/json")
-	glog.Infof("Mist request url=%s, payload=%s", mc.ApiUrl, c)
 	resp, err := metrics.MonitorRequest(metrics.Metrics.MistClient, mistRetryableClient, req)
 	if err != nil {
 		return "", err
@@ -250,7 +250,6 @@ func (mc *MistClient) sendCommand(command interface{}) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	glog.Infof("Mist response: %s", string(body))
 	return string(body), err
 }
 
@@ -260,6 +259,10 @@ func commandToString(command interface{}) (string, error) {
 		return "", err
 	}
 	return string(res), nil
+}
+
+func payloadFor(command string) string {
+	return fmt.Sprintf("command=%s", url.QueryEscape(command))
 }
 
 func (mc *MistClient) sendHttpRequest(streamName string) (string, error) {

--- a/clients/mist_client_test.go
+++ b/clients/mist_client_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -19,27 +20,27 @@ func TestRequestPayload(t *testing.T) {
 		command  interface{}
 	}{
 		{
-			`{"addstream":{"somestream":{"source":"http://some-storage-url.com/vod.mp4"}}}`,
+			"command=%7B%22addstream%22%3A%7B%22somestream%22%3A%7B%22source%22%3A%22http%3A%2F%2Fsome-storage-url.com%2Fvod.mp4%22%7D%7D%7D",
 			commandAddStream("somestream", "http://some-storage-url.com/vod.mp4"),
 		},
 		{
-			`{"push_start":{"stream":"somestream","target":"http://some-target-url.com/target.mp4"}}`,
+			"command=%7B%22push_start%22%3A%7B%22stream%22%3A%22somestream%22%2C%22target%22%3A%22http%3A%2F%2Fsome-target-url.com%2Ftarget.mp4%22%7D%7D",
 			commandPushStart("somestream", "http://some-target-url.com/target.mp4"),
 		},
 		{
-			`{"deletestream":{"somestream":null}}`,
+			"command=%7B%22deletestream%22%3A%7B%22somestream%22%3Anull%7D%7D",
 			commandDeleteStream("somestream"),
 		},
 		{
-			`{"nuke_stream":"somestream"}`,
+			"command=%7B%22nuke_stream%22%3A%22somestream%22%7D",
 			commandNukeStream("somestream"),
 		},
 		{
-			`{"config":{"triggers":{"PUSH_END":[{"handler":"http://localhost/api","streams":["somestream"],"sync":false}]}}}`,
+			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3A%5B%7B%22handler%22%3A%22http%3A%2F%2Flocalhost%2Fapi%22%2C%22streams%22%3A%5B%22somestream%22%5D%2C%22sync%22%3Afalse%7D%5D%7D%7D%7D",
 			commandAddTrigger([]string{"somestream"}, "PUSH_END", "http://localhost/api", Triggers{}, false),
 		},
 		{
-			`{"config":{"triggers":{"PUSH_END":null}}}`,
+			"command=%7B%22config%22%3A%7B%22triggers%22%3A%7B%22PUSH_END%22%3Anull%7D%7D%7D",
 			commandDeleteTrigger([]string{"somestream"}, "PUSH_END", Triggers{}),
 		},
 	}
@@ -47,7 +48,8 @@ func TestRequestPayload(t *testing.T) {
 	for _, tt := range tests {
 		c, err := commandToString(tt.command)
 		require.NoError(err)
-		require.Equal(tt.expected, c)
+		p := payloadFor(c)
+		require.Equal(tt.expected, p)
 	}
 }
 
@@ -302,7 +304,7 @@ func TestItCanGetStreamStats(t *testing.T) {
 	svr := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		require.NoError(t, err)
-		require.Equal(t, string(body), `{"stats_streams":["clients","lastms"],"push_list":true}`)
+		require.Equal(t, string(body), "command="+url.QueryEscape(`{"stats_streams":["clients","lastms"],"push_list":true}`))
 
 		_, err = w.Write([]byte(mistStatsResponse))
 		require.NoError(t, err)


### PR DESCRIPTION
This ensures a smooth rollout of https://github.com/livepeer/catalyst-api/pull/764 