### PR TITLE
Stop falling back based on audio codec

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -348,8 +348,7 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 func checkLivepeerCompatible(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
 	for _, track := range iv.Tracks {
 		// if the codecs are not compatible then override to external pipeline to avoid sending to Livepeer
-		if (track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264") ||
-			(track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac") {
+		if track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264" {
 			log.Log(requestID, "codec not supported by Livepeer pipeline", "trackType", track.Type, "codec", track.Codec)
 			return livepeerNotSupported(strategy)
 		}

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -755,8 +755,8 @@ func Test_checkMistCompatible(t *testing.T) {
 				strategy: StrategyFallbackExternal,
 				iv:       inCompatibleAudio,
 			},
-			want:          StrategyExternalDominance,
-			wantSupported: false,
+			want:          StrategyFallbackExternal,
+			wantSupported: true,
 		},
 		{
 			name: "compatible with ffmpeg - StrategyFallbackExternal",

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -681,7 +681,7 @@ func Test_checkMistCompatible(t *testing.T) {
 			},
 		},
 	}
-	inCompatibleAudio := video.InputVideo{
+	nonAACAudio := video.InputVideo{
 		Tracks: []video.InputTrack{
 			{
 				Codec: "h264",
@@ -753,7 +753,7 @@ func Test_checkMistCompatible(t *testing.T) {
 			name: "incompatible with ffmpeg - StrategyFallbackExternal",
 			args: args{
 				strategy: StrategyFallbackExternal,
-				iv:       inCompatibleAudio,
+				iv:       nonAACAudio,
 			},
 			want:          StrategyFallbackExternal,
 			wantSupported: true,


### PR DESCRIPTION
We're initially going to check if the transcode pipeline already handles doing the audio transcode to AAC and if not, start doing that transcode inside Catalyst API