### PR TITLE
Ignore profiles override for audio-only content

### DIFF
--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -131,6 +131,12 @@ func (mc *MediaConvert) Transcode(ctx context.Context, args TranscodeJobArgs) (o
 		}
 	}
 
+	// If we don't have a video track then ignore any profiles that have been passed in
+	// and do a default audio transcode
+	if !hasVideoTrack {
+		mcArgs.Profiles = []video.EncodedProfile{}
+	}
+
 	var mcHlsOutputRelPath string
 	if hlsTarget != nil {
 		// AWS MediaConvert adds the .m3u8 to the end of the output file name


### PR DESCRIPTION
This came up from a failed audio-only transcode where the request had come in with a Profiles override via the Transcode API.

If users do start wanting to override for the audio-only case then we can look at making this more sophisticated in the future.