### PR TITLE
Add track durations to match task-runner

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -13,7 +13,10 @@ import (
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
-var unsupportedVideoCodecList = []string{"mjpeg", "jpeg", "png"}
+var (
+	unsupportedVideoCodecList = []string{"mjpeg", "jpeg", "png"}
+	supportedFormats          = []string{"mp4", "mov", "hls"}
+)
 
 type Prober interface {
 	ProbeFile(requestID, url string, ffProbeOptions ...string) (InputVideo, error)
@@ -138,7 +141,7 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 
 	// format file stats into InputVideo
 	iv := InputVideo{
-		Format: probeData.Format.FormatName,
+		Format: findFormat(probeData.Format.FormatName),
 		Tracks: []InputTrack{
 			{
 				Type:        TrackTypeVideo,
@@ -237,4 +240,23 @@ func parseFps(framerate string) (float64, error) {
 	}
 
 	return float64(num) / float64(den), nil
+}
+
+func findFormat(format string) string {
+	actualFormats := strings.Split(format, ",")
+	for _, f := range supportedFormats {
+		if containsStr(actualFormats, f) {
+			return f
+		}
+	}
+	return actualFormats[0]
+}
+
+func containsStr(slc []string, val string) bool {
+	for _, v := range slc {
+		if v == val {
+			return true
+		}
+	}
+	return false
 }

--- a/video/probe.go
+++ b/video/probe.go
@@ -141,9 +141,10 @@ func parseProbeOutput(probeData *ffprobe.ProbeData) (InputVideo, error) {
 		Format: probeData.Format.FormatName,
 		Tracks: []InputTrack{
 			{
-				Type:    TrackTypeVideo,
-				Codec:   videoStream.CodecName,
-				Bitrate: bitrate,
+				Type:        TrackTypeVideo,
+				Codec:       videoStream.CodecName,
+				Bitrate:     bitrate,
+				DurationSec: parseAssetDuration(videoStream.Duration),
 				VideoTrack: VideoTrack{
 					Width:              int64(videoStream.Width),
 					Height:             int64(videoStream.Height),
@@ -182,9 +183,10 @@ func addAudioTrack(probeData *ffprobe.ProbeData, iv InputVideo) (InputVideo, err
 
 	bitrate, _ := strconv.ParseInt(audioTrack.BitRate, 10, 64)
 	iv.Tracks = append(iv.Tracks, InputTrack{
-		Type:    TrackTypeAudio,
-		Codec:   audioTrack.CodecName,
-		Bitrate: bitrate,
+		Type:        TrackTypeAudio,
+		Codec:       audioTrack.CodecName,
+		Bitrate:     bitrate,
+		DurationSec: parseAssetDuration(audioTrack.Duration),
 		AudioTrack: AudioTrack{
 			Channels:   audioTrack.Channels,
 			SampleBits: audioTrack.BitsPerSample,
@@ -194,6 +196,11 @@ func addAudioTrack(probeData *ffprobe.ProbeData, iv InputVideo) (InputVideo, err
 	})
 
 	return iv, nil
+}
+
+func parseAssetDuration(duration string) float64 {
+	d, _ := strconv.ParseFloat(duration, 64)
+	return d
 }
 
 // function taken from task-runner task/probe.go

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -80,9 +80,10 @@ func TestProbe(t *testing.T) {
 		Duration: 16.2,
 		Tracks: []InputTrack{
 			{
-				Type:    TrackTypeVideo,
-				Codec:   "h264",
-				Bitrate: 1234521,
+				Type:        TrackTypeVideo,
+				Codec:       "h264",
+				Bitrate:     1234521,
+				DurationSec: 16.2,
 				VideoTrack: VideoTrack{
 					Width:       576,
 					Height:      1024,
@@ -91,9 +92,10 @@ func TestProbe(t *testing.T) {
 				},
 			},
 			{
-				Type:    TrackTypeAudio,
-				Codec:   "aac",
-				Bitrate: 128248,
+				Type:        TrackTypeAudio,
+				Codec:       "aac",
+				Bitrate:     128248,
+				DurationSec: 16.207007,
 				AudioTrack: AudioTrack{
 					Channels:   2,
 					SampleRate: 44100,

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -76,7 +76,7 @@ func TestProbe(t *testing.T) {
 	require.NoError(err)
 
 	expectedInput := InputVideo{
-		Format:   "mov,mp4,m4a,3gp,3g2,mj2",
+		Format:   "mp4",
 		Duration: 16.2,
 		Tracks: []InputTrack{
 			{

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -132,3 +132,34 @@ func TestProbe_IgnoreSomeErrors(t *testing.T) {
 	_, err = Probe{IgnoreErrMessages: []string{"non-existing pps 0 referenced"}}.ProbeFile("requestID", "./fixtures/non-existing-pps.ts")
 	require.NoError(t, err)
 }
+
+func Test_findFormat(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{
+			name:   "single format",
+			format: "mp4",
+			want:   "mp4",
+		},
+		{
+			name:   "empty format",
+			format: "",
+			want:   "",
+		},
+		{
+			name:   "multiple format",
+			format: "mov,hello",
+			want:   "mov",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := findFormat(tt.format); got != tt.want {
+				t.Errorf("findFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I'm correcting some differences I saw to task-runners probing logic so that we can use catalyst's output and remove the logic from task-runner