### PR TITLE
Revert "Stop falling back based on audio codec"

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -348,7 +348,8 @@ func (c *Coordinator) startUploadJob(p UploadJobPayload) {
 func checkLivepeerCompatible(requestID string, strategy Strategy, iv video.InputVideo) (bool, Strategy) {
 	for _, track := range iv.Tracks {
 		// if the codecs are not compatible then override to external pipeline to avoid sending to Livepeer
-		if track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264" {
+		if (track.Type == video.TrackTypeVideo && strings.ToLower(track.Codec) != "h264") ||
+			(track.Type == video.TrackTypeAudio && strings.ToLower(track.Codec) != "aac") {
 			log.Log(requestID, "codec not supported by Livepeer pipeline", "trackType", track.Type, "codec", track.Codec)
 			return livepeerNotSupported(strategy)
 		}

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -681,7 +681,7 @@ func Test_checkMistCompatible(t *testing.T) {
 			},
 		},
 	}
-	nonAACAudio := video.InputVideo{
+	inCompatibleAudio := video.InputVideo{
 		Tracks: []video.InputTrack{
 			{
 				Codec: "h264",
@@ -753,10 +753,10 @@ func Test_checkMistCompatible(t *testing.T) {
 			name: "incompatible with ffmpeg - StrategyFallbackExternal",
 			args: args{
 				strategy: StrategyFallbackExternal,
-				iv:       nonAACAudio,
+				iv:       inCompatibleAudio,
 			},
-			want:          StrategyFallbackExternal,
-			wantSupported: true,
+			want:          StrategyExternalDominance,
+			wantSupported: false,
 		},
 		{
 			name: "compatible with ffmpeg - StrategyFallbackExternal",


### PR DESCRIPTION
Reverts livepeer/catalyst-api#796