### PR TITLE
manifest: update ABR ordering logic to optimize playback for 2k and greater resolutions

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -108,10 +108,10 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 		}
 	})
 
-	// If the first rendition is 4k or greater resolution, then swap with the second rendition. HLS players
+	// If the first rendition is greater than 2k resolution, then swap with the second rendition. HLS players
 	// typically load the first rendition in a master playlist and this can result in long downloads (and
 	// hence long TTFF) for high-res video segments.
-	if len(transcodedStats) >= 2 && (transcodedStats[0].Width >= 3840 || transcodedStats[0].Height >= 3840) {
+	if len(transcodedStats) >= 2 && (transcodedStats[0].Width >= 2160 || transcodedStats[0].Height >= 2160) {
 		transcodedStats[0], transcodedStats[1] = transcodedStats[1], transcodedStats[0]
 	}
 

--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -141,7 +141,7 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 			{
 				Name:          "super-duper-high-def",
 				FPS:           30,
-				Width:         3840,
+				Width:         3240,
 				Height:        2160,
 				BitsPerSecond: 1,
 			},
@@ -160,7 +160,7 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 #EXT-X-VERSION:3
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=2560x1440,NAME="0-bit-more-super-high-def",FRAME-RATE=30.000
 bit-more-super-high-def/index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=3840x2160,NAME="1-super-duper-high-def",FRAME-RATE=30.000
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=3240x2160,NAME="1-super-duper-high-def",FRAME-RATE=30.000
 super-duper-high-def/index.m3u8
 #EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1,RESOLUTION=1080x720,NAME="2-super-high-def",FRAME-RATE=30.000
 super-high-def/index.m3u8


### PR DESCRIPTION
It was found that 2k segments can also be ~60MB in size resulting in
long download times for the first segment and thus long TTFFs. So change
the threshold for ABR ordering to 2k instead of 4k previously.
