### PR TITLE
Local probe on timeout

### DIFF
--- a/clients/file_copy.go
+++ b/clients/file_copy.go
@@ -1,0 +1,128 @@
+package clients
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/livepeer/catalyst-api/crypto"
+	xerrors "github.com/livepeer/catalyst-api/errors"
+	"github.com/livepeer/catalyst-api/log"
+	"github.com/livepeer/go-tools/drivers"
+)
+
+const MaxCopyFileDuration = 2 * time.Hour
+const PresignDuration = 24 * time.Hour
+
+func IsHLSInput(inputFile *url.URL) bool {
+	ext := strings.LastIndex(inputFile.Path, ".")
+	if ext == -1 {
+		return false
+	}
+	return inputFile.Path[ext:] == ".m3u8"
+}
+
+type ByteAccumulatorWriter struct {
+	count int64
+}
+
+func (acc *ByteAccumulatorWriter) Write(p []byte) (int, error) {
+	acc.count += int64(len(p))
+	return 0, nil
+}
+
+func CopyFileWithDecryption(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string, decryptor *crypto.DecryptionKeys) (writtenBytes int64, err error) {
+	dStorage := NewDStorageDownload()
+	err = backoff.Retry(func() error {
+		// currently this timeout is only used for http downloads in the getFileHTTP function when it calls http.NewRequestWithContext
+		ctx, cancel := context.WithTimeout(ctx, MaxCopyFileDuration)
+		defer cancel()
+
+		byteAccWriter := ByteAccumulatorWriter{count: 0}
+		defer func() { writtenBytes = byteAccWriter.count }()
+
+		var c io.ReadCloser
+		c, err := GetFile(ctx, requestID, sourceURL, dStorage)
+
+		if err != nil {
+			return fmt.Errorf("download error: %w", err)
+		}
+
+		defer c.Close()
+
+		if decryptor != nil {
+			decryptedFile, err := crypto.DecryptAESCBC(c, decryptor.DecryptKey, decryptor.EncryptedKey)
+			if err != nil {
+				return fmt.Errorf("error decrypting file: %w", err)
+			}
+			c = io.NopCloser(decryptedFile)
+		}
+
+		content := io.TeeReader(c, &byteAccWriter)
+
+		err = UploadToOSURL(destOSBaseURL, filename, content, MaxCopyFileDuration)
+		if err != nil {
+			log.Log(requestID, "Copy attempt failed", "source", sourceURL, "dest", path.Join(destOSBaseURL, filename), "err", err)
+		}
+		return err
+	}, UploadRetryBackoff())
+	return
+}
+
+func CopyFile(ctx context.Context, sourceURL, destOSBaseURL, filename, requestID string) (writtenBytes int64, err error) {
+	return CopyFileWithDecryption(ctx, sourceURL, destOSBaseURL, filename, requestID, nil)
+}
+
+func GetFile(ctx context.Context, requestID, url string, dStorage *DStorageDownload) (io.ReadCloser, error) {
+	_, err := drivers.ParseOSURL(url, true)
+	if err == nil {
+		return DownloadOSURL(url)
+	} else if IsDStorageResource(url) && dStorage != nil {
+		return dStorage.DownloadDStorageFromGatewayList(url, requestID)
+	} else {
+		return getFileHTTP(ctx, url)
+	}
+}
+
+var retryableHttpClient = newRetryableHttpClient()
+
+func newRetryableHttpClient() *http.Client {
+	client := retryablehttp.NewClient()
+	client.RetryMax = 5                          // Retry a maximum of this+1 times
+	client.RetryWaitMin = 200 * time.Millisecond // Wait at least this long between retries
+	client.RetryWaitMax = 5 * time.Second        // Wait at most this long between retries (exponential backoff)
+	client.HTTPClient = &http.Client{
+		// Give up on requests that take more than this long - the file is probably too big for us to process locally if it takes this long
+		// or something else has gone wrong and the request is hanging
+		Timeout: MaxCopyFileDuration,
+	}
+
+	return client.StandardClient()
+}
+
+func getFileHTTP(ctx context.Context, url string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return nil, xerrors.Unretriable(fmt.Errorf("error creating http request: %w", err))
+	}
+	resp, err := retryableHttpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error on import request: %w", err)
+	}
+	if resp.StatusCode >= 300 {
+		resp.Body.Close()
+		err := fmt.Errorf("bad status code from import request: %d %s", resp.StatusCode, resp.Status)
+		if resp.StatusCode < 500 {
+			err = xerrors.Unretriable(err)
+		}
+		return nil, err
+	}
+	return resp.Body, nil
+}

--- a/clients/file_copy_test.go
+++ b/clients/file_copy_test.go
@@ -1,0 +1,44 @@
+package clients
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isHLSInput(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputFile string
+		want      bool
+	}{
+		{
+			name:      "valid manifest",
+			inputFile: "https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4/index.m3u8",
+			want:      true,
+		},
+		{
+			name:      "invalid manifest",
+			inputFile: "https://lp-us-vod-com.storage.googleapis.com/2697c12g97x2sxn4",
+			want:      false,
+		},
+		{
+			name:      "invalid manifest",
+			inputFile: "https://lp-us-vod-com.storage.HELLO.com/2697c12g97x2sxn4/video.mp4",
+			want:      false,
+		},
+		{
+			name:      "invalid manifest",
+			inputFile: "s3+https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4/output.m3u",
+			want:      false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputURL, err := url.Parse(tt.inputFile)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, IsHLSInput(inputURL))
+		})
+	}
+}

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -37,15 +37,6 @@ var errCodesAcceleration = []int64{
 }
 var ErrJobAcceleration = errors.New("job should not have acceleration")
 
-type ByteAccumulatorWriter struct {
-	count int64
-}
-
-func (acc *ByteAccumulatorWriter) Write(p []byte) (int, error) {
-	acc.count += int64(len(p))
-	return 0, nil
-}
-
 type MediaConvertOptions struct {
 	Endpoint, Region, Role       string
 	AccessKeyID, AccessKeySecret string

--- a/middleware/capacity_test.go
+++ b/middleware/capacity_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/julienschmidt/httprouter"
-	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/pipeline"
 	"github.com/stretchr/testify/require"
 )
@@ -42,7 +41,7 @@ func TestItErrorsWhenNoCapacityAvailable(t *testing.T) {
 	pipeFfmpeg, release := pipeline.NewBlockingStubHandler()
 	defer release()
 	coordinator := pipeline.NewStubCoordinatorOpts(pipeline.StrategyCatalystFfmpegDominance, nil, pipeFfmpeg, nil, "")
-	coordinator.InputCopy = &clients.StubInputCopy{}
+	coordinator.InputCopy = &pipeline.StubInputCopy{}
 
 	// Create a lot of in-flight jobs
 	for x := 0; x < 8; x++ {

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -101,11 +101,11 @@ func (p *UploadJobPayload) CopySourceToDisk() error {
 		}
 	}
 
-	log.Log(p.RequestID, "copying to local disk")
 	localSourceFile, err := os.CreateTemp(os.TempDir(), localSourceFilePattern)
 	if err != nil {
 		return fmt.Errorf("failed to create local file (%s): %w", localSourceFile.Name(), err)
 	}
+	log.Log(p.RequestID, "copying to local disk", "local_file", localSourceFile.Name())
 	// Copy the file locally because of issues with ffmpeg segmenting and remote files
 	// We can be aggressive with the timeout because we're copying from cloud storage
 	timeout, cancel := context.WithTimeout(context.Background(), 30*time.Minute)

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -61,7 +61,7 @@ func setupTransferDir(t *testing.T, coor *Coordinator) (inputFile *os.File, tran
 		require.NoError(t, inputFile.Close())
 	}
 
-	coor.InputCopy = &clients.InputCopy{
+	coor.InputCopy = &InputCopy{
 		Probe: video.Probe{},
 	}
 	transferURL, err = url.Parse(transferDir)
@@ -483,7 +483,7 @@ func Test_ProbeErrors(t *testing.T) {
 			coord := NewStubCoordinatorOpts("", callbackHandler, nil, nil, "")
 			inputFile, transferDir, cleanup := setupTransferDir(t, coord)
 			defer cleanup()
-			coord.InputCopy = &clients.InputCopy{
+			coord.InputCopy = &InputCopy{
 				Probe: stubFFprobe{
 					FPS:  tt.fps,
 					Type: tt.assetType,

--- a/pipeline/handler.go
+++ b/pipeline/handler.go
@@ -36,10 +36,7 @@ type HandlerOutput struct {
 	Result *UploadJobResult
 }
 
-// Helper value to be returned by the handlers when continuing the pipeline async.
-var ContinuePipeline = &HandlerOutput{Continue: true}
-
-// Used for testing
+// StubHandler is used for testing
 type StubHandler struct {
 	name                      string
 	handleStartUploadJob      func(job *JobInfo) (*HandlerOutput, error)

--- a/pipeline/input_copy_test.go
+++ b/pipeline/input_copy_test.go
@@ -1,4 +1,4 @@
-package clients
+package pipeline
 
 import (
 	"net/url"
@@ -6,78 +6,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 )
-
-func Test_isDirectUpload(t *testing.T) {
-	tests := []struct {
-		name      string
-		inputFile string
-		want      bool
-	}{
-		{
-			name:      "direct upload w/ directUpload in path",
-			inputFile: "https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4",
-			want:      true,
-		},
-		{
-			name:      "direct upload w/o directUpload in path",
-			inputFile: "https://lp-us-vod-com.storage.googleapis.com/2697c12g97x2sxn4",
-			want:      false,
-		},
-		{
-			name:      "not direct upload w/ directUpload in path",
-			inputFile: "https://lp-us-vod-com.storage.HELLO.com/2697c12g97x2sxn4",
-			want:      false,
-		},
-		{
-			name:      "not direct upload",
-			inputFile: "s3+https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4",
-			want:      false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			inputURL, err := url.Parse(tt.inputFile)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, isDirectUpload(inputURL))
-		})
-	}
-}
-
-func Test_isHLSInput(t *testing.T) {
-	tests := []struct {
-		name      string
-		inputFile string
-		want      bool
-	}{
-		{
-			name:      "valid manifest",
-			inputFile: "https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4/index.m3u8",
-			want:      true,
-		},
-		{
-			name:      "invalid manifest",
-			inputFile: "https://lp-us-vod-com.storage.googleapis.com/2697c12g97x2sxn4",
-			want:      false,
-		},
-		{
-			name:      "invalid manifest",
-			inputFile: "https://lp-us-vod-com.storage.HELLO.com/2697c12g97x2sxn4/video.mp4",
-			want:      false,
-		},
-		{
-			name:      "invalid manifest",
-			inputFile: "s3+https://lp-us-vod-com.storage.googleapis.com/directUpload/2697c12g97x2sxn4/output.m3u",
-			want:      false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			inputURL, err := url.Parse(tt.inputFile)
-			require.NoError(t, err)
-			require.Equal(t, tt.want, IsHLSInput(inputURL))
-		})
-	}
-}
 
 func Test_getSegmentTransferLocation(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
This is a work in progress.
When we get a timeout on probing we should probe from local disk instead. After speaking to @thomshutt though we decided we might as well always copy to disk since it would only be mediaconvert jobs that wouldn't be copied to disk for segmenting.

Removing the file now also happens in the `Coordinator.finishJob()` function, It would be better/safer if we could do the local copy in the top level function in `Coordinator` so that we can still remove the file in a `defer()`, however I looked into this and there are goroutines spawned after the input probing happens so the `defer()` option wouldn't work as the function exits early.

Had to do some refactoring to simplify things which unfortunately pollutes the diff. I basically moved the main input_copy function into the pipeline package, this made it possible to pass in the `UploadJobPayload` struct and call the `CopySourceToDisk()` on it. It also means we can mutate the `UploadJobPayload` rather than having multiple return values (we can also remove some of the function params and read them from the struct).