### PR TITLE
cluster: allow subpaths in protocol urls

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -72,10 +72,15 @@ func (b *BalancerImpl) Start(ctx context.Context) error {
 // wait for the mist LB to be available. can be called multiple times.
 func (b *BalancerImpl) waitForStartup(ctx context.Context) {
 	b.startupOnce.Do(func() {
+		i := 0
 		for {
 			_, err := b.getMistLoadBalancerServers(ctx)
 			if err == nil {
 				return
+			}
+			i += 1
+			if i > 10 {
+				panic("no mist startup!!!!")
 			}
 			time.Sleep(250 * time.Millisecond)
 		}

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net"
 	"net/url"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -240,7 +241,7 @@ func ResolveNodeURL(c Cluster, streamURL string) (string, error) {
 		glog.Error(err)
 		return "", err
 	}
-	u2.Path = u.Path
+	u2.Path = filepath.Join(u2.Path, u.Path)
 	u2.RawQuery = u.RawQuery
 	return u2.String(), nil
 }

--- a/mapic/stats_collector.go
+++ b/mapic/stats_collector.go
@@ -132,8 +132,8 @@ func (c *metricsCollector) collectMetrics(ctx context.Context) error {
 func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *streamMetrics) *data.MediaServerMetricsEvent {
 	info.mu.Lock()
 	defer info.mu.Unlock()
-	multistream := make([]*data.MultistreamTargetMetrics, len(metrics.pushes))
-	for i, push := range metrics.pushes {
+	multistream := []*data.MultistreamTargetMetrics{}
+	for _, push := range metrics.pushes {
 		pushInfo := info.pushStatus[push.OriginalURL]
 		if pushInfo == nil {
 			glog.Infof("Mist exported metrics from unknown push. streamId=%q pushURL=%q", info.id, push.OriginalURL)
@@ -157,10 +157,10 @@ func createMetricsEvent(nodeID, region string, info *streamInfo, metrics *stream
 			}
 			pushInfo.metrics = metrics
 		}
-		multistream[i] = &data.MultistreamTargetMetrics{
+		multistream = append(multistream, &data.MultistreamTargetMetrics{
 			Target:  pushToMultistreamTargetInfo(pushInfo),
 			Metrics: metrics,
-		}
+		})
 	}
 	var stream *data.StreamMetrics
 	if ss := metrics.stream; ss != nil {


### PR DESCRIPTION
Currently we discard the subpath in a protocol redirect. This changes this, allowing us to redirect to, for example, a Mist hosted on a subdirectory like `/mist/hls/stream/index.m3u8`.