### PR TITLE
[SRE-160] CDN redirect

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -59,6 +59,8 @@ type Cli struct {
 	GateURL                   string
 	StreamHealthHookURL       string
 	BroadcasterURL            string
+	CdnRedirectPrefix         *url.URL
+	CdnRedirectPlaybackIDs    []string
 }
 
 // Return our own URL for callback trigger purposes

--- a/main.go
+++ b/main.go
@@ -86,6 +86,8 @@ func main() {
 	fs.StringVar(&cli.NodeName, "node", hostname, "Name of this node within the cluster")
 	config.SpaceSliceFlag(fs, &cli.BalancerArgs, "balancer-args", []string{}, "arguments passed to MistUtilLoad")
 	fs.StringVar(&cli.NodeHost, "node-host", "", "Hostname this node should handle requests for. Requests on any other domain will trigger a redirect. Useful as a 404 handler to send users to another node.")
+	config.CommaSliceFlag(fs, &cli.CdnRedirectPlaybackIDs, "cdn-redirect-playback-ids", []string{}, "PlaybackIDs to be redirected to CDN.")
+	config.URLVarFlag(fs, &cli.CdnRedirectPrefix, "cdn-redirect-prefix", "", "CDN URL where streams selected by -cdn-redirect-playback-ids are redirected. E.g. https://externalcdn.livepeer.com/mist/")
 	fs.Float64Var(&cli.NodeLatitude, "node-latitude", 0, "Latitude of this Catalyst node. Used for load balancing.")
 	fs.Float64Var(&cli.NodeLongitude, "node-longitude", 0, "Longitude of this Catalyst node. Used for load balancing.")
 	config.CommaSliceFlag(fs, &cli.RedirectPrefixes, "redirect-prefixes", []string{}, "Set of valid prefixes of playback id which are handled by mistserver")

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -27,6 +27,7 @@ type CatalystAPIMetrics struct {
 	UploadVODRequestDurationSec *prometheus.SummaryVec
 	TranscodeSegmentDurationSec prometheus.Histogram
 	PlaybackRequestDurationSec  *prometheus.SummaryVec
+	CDNRedirectCount            *prometheus.CounterVec
 
 	TranscodingStatusUpdate ClientMetrics
 	BroadcasterClient       ClientMetrics
@@ -64,7 +65,10 @@ func NewMetrics() *CatalystAPIMetrics {
 			Name: "catalyst_playback_request_duration_seconds",
 			Help: "The latency of the requests made to /asset/hls in seconds broken up by success and status code",
 		}, []string{"success", "status_code", "version"}),
-
+		CDNRedirectCount: promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "cdn_redirect_count",
+			Help: "Number of requests redirected to CDN",
+		}, []string{"playbackID"}),
 		// Clients metrics
 
 		TranscodingStatusUpdate: ClientMetrics{


### PR DESCRIPTION
https://linear.app/livepeer/issue/SRE-160/cdn-big-red-button
catalyst-api to support new `-cdn-redirect-playback-ids` and `-cdn-redirect-prefix` parameters.

This implementation requires changes to `catalyst-api` helm values and `catalyst` deployment.,
In future the list of CDN-redirected playbacks could be pulled from studio...