### PR TITLE
manifest: update output video list with fmp4 manifest urls

### DIFF
--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -186,7 +186,7 @@ func TestItCanGenerateAndWriteFmp4Manifests(t *testing.T) {
 	}
 
 	// Do the thing
-	err = GenerateAndUploadFragMp4Manifests(
+	_, err = GenerateAndUploadFragMp4Manifests(
 		outputDir,
 		fmp4Manifests,
 		[]*video.RenditionStats{

--- a/video/profiles.go
+++ b/video/profiles.go
@@ -208,7 +208,7 @@ type OutputVideoFile struct {
 }
 
 func PopulateOutput(requestID string, probe Prober, outputURL string, videoFile OutputVideoFile) (OutputVideoFile, error) {
-	outputVideoProbe, err := probe.ProbeFile(requestID, outputURL)
+	outputVideoProbe, err := probe.ProbeFile(requestID, outputURL, "-analyzeduration", "15000000")
 	if err != nil {
 		return OutputVideoFile{}, fmt.Errorf("error probing output file from S3: %w", err)
 	}

--- a/video/transmux.go
+++ b/video/transmux.go
@@ -13,10 +13,10 @@ func MuxTStoMP4(tsInputFile, mp4OutputFile string) ([]string, error) {
 	// transmux the .ts file into a standalone MP4 file
 	err := ffmpeg.Input(tsInputFile).
 		Output(mp4OutputFile, ffmpeg.KwArgs{
-			"analyzeduration": "15M",       // Analyze up to 15s of video to figure out the format. We saw failures to detect the video codec without this
-			"movflags":        "faststart", // Need this for progressive playback and probing
-			"c":               "copy",      // Don't accidentally transcode
-			"bsf:a":           "aac_adtstoasc",
+			"analyzeduration": "15M",           // Analyze up to 15s of video to figure out the format. We saw failures to detect the video codec without this
+			"movflags":        "faststart",     // Need this for progressive playback and probing
+			"c":               "copy",          // Don't accidentally transcode
+			"bsf:a":           "aac_adtstoasc", // Remove ADTS header (required for ts -> mp4 container conversion)
 		}).
 		OverWriteOutput().ErrorToStdOut().Run()
 	if err != nil {


### PR DESCRIPTION
 - Only probe mp4 and fmp4s media files after they are generated i.e.
      skip any manifest files for fmp4s since probing takes a while and
    sometimes returns errors.
- Add fmp4 master playlist as an addition output video in the final
      response to Studio.