### PR TITLE
Revert "fix: active idle status & restore metrics collection"

### DIFF
--- a/mapic/mistapiconnector_app_test.go
+++ b/mapic/mistapiconnector_app_test.go
@@ -1,14 +1,13 @@
 package mistapiconnector
 
 import (
-	"testing"
-
 	"github.com/golang/mock/gomock"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 	mockmistclient "github.com/livepeer/catalyst-api/mocks/clients"
 	"github.com/livepeer/go-api-client"
 	"github.com/stretchr/testify/require"
+	"testing"
 )
 
 func TestReconcileMultistream(t *testing.T) {
@@ -158,9 +157,7 @@ func TestReconcileMultistream(t *testing.T) {
 		return nil
 	}).AnyTimes()
 
-	mistState, err := mm.GetState()
-	require.NoError(t, err)
-	mc.reconcileMultistream(mistState)
+	mc.reconcileMultistream()
 
 	expectedAutoToAdd := []streamTarget{
 		{

--- a/mapic/stats_collector.go
+++ b/mapic/stats_collector.go
@@ -19,7 +19,6 @@ const lastSeenBumpPeriod = 30 * time.Second
 
 type infoProvider interface {
 	getStreamInfo(mistID string) (*streamInfo, error)
-	wildcardPlaybackID(stream *api.Stream) string
 }
 
 type metricsCollector struct {
@@ -31,27 +30,45 @@ type metricsCollector struct {
 	infoProvider
 }
 
-func createMetricsCollector(nodeID, ownRegion string, mapi clients.MistAPIClient, lapi *api.Client, producer event.AMQPProducer, amqpExchange string, infop infoProvider) *metricsCollector {
+func startMetricsCollector(ctx context.Context, period time.Duration, nodeID, ownRegion string, mapi clients.MistAPIClient, lapi *api.Client, producer event.AMQPProducer, amqpExchange string, infop infoProvider) {
 	mc := &metricsCollector{nodeID, ownRegion, mapi, lapi, producer, amqpExchange, infop}
-	return mc
+	mc.collectMetricsLogged(ctx, period)
+	go mc.mainLoop(ctx, period)
 }
 
-func (c *metricsCollector) collectMetricsLogged(ctx context.Context, timeout time.Duration, mistState clients.MistState) {
+func (c *metricsCollector) mainLoop(loopCtx context.Context, period time.Duration) {
+	ticker := time.NewTicker(period)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-loopCtx.Done():
+			return
+		case <-ticker.C:
+			c.collectMetricsLogged(loopCtx, period)
+		}
+	}
+}
+
+func (c *metricsCollector) collectMetricsLogged(ctx context.Context, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
-	if err := c.collectMetrics(ctx, mistState); err != nil {
+	if err := c.collectMetrics(ctx); err != nil {
 		glog.Errorf("Error collecting mist metrics. err=%v", err)
 	}
 }
 
-func (c *metricsCollector) collectMetrics(ctx context.Context, mistState clients.MistState) error {
+func (c *metricsCollector) collectMetrics(ctx context.Context) error {
 	defer func() {
 		if rec := recover(); rec != nil {
 			glog.Errorf("Panic in metrics collector. value=%v", rec)
 		}
 	}()
 
-	streamsMetrics := compileStreamMetrics(&mistState)
+	mistStats, err := c.mist.GetState()
+	if err != nil {
+		return err
+	}
+	streamsMetrics := compileStreamMetrics(&mistStats)
 
 	eg := errgroup.Group{}
 	eg.SetLimit(5)
@@ -70,12 +87,11 @@ func (c *metricsCollector) collectMetrics(ctx context.Context, mistState clients
 			glog.Errorf("Error getting stream info for streamId=%s err=%q", streamID, err)
 			continue
 		}
-
-		stream := c.infoProvider.wildcardPlaybackID(info.stream)
-		isIngest := isIngestStream(stream, info, mistState)
-
-		if !isIngest {
-			glog.V(8).Infof("Skipping non-ingest stream. streamId=%q", streamID)
+		if info.isLazy {
+			// avoid spamming metrics for playback-only catalyst instances. This means
+			// that if mapic restarts we will stop sending metrics from previous
+			// streams as well, but that's a minor issue (curr stream health is dying).
+			glog.Infof("Skipping metrics for lazily created stream info. streamId=%q metrics=%+v", streamID, metrics)
 			continue
 		}
 


### PR DESCRIPTION
Reverts livepeer/catalyst-api#819

Reverting until we're confident enough to deploy this