### PR TITLE
clients: update manifest ordering logic to handle 4K resolutions

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -108,6 +108,13 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 		}
 	})
 
+	// If the first rendition is 4k or greater resolution, then swap with the second rendition. HLS players
+	// typically load the first rendition in a master playlist and this can result in long downloads (and
+	// hence long TTFF) for high-res video segments.
+	if len(transcodedStats) >= 2 && (transcodedStats[0].Width >= 3840 || transcodedStats[0].Height >= 3840) {
+		transcodedStats[0], transcodedStats[1] = transcodedStats[1], transcodedStats[0]
+	}
+
 	for i, profile := range transcodedStats {
 		// For each profile, add a new entry to the master manifest
 		masterPlaylist.Append(

--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -131,6 +131,20 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 				Height:        720,
 				BitsPerSecond: 1,
 			},
+			{
+				Name:          "bit-more-super-high-def",
+				FPS:           30,
+				Width:         2560,
+				Height:        1440,
+				BitsPerSecond: 1,
+			},
+			{
+				Name:          "super-duper-high-def",
+				FPS:           30,
+				Width:         3840,
+				Height:        2160,
+				BitsPerSecond: 1,
+			},
 		},
 	)
 	require.NoError(t, err)
@@ -144,9 +158,13 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 
 	const expectedMasterManifest = `#EXTM3U
 #EXT-X-VERSION:3
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=1080x720,NAME="0-super-high-def",FRAME-RATE=30.000
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=2560x1440,NAME="0-bit-more-super-high-def",FRAME-RATE=30.000
+bit-more-super-high-def/index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=3840x2160,NAME="1-super-duper-high-def",FRAME-RATE=30.000
+super-duper-high-def/index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=1080x720,NAME="2-super-high-def",FRAME-RATE=30.000
 super-high-def/index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=800x600,NAME="1-lowlowlow",FRAME-RATE=60.000
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=800x600,NAME="3-lowlowlow",FRAME-RATE=60.000
 lowlowlow/index.m3u8
 `
 	require.Equal(t, expectedMasterManifest, string(masterManifestContents))
@@ -200,7 +218,6 @@ func TestCompliantMasterManifestOrdering(t *testing.T) {
 	masterManifest := filepath.Join(outputDir, "index.m3u8")
 	masterManifestContents, err := os.ReadFile(masterManifest)
 	require.NoError(t, err)
-
 	const expectedMasterManifest = `#EXTM3U
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2000000,RESOLUTION=1080x720,NAME="0-super-high-def",FRAME-RATE=30.000


### PR DESCRIPTION
HLS players begin playing a stream by typically loading the first rendition listed in a master playlist. The player will attempt downloading a few segments from the first rendition before playback can begin. For 4K resolutions, the segments can be fairly large in size (~20MB in some cases) and this results in a very slow TTFF. In order to optimize quick playback, we prioritize a rendition lower than 4K and then let the HLS player adjust quality as playback continues -- this ensures TTFF are short and the viewer sees playback begin quickly.

Fix VID-222