### PR TITLE
clip: add scaffolding to accept clipping requests

### DIFF
--- a/handlers/schemas/UploadVOD.yaml
+++ b/handlers/schemas/UploadVOD.yaml
@@ -24,6 +24,16 @@ properties:
     required: 
       - "encrypted_key"
     additionalProperties: false
+  clip_strategy:
+    type: "object"
+    properties:
+      start_time:
+        type: "integer"
+      end_time:
+        type: "integer"
+    required:
+      -  "start_time"
+    additionalProperties: false
   pipeline_strategy:
     type: string
     description:

--- a/video/clip.go
+++ b/video/clip.go
@@ -5,8 +5,15 @@ import (
 	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/log"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
+	"net/url"
 	"time"
 )
+
+type ClipStrategy struct {
+	Enabled   bool
+	StartTime float64 `json:"start_time,omitempty"`
+	EndTime   float64 `json:"end_time,omitempty"`
+}
 
 // format time in secs to be copatible with ffmpeg's expected time syntax
 func formatTime(seconds float64) string {
@@ -53,6 +60,13 @@ func getRelevantSegment(allSegments []*m3u8.MediaSegment, playHeadTime float64, 
 		return segment.SeqId, nil
 	}
 	return 0, fmt.Errorf("error clipping: did not find a segment that falls within %v seconds", playHeadTime)
+}
+
+// Function that will take a source URL manifest and return a new URL
+// pointing to the clipped manifest
+func ClipInput(requestID string, srcUrl *url.URL, startTime, endTime float64) (*url.URL, error) {
+	// TODO:*actually* do the clipping
+	return srcUrl, nil
 }
 
 // Function to find relevant segments that span from the clipping start and end times


### PR DESCRIPTION
This adds additional parameters to the vod endpoint to accept clipping start/end times. If the fields are set with valid values, the input manifest will be clipped and then a new clipped manifest will be used in the VOD pipeline to generate assets as usual. The logic for clipping the actual manifest will be done as a follow-on PR.