### PR TITLE
Skip source copy for HLS input

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -46,15 +46,20 @@ func NewInputCopy() *InputCopy {
 
 // CopyInputToS3 copies the input video to our S3 transfer bucket and probes the file.
 func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *url.URL, decryptor *crypto.DecryptionKeys) (inputVideoProbe video.InputVideo, signedURL string, err error) {
-	err = CopyAllInputFiles(requestID, inputFile, osTransferURL, decryptor)
-	if err != nil {
-		err = fmt.Errorf("failed to copy file(s): %w", err)
-		return
-	}
+	if IsHLSInput(inputFile) {
+		log.Log(requestID, "skipping copy for hls")
+		signedURL = inputFile.String()
+	} else {
+		err = CopyAllInputFiles(requestID, inputFile, osTransferURL, decryptor)
+		if err != nil {
+			err = fmt.Errorf("failed to copy file(s): %w", err)
+			return
+		}
 
-	signedURL, err = getSignedURL(osTransferURL)
-	if err != nil {
-		return
+		signedURL, err = getSignedURL(osTransferURL)
+		if err != nil {
+			return
+		}
 	}
 
 	log.Log(requestID, "starting probe", "source", inputFile.String(), "dest", osTransferURL.String())

--- a/config/cli.go
+++ b/config/cli.go
@@ -59,6 +59,7 @@ type Cli struct {
 	GateURL                   string
 	StreamHealthHookURL       string
 	BroadcasterURL            string
+	SourcePlaybackHosts       map[string]string
 }
 
 // Return our own URL for callback trigger purposes

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func main() {
 	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
+	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "source-playback-hosts", map[string]string{}, "Hostname to prefix mappings for source playback URLs")
 
 	// mist-api-connector parameters
 	fs.IntVar(&cli.MistPort, "mist-port", 4242, "Port to connect to Mist")
@@ -185,7 +186,7 @@ func main() {
 
 	// Start the "co-ordinator" that determines whether to send jobs to the Catalyst transcoding pipeline
 	// or an external one
-	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey, cli.BroadcasterURL)
+	vodEngine, err := pipeline.NewCoordinator(pipeline.Strategy(cli.VodPipelineStrategy), cli.SourceOutput, cli.ExternalTranscoder, statusClient, metricsDB, vodDecryptPrivateKey, cli.BroadcasterURL, cli.SourcePlaybackHosts)
 	if err != nil {
 		glog.Fatalf("Error creating VOD pipeline coordinator: %v", err)
 	}

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -156,7 +156,7 @@ type Coordinator struct {
 	SourceOutputURL      *url.URL
 }
 
-func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string, statusClient clients.TranscodeStatusClient, metricsDB *sql.DB, VodDecryptPrivateKey *rsa.PrivateKey, broadcasterURL string) (*Coordinator, error) {
+func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string, statusClient clients.TranscodeStatusClient, metricsDB *sql.DB, VodDecryptPrivateKey *rsa.PrivateKey, broadcasterURL string, sourcePlaybackHosts map[string]string) (*Coordinator, error) {
 	if !strategy.IsValid() {
 		return nil, fmt.Errorf("invalid strategy: %s", strategy)
 	}
@@ -185,9 +185,10 @@ func NewCoordinator(strategy Strategy, sourceOutputURL, extTranscoderURL string,
 		strategy:     strategy,
 		statusClient: statusClient,
 		pipeFfmpeg: &ffmpeg{
-			SourceOutputUrl: sourceOutputURL,
-			Broadcaster:     broadcaster,
-			probe:           video.Probe{},
+			SourceOutputUrl:     sourceOutputURL,
+			Broadcaster:         broadcaster,
+			probe:               video.Probe{},
+			sourcePlaybackHosts: sourcePlaybackHosts,
 		},
 		pipeExternal:         &external{extTranscoder},
 		Jobs:                 cache.New[*JobInfo](),
@@ -262,7 +263,9 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 		}
 
 		osTransferURL := c.SourceOutputURL.JoinPath(p.RequestID, "transfer", path.Base(sourceURL.Path))
-		if !clients.IsHLSInput(sourceURL) && p.SourceCopy {
+		if clients.IsHLSInput(sourceURL) {
+			osTransferURL = sourceURL
+		} else if p.SourceCopy {
 			log.Log(p.RequestID, "source copy enabled")
 			osTransferURL = p.HlsTargetURL.JoinPath("video")
 		}

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -25,8 +25,9 @@ type ffmpeg struct {
 	// The base of where to output source segments to
 	SourceOutputUrl string
 	// Broadcaster for local transcoding
-	Broadcaster clients.BroadcasterClient
-	probe       video.Prober
+	Broadcaster         clients.BroadcasterClient
+	probe               video.Prober
+	sourcePlaybackHosts map[string]string
 }
 
 func init() {
@@ -65,7 +66,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		job.SegmentingTargetURL = job.SourceFile
 	}
 	job.SegmentingDone = time.Now()
-	sendSourcePlayback(job)
+	f.sendSourcePlayback(job)
 	job.ReportProgress(clients.TranscodeStatusPreparingCompleted, 1)
 
 	// Transcode Beginning
@@ -153,7 +154,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 
 var sourcePlaybackBucketBlocklist = []string{"lp-us-catalyst-vod-pvt-monster", "lp-us-catalyst-vod-pvt-com"}
 
-func sendSourcePlayback(job *JobInfo) {
+func (f *ffmpeg) sendSourcePlayback(job *JobInfo) {
 	segmentingTargetURL, err := url.Parse(job.SegmentingTargetURL)
 	if err != nil {
 		log.LogError(job.RequestID, "unable to parse url for source playback", err)
@@ -186,7 +187,20 @@ func sendSourcePlayback(job *JobInfo) {
 		log.LogError(job.RequestID, "unable to find a video track for source playback", err)
 		return
 	}
-	sourceMaster.Append("/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
+
+	sourceURL, err := url.Parse(job.SourceFile)
+	if err != nil {
+		log.LogError(job.RequestID, "unable to parse source url for source playback", err)
+		return
+	}
+
+	prefix := f.sourcePlaybackHosts[sourceURL.Host]
+	if clients.IsHLSInput(sourceURL) && prefix == "" {
+		log.Log(job.RequestID, "no source playback prefix found", "host", sourceURL.Host)
+		return
+	}
+
+	sourceMaster.Append(prefix+"/"+path.Join(segmentingPath[2:]...), &m3u8.MediaPlaylist{}, m3u8.VariantParams{
 		Bandwidth:  uint32(videoTrack.Bitrate),
 		Resolution: fmt.Sprintf("%dx%d", videoTrack.Width, videoTrack.Height),
 		Name:       fmt.Sprintf("%dp", videoTrack.Height),

--- a/test/steps/broadcaster.go
+++ b/test/steps/broadcaster.go
@@ -134,10 +134,11 @@ func (s *StepContext) BroadcasterReceivesSegmentsWithinSeconds(numSegmentsExpect
 func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsExpected int, profiles string, secs int) error {
 	// Master manifest is written last, so we only need to do the timeout here and then can assume that all the other files are already written
 	masterManifestPath := filepath.Join(s.TranscodedOutputDir, "index.m3u8")
+	profileNames := strings.Split(profiles, ",")
 	var err error
 	for t := 0; t < secs*2; t++ {
 		if contents, err := os.ReadFile(masterManifestPath); err == nil {
-			if !strings.Contains(string(contents), "/source/") { // ignore fast TTR source playback manifest
+			if strings.Contains(string(contents), profileNames[0]) { // the final manifest should contain the profile name
 				break
 			}
 		}
@@ -147,7 +148,6 @@ func (s *StepContext) TranscodedSegmentsWrittenToDiskWithinSeconds(numSegmentsEx
 		return err
 	}
 
-	profileNames := strings.Split(profiles, ",")
 	for _, profile := range profileNames {
 		for segNum := 0; segNum < numSegmentsExpected; segNum++ {
 			segPath := filepath.Join(s.TranscodedOutputDir, profile, fmt.Sprintf("%d.ts", segNum))


### PR DESCRIPTION
Re-rolling #818 after doing plenty of testing on staging and confirmed that the issue I saw yesterday was something long standing, HLS inputs with queryparams fail processing at task-runner, this is fixed in https://github.com/livepeer/task-runner/pull/211