### PR TITLE
profiles: support transcode for empty profiles and bitrate-only profiles

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -121,8 +121,13 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) (o
 		mp4Target = args.MP4OutputLocation
 	)
 
+	videoTrack, err := mcArgs.InputFileInfo.GetTrack(video.TrackTypeVideo)
+	if err != nil {
+		return nil, fmt.Errorf("no video track found in input video: %w", err)
+	}
+
 	if len(mcArgs.Profiles) == 0 {
-		mcArgs.Profiles, err = video.GetPlaybackProfiles(mcArgs.InputFileInfo)
+		mcArgs.Profiles, err = video.GetDefaultPlaybackProfiles(videoTrack)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get playback profiles: %w", err)
 		}

--- a/handlers/schemas/UploadVOD.yaml
+++ b/handlers/schemas/UploadVOD.yaml
@@ -110,9 +110,6 @@ properties:
       additionalProperties: false
       required:
       -  "name"
-      - "width"
-      -  "height"
-      - "bitrate"
 required:
   - "url"
   - "callback_url"

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"testing"
 
+	"github.com/livepeer/catalyst-api/video"
 	"github.com/stretchr/testify/require"
 )
 
@@ -82,4 +83,77 @@ func TestItAcceptsValidSourceURLs(t *testing.T) {
 	require.NoError(t, CheckSourceURLValid("http://www.google.com:8080/123/asdsdf"))
 	require.NoError(t, CheckSourceURLValid("ipfs://sfsdf234fdsdfsd"))
 	require.NoError(t, CheckSourceURLValid("ar://123456"))
+}
+
+func TestIsProfileValid(t *testing.T) {
+	tests := []struct {
+		name     string
+		request  UploadVODRequest
+		expected bool
+	}{
+		{
+			name: "ValidProfiles",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Width: 1920, Height: 1080, Bitrate: 5000, FPS: 30},
+					{Width: 1280, Height: 720, Bitrate: 2000, FPS: 24},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "InvalidProfileWidthWithoutHeight",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Width: 0, Height: 720, Bitrate: 2000, FPS: 24},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "InvalidProfileHeightWithoutWidth",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Width: 1920, Height: 0, Bitrate: 5000, FPS: 30},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "InvalidProfileWidthHeightWithoutBitrate",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Width: 1920, Height: 1080, Bitrate: 0, FPS: 30},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "SingleProfileWithNonZeroBitrate",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Bitrate: 2000},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "SingleProfileWithZeroBitrate",
+			request: UploadVODRequest{
+				Profiles: []video.EncodedProfile{
+					{Bitrate: 0},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result := test.request.IsProfileValid()
+			if result != test.expected {
+				t.Errorf("Expected %v, but got %v", test.expected, result)
+			}
+		})
+	}
 }

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -61,15 +61,11 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 
 	// Grab some useful parameters to be used later from the TranscodeSegmentRequest
 	sourceManifestOSURL := transcodeRequest.SourceManifestURL
-	// transcodeProfiles are desired constraints for transcoding process
-	transcodeProfiles := transcodeRequest.Profiles
 
-	// If Profiles haven't been overridden, use the default set
-	if len(transcodeProfiles) == 0 {
-		transcodeProfiles, err = video.GetPlaybackProfiles(inputInfo)
-		if err != nil {
-			return outputs, segmentsCount, fmt.Errorf("failed to get playback profiles: %w", err)
-		}
+	// transcodeProfiles are desired constraints for transcoding process
+	transcodeProfiles, err := video.SetTranscodeProfiles(inputInfo, transcodeRequest.Profiles)
+	if err != nil || len(transcodeProfiles) == 0 {
+		return outputs, segmentsCount, fmt.Errorf("failed to set playback profiles: %w", err)
 	}
 
 	// Download the "source" manifest that contains all the segments we'll be transcoding

--- a/video/profiles_test.go
+++ b/video/profiles_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetPlaybackProfiles(t *testing.T) {
+func TestGetDefaultPlaybackProfiles(t *testing.T) {
 	tests := []struct {
 		name  string
 		track InputTrack
@@ -140,9 +140,7 @@ func TestGetPlaybackProfiles(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetPlaybackProfiles(InputVideo{
-				Tracks: []InputTrack{tt.track},
-			})
+			got, err := GetDefaultPlaybackProfiles(tt.track)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})
@@ -182,7 +180,9 @@ func TestCheckUpdatedAlgo(t *testing.T) {
 				}},
 			}
 			oldAlgorithmOutput := testCase.ExpectedOutput
-			current, err := GetPlaybackProfiles(iv)
+			vt, err := iv.GetTrack(TrackTypeVideo)
+			require.NoError(t, err)
+			current, err := GetDefaultPlaybackProfiles(vt)
 			require.NoError(t, err)
 			require.Equal(t, testCase.CurrentOutput, current)
 			require.Equal(t, len(oldAlgorithmOutput), len(current))


### PR DESCRIPTION
The transcode profile logic is being updated to handle these new changes:
* The transcode-api will now pass through empty profiles to catalyst-api. These cases should use catalyst-api's default ABR ladder.
* The transcode-api will also allow profiles with just the bitrate field set. These cases should use the resolution of the input video with the specified target bitrate for transcoding.

TODO: add/fix tests