### PR TITLE
Skip source copy for HLS input

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -46,15 +46,20 @@ func NewInputCopy() *InputCopy {
 
 // CopyInputToS3 copies the input video to our S3 transfer bucket and probes the file.
 func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL, decryptor *crypto.DecryptionKeys) (inputVideoProbe video.InputVideo, signedURL string, err error) {
-	err = CopyAllInputFiles(requestID, inputFile, osTransferURL, decryptor)
-	if err != nil {
-		err = fmt.Errorf("failed to copy file(s): %w", err)
-		return
-	}
+	if IsHLSInput(inputFile) {
+		log.Log(requestID, "skipping copy for hls")
+		signedURL = inputFile.String()
+	} else {
+		err = CopyAllInputFiles(requestID, inputFile, osTransferURL, decryptor)
+		if err != nil {
+			err = fmt.Errorf("failed to copy file(s): %w", err)
+			return
+		}
 
-	signedURL, err = getSignedURL(osTransferURL)
-	if err != nil {
-		return
+		signedURL, err = getSignedURL(osTransferURL)
+		if err != nil {
+			return
+		}
 	}
 
 	log.Log(requestID, "starting probe", "source", inputFile.String(), "dest", osTransferURL.String())

--- a/config/cli.go
+++ b/config/cli.go
@@ -59,6 +59,7 @@ type Cli struct {
 	GateURL                   string
 	StreamHealthHookURL       string
 	BroadcasterURL            string
+	SourcePlaybackHosts       map[string]string
 }
 
 // Return our own URL for callback trigger purposes

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
-	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "sourcePlaybackHosts", map[string]string{}, "Bucket to hostname mappings for source playback")
+	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "sourcePlaybackHosts", map[string]string{}, "Hostname to prefix mappings for source playback URLs")
 
 	// mist-api-connector parameters
 	fs.IntVar(&cli.MistPort, "mist-port", 4242, "Port to connect to Mist")

--- a/main.go
+++ b/main.go
@@ -63,7 +63,7 @@ func main() {
 	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
-	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "sourcePlaybackHosts", map[string]string{}, "Hostname to prefix mappings for source playback URLs")
+	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "source-playback-hosts", map[string]string{}, "Hostname to prefix mappings for source playback URLs")
 
 	// mist-api-connector parameters
 	fs.IntVar(&cli.MistPort, "mist-port", 4242, "Port to connect to Mist")

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
+	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "sourcePlaybackHosts", map[string]string{}, "Bucket to hostname mappings for source playback")
 
 	// mist-api-connector parameters
 	fs.IntVar(&cli.MistPort, "mist-port", 4242, "Port to connect to Mist")
@@ -185,7 +186,7 @@ func main() {
 
 	// Start the "co-ordinator" that determines whether to send jobs to the Catalyst transcoding pipeline
 	// or an external one
-	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey, cli.BroadcasterURL)
+	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey, cli.BroadcasterURL, cli.SourcePlaybackHosts)
 	if err != nil {
 		glog.Fatalf("Error creating VOD pipeline coordinator: %v", err)
 	}

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -156,7 +156,7 @@ type Coordinator struct {
 	SourceOutputURL      *url.URL
 }
 
-func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string, statusClient clients.TranscodeStatusClient, metricsDB *sql.DB, VodDecryptPrivateKey *rsa.PrivateKey, broadcasterURL string) (*Coordinator, error) {
+func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string, statusClient clients.TranscodeStatusClient, metricsDB *sql.DB, VodDecryptPrivateKey *rsa.PrivateKey, broadcasterURL string, sourcePlaybackHosts map[string]string) (*Coordinator, error) {
 	if !strategy.IsValid() {
 		return nil, fmt.Errorf("invalid strategy: %s", strategy)
 	}
@@ -185,9 +185,10 @@ func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string,
 		strategy:     strategy,
 		statusClient: statusClient,
 		pipeFfmpeg: &ffmpeg{
-			SourceOutputUrl: sourceOutputURL,
-			Broadcaster:     broadcaster,
-			probe:           video.Probe{},
+			SourceOutputUrl:     sourceOutputURL,
+			Broadcaster:         broadcaster,
+			probe:               video.Probe{},
+			sourcePlaybackHosts: sourcePlaybackHosts,
 		},
 		pipeExternal:         &external{extTranscoder},
 		Jobs:                 cache.New[*JobInfo](),

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -262,7 +262,9 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 		}
 
 		osTransferURL := c.SourceOutputURL.JoinPath(p.RequestID, "transfer", path.Base(sourceURL.Path))
-		if !clients.IsHLSInput(sourceURL) && p.SourceCopy {
+		if clients.IsHLSInput(sourceURL) {
+			osTransferURL = sourceURL
+		} else if p.SourceCopy {
 			log.Log(p.RequestID, "source copy enabled")
 			osTransferURL = p.HlsTargetURL.JoinPath("video")
 		}

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -195,6 +195,11 @@ func (f *ffmpeg) sendSourcePlayback(job *JobInfo) {
 	}
 
 	prefix := f.sourcePlaybackHosts[sourceURL.Host]
+	if clients.IsHLSInput(sourceURL) && prefix == "" {
+		log.Log(job.RequestID, "no source playback prefix found", "host", sourceURL.Host)
+		return
+	}
+
 	sourceMaster.Append(prefix+"/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
 		Bandwidth:  uint32(videoTrack.Bitrate),
 		Resolution: fmt.Sprintf("%dx%d", videoTrack.Width, videoTrack.Height),

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -186,6 +186,9 @@ func sendSourcePlayback(job *JobInfo) {
 		log.LogError(job.RequestID, "unable to find a video track for source playback", err)
 		return
 	}
+	// TODO switch the public url in the recording data store to the new cdn host. then use the host from the input url for hls inputs
+	// TODO add vhost like ~/Downloads/asset-cdn-conf.json
+	// TODO check against prod cdn config
 	prefix := "//recordings-cdn.lp-playback.monster/hls"
 	sourceMaster.Append(prefix+"/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
 		Bandwidth:  uint32(videoTrack.Bitrate),

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -186,7 +186,8 @@ func sendSourcePlayback(job *JobInfo) {
 		log.LogError(job.RequestID, "unable to find a video track for source playback", err)
 		return
 	}
-	sourceMaster.Append("/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
+	prefix := "//recordings-cdn.lp-playback.monster/hls"
+	sourceMaster.Append(prefix+"/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
 		Bandwidth:  uint32(videoTrack.Bitrate),
 		Resolution: fmt.Sprintf("%dx%d", videoTrack.Width, videoTrack.Height),
 		Name:       fmt.Sprintf("%dp", videoTrack.Height),

--- a/test/steps/broadcaster.go
+++ b/test/steps/broadcaster.go
@@ -134,10 +134,11 @@ func (s *StepContext) BroadcasterReceivesSegmentsWithinSeconds(numSegmentsExpect
 func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsExpected int, profiles string, secs int) error {
 	// Master manifest is written last, so we only need to do the timeout here and then can assume that all the other files are already written
 	masterManifestPath := filepath.Join(s.TranscodedOutputDir, "index.m3u8")
+	profileNames := strings.Split(profiles, ",")
 	var err error
 	for t := 0; t < secs*2; t++ {
 		if contents, err := os.ReadFile(masterManifestPath); err == nil {
-			if !strings.Contains(string(contents), "/source/") { // ignore fast TTR source playback manifest
+			if strings.Contains(string(contents), profileNames[0]) { // the final manifest should contain the profile name
 				break
 			}
 		}
@@ -147,7 +148,6 @@ func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsEx
 		return err
 	}
 
-	profileNames := strings.Split(profiles, ",")
 	for _, profile := range profileNames {
 		for segNum := 0; segNum < numSegmentsExpected; segNum++ {
 			segPath := filepath.Join(s.TranscodedOutputDir, profile, fmt.Sprintf("%d.ts", segNum))


### PR DESCRIPTION
This is to drastically speed up processing for recordings. A new config param was needed to allow source playback still to work, this is so that app knows what hostname to use in the source playback manifest (to reach the recordings bucket rather than the normal asset bucket). E.g. a source playback manifest for a recording will look something like:

```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=4000000,RESOLUTION=1280x720,NAME="720p"
//recordings-cdn.lp-playback.studio/hls/b7caqhzl06ma2iqn/e0e9a30f-769c-4e50-9b69-2cf0ac97e68c/output.m3u8
```