### PR TITLE
Add support new output format (fragmented-MP4 packaged with HLS)

### DIFF
--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -12,6 +12,7 @@ func TestGetTargetOutputs(t *testing.T) {
 		req                  UploadVODRequest
 		expectedHlsURL       string
 		expectedMp4URL       string
+		expectedFragMp4URL   string
 		expectedMp4ShortOnly bool
 	}{
 		{
@@ -21,8 +22,9 @@ func TestGetTargetOutputs(t *testing.T) {
 				Outputs: UploadVODRequestOutputLocationOutputs{
 					HLS: "enabled",
 				}}}},
-			expectedHlsURL: "s3+https://user:pass@bucket",
-			expectedMp4URL: "",
+			expectedHlsURL:     "s3+https://user:pass@bucket",
+			expectedMp4URL:     "",
+			expectedFragMp4URL: "",
 		},
 		{
 			name: "no location with HLS",
@@ -31,8 +33,9 @@ func TestGetTargetOutputs(t *testing.T) {
 				Outputs: UploadVODRequestOutputLocationOutputs{
 					MP4: "enabled",
 				}}}},
-			expectedHlsURL: "",
-			expectedMp4URL: "s3+https://user:pass@bucket",
+			expectedHlsURL:     "",
+			expectedMp4URL:     "s3+https://user:pass@bucket",
+			expectedFragMp4URL: "",
 		},
 		{
 			name: "multiple output locations, one with source segments",
@@ -49,9 +52,16 @@ func TestGetTargetOutputs(t *testing.T) {
 						MP4: "only_short",
 					},
 				},
+				{
+					URL: "s3+https://third:third@bucket",
+					Outputs: UploadVODRequestOutputLocationOutputs{
+						FragmentedMP4: "enabled",
+					},
+				},
 			}},
 			expectedHlsURL:       "s3+https://first:first@bucket",
 			expectedMp4URL:       "s3+https://second:second@bucket",
+			expectedFragMp4URL:   "s3+https://third:third@bucket",
 			expectedMp4ShortOnly: true,
 		},
 	}
@@ -61,8 +71,10 @@ func TestGetTargetOutputs(t *testing.T) {
 			gotHls := tt.req.getTargetHlsOutput()
 			require.Equal(t, tt.expectedHlsURL, gotHls.URL)
 			gotMp4, gotShortOnly := tt.req.getTargetMp4Output()
+			gotFragMp4 := tt.req.getTargetFragMp4Output()
 			require.Equal(t, tt.expectedMp4URL, gotMp4.URL)
 			require.Equal(t, tt.expectedMp4ShortOnly, gotShortOnly)
+			require.Equal(t, tt.expectedFragMp4URL, gotFragMp4.URL)
 		})
 	}
 }

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -851,51 +851,66 @@ func TestMP4Generation(t *testing.T) {
 	mp4TargetURL, err := url.Parse("http://not-a-real-domain.lol/target/target.mp4")
 	require.NoError(t, err)
 
+	fragMp4TargetURL, err := url.Parse("http://not-a-real-domain.lol/target/target.m3u8")
+	require.NoError(t, err)
+
 	require.False(
 		t,
-		ShouldGenerateMP4(mp4SourceURL, nil, true, 60),
+		ShouldGenerateMP4(mp4SourceURL, nil, nil, true, 60),
 		"Should NOT generate an MP4 if the MP4 target URL isn't present",
 	)
 
 	require.True(
 		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, true, 60),
+		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, fragMp4TargetURL, true, 60),
 		"SHOULD generate an MP4 for a short source MP4 input even if 'only short MP4s' mode is enabled",
 	)
 
 	require.True(
 		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, true, 60),
+		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60),
 		"SHOULD generate an MP4 for a short source HLS input even if 'only short MP4s' mode is enabled",
 	)
 
 	require.False(
 		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, true, 60*10),
+		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, true, 60*10),
 		"Should NOT generate an MP4 for a long source MP4 input if 'only short MP4s' mode is enabled",
 	)
 
 	require.False(
 		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, true, 60*10),
+		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60*10),
 		"Should NOT generate an MP4 for a long source HLS input if 'only short MP4s' mode is enabled",
 	)
 
 	require.True(
 		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, false, 60*10),
+		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, false, 60*10),
 		"SHOULD generate an MP4 for a long source MP4 input if 'only short MP4s' mode is disabled",
 	)
 
 	require.True(
 		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, false, 60*10),
+		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*10),
 		"SHOULD generate an MP4 for a long source HLS input if 'only short MP4s' mode is disabled",
 	)
 
 	require.False(
 		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, false, 60*60*13),
+		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*60*13),
 		"SHOULD NOT generate an MP4 for a VERY long source HLS input even if 'only short MP4s' mode is disabled",
+	)
+
+	require.True(
+		t,
+		ShouldGenerateMP4(hlsSourceURL, nil, fragMp4TargetURL, false, 60*60*1),
+		"SHOULD generate an MP4 for a fragmented Mp4 regardless of 'only short MP4s' mode",
+	)
+
+	require.False(
+		t,
+		ShouldGenerateMP4(hlsSourceURL, nil, nil, false, 60*60*13),
+		"SHOULD NOT generate an MP4 if no valid mp4 or fmp4 URL was provided",
 	)
 }

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -81,6 +81,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		SourceOutputURL:   job.SourceOutputURL,
 		HlsTargetURL:      toStr(job.HlsTargetURL),
 		Mp4TargetUrl:      toStr(job.Mp4TargetURL),
+		FragMp4TargetUrl:  toStr(job.FragMp4TargetURL),
 		RequestID:         job.RequestID,
 		ReportProgress:    job.ReportProgress,
 		GenerateMP4:       job.GenerateMP4,

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -29,6 +29,7 @@ type TranscodeSegmentRequest struct {
 	SourceOutputURL   string                 `json:"source_output_url"`
 	HlsTargetURL      string                 `json:"target_url"`
 	Mp4TargetUrl      string                 `json:"mp4_target_url"`
+	FragMp4TargetUrl  string                 `json:"fragmented_mp4_target_url"`
 	StreamKey         string                 `json:"streamKey"`
 	AccessToken       string                 `json:"accessToken"`
 	TranscodeAPIUrl   string                 `json:"transcodeAPIUrl"`
@@ -119,7 +120,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	transcodedStats := statsFromProfiles(transcodeProfiles)
 
 	renditionList := video.TRenditionList{RenditionSegmentTable: make(map[string]*video.TSegmentList)}
-	// Only populate video.TRenditionList map if MP4 is enabled via override or short-form video detection.
+        // Only populate video.TRenditionList map if MP4/FragmentedMP4 is enabled or short-form video detection.
 	// And if the original input file was an HLS video, then only generate an MP4 for the highest bitrate profile.
 	var maxBitrate int64
 	var maxProfile video.EncodedProfile

--- a/video/transmux.go
+++ b/video/transmux.go
@@ -4,17 +4,70 @@ import (
 	"fmt"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 	"os"
+	"path/filepath"
 )
 
-func MuxTStoMP4(tsInputFile, mp4OutputFile string) error {
-	// transmux the .ts file into mp4
+func MuxTStoMP4(tsInputFile, mp4OutputFile string) ([]string, error) {
+	var transmuxOutputFiles []string
+	// transmux the .ts file into a standalone MP4 file
 	err := ffmpeg.Input(tsInputFile).
 		Output(mp4OutputFile, ffmpeg.KwArgs{"movflags": "faststart", "c": "copy", "bsf:a": "aac_adtstoasc"}).
 		OverWriteOutput().ErrorToStdOut().Run()
 	if err != nil {
-		return fmt.Errorf("failed to transmux concatenated mpeg-ts file (%s) into a mp4 file: %s", tsInputFile, err)
+		return nil, fmt.Errorf("failed to transmux concatenated mpeg-ts file (%s) into a mp4 file: %s", tsInputFile, err)
 	}
-	return nil
+	// Verify the mp4 output file was created
+	_, err = os.Stat(mp4OutputFile)
+	if err != nil {
+		return nil, fmt.Errorf("transmux error: failed to stat MP4 media file: %s", err)
+	} else {
+		transmuxOutputFiles = append(transmuxOutputFiles, mp4OutputFile)
+	}
+	return transmuxOutputFiles, nil
+}
+
+func MuxTStoFMP4WithHLS(tsInputFile, fmp4ManifestOutputFile string) ([]string, error) {
+
+	baseFragMp4Dir := filepath.Dir(fmp4ManifestOutputFile)
+	err := os.Mkdir(baseFragMp4Dir, 0700)
+	if err != nil && !os.IsExist(err) {
+		return nil, fmt.Errorf("transmux error: failed to create subdir to output fmp4 files: %s", err)
+	}
+
+	var transmuxOutputFiles []string
+	// transmux the .ts file into fMP4 packaged with HLS
+	err = ffmpeg.Input(tsInputFile).
+		Output(fmp4ManifestOutputFile, ffmpeg.KwArgs{"movflags": "frag_keyframe+empty_moov",
+			"c":                 "copy",
+			"bsf:a":             "aac_adtstoasc",
+			"hls_time":          10,
+			"hls_playlist_type": "vod",
+			"hls_segment_type":  "fmp4",
+			"hls_flags":         "single_file"}).
+		OverWriteOutput().ErrorToStdOut().Run()
+	if err != nil {
+		return nil, fmt.Errorf("transmux error: failed to transmux concatenated mpeg-ts file (%s) into a fragemented-mp4 file: %s", tsInputFile, err)
+	}
+
+	fmp4VideoOutputFile := fmp4ManifestOutputFile[:len(fmp4ManifestOutputFile)-len(filepath.Ext(fmp4ManifestOutputFile))] + ".m4s"
+
+	// Verify the fmp4 manifest output file was created
+	_, err = os.Stat(fmp4ManifestOutputFile)
+	if err != nil {
+		return nil, fmt.Errorf("transmux error: failed to stat fMP4 manifest file: %s", err)
+	} else {
+		transmuxOutputFiles = append(transmuxOutputFiles, fmp4ManifestOutputFile)
+	}
+
+	// Verify the fmp4 media output file was created
+	_, err = os.Stat(fmp4VideoOutputFile)
+	if err != nil {
+		return nil, fmt.Errorf("transmux error: failed to stat fMP4 media file: %s", err)
+	} else {
+		transmuxOutputFiles = append(transmuxOutputFiles, fmp4VideoOutputFile)
+	}
+
+	return transmuxOutputFiles, nil
 }
 
 func ConcatTS(tsFileName string, segmentsList *TSegmentList) (int64, error) {


### PR DESCRIPTION
This PR adds the option to generate fragmented-mp4s packaged with HLS. 

**TODOs:**
~~* Add option to generate different mp4 types in vod request handler~~
~~* Fix location of output dir for fmp4 in object-store~~
~~* Fix mp4 output response to Studio~~
~~-- Fix probing issue post-transcode~~
~~-- Fix fmp4 output to generate separate a/v tracks~~ --> will be a followup PR
~~-- Fix/add unit tests~~ (separate PR will be used for integration tests)
~~-- Some more testing in staging including regression testing~~

/Fix VID-341