### PR TITLE
clip: add support to clip and upload clipped segments

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -107,7 +107,7 @@ func (r UploadVODRequest) IsProfileValid() bool {
 func (r UploadVODRequest) IsClipValid() bool {
 	startTime := r.ClipStrategy.StartTime
 	endTime := r.ClipStrategy.EndTime
-	if startTime < 0 || endTime <= 0 || startTime == endTime || startTime < endTime {
+	if startTime < 0 || endTime <= 0 || startTime == endTime || startTime > endTime {
 		return false
 	}
 	return true

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -273,16 +273,19 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 		}
 
 		osTransferURL := c.SourceOutputURL.JoinPath(p.RequestID, "transfer", path.Base(sourceURL.Path))
+
+		// Update osTransferURL if needed
 		if clients.IsHLSInput(sourceURL) {
 			// Currently we only clip an HLS source (e.g recordings or transcoded asset)
 			if p.ClipStrategy.Enabled {
 				log.Log(p.RequestID, "clippity clipping the input", "Playback-ID", p.ClipStrategy.PlaybackID)
 				// Use new clipped manifest as the source URL
-				sourceURL, err = video.ClipInput(p.RequestID, sourceURL, p.ClipStrategy.StartTime, p.ClipStrategy.EndTime)
+				sourceURL, err := clients.ClipInputManifest(p.RequestID, sourceURL.String(), p.HlsTargetURL.String(), p.ClipStrategy.StartTime, p.ClipStrategy.EndTime)
 				if err != nil {
-					return nil, fmt.Errorf("error clipping input: %w", err)
+					return nil, fmt.Errorf("error clippity: %s %w", sourceURL, err)
 				}
 			}
+			// Use the source URL location as the transfer directory to hold the clipped outputs
 			osTransferURL = sourceURL
 		} else if p.SourceCopy {
 			log.Log(p.RequestID, "source copy enabled")

--- a/video/clip.go
+++ b/video/clip.go
@@ -8,10 +8,6 @@ import (
 	"time"
 )
 
-const (
-	ClipStorageDir = "/tmp/clip_stage"
-)
-
 type ClipStrategy struct {
 	Enabled    bool
 	StartTime  float64 `json:"start_time,omitempty"`

--- a/video/clip.go
+++ b/video/clip.go
@@ -5,8 +5,11 @@ import (
 	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/log"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
-	"net/url"
 	"time"
+)
+
+const (
+	ClipStorageDir = "/tmp/clip_stage"
 )
 
 type ClipStrategy struct {
@@ -61,13 +64,6 @@ func getRelevantSegment(allSegments []*m3u8.MediaSegment, playHeadTime float64, 
 		return segment.SeqId, nil
 	}
 	return 0, fmt.Errorf("error clipping: did not find a segment that falls within %v seconds", playHeadTime)
-}
-
-// Function that will take a source URL manifest and return a new URL
-// pointing to the clipped manifest
-func ClipInput(requestID string, srcUrl *url.URL, startTime, endTime float64) (*url.URL, error) {
-	// TODO:*actually* do the clipping
-	return srcUrl, nil
 }
 
 // Function to find relevant segments that span from the clipping start and end times
@@ -134,7 +130,7 @@ func ClipSegment(tsInputFile, tsOutputFile string, startTime, endTime float64) e
 			"c:a":          "copy"}).
 		OverWriteOutput().ErrorToStdOut().Run()
 	if err != nil {
-		return fmt.Errorf("failed to transmux concatenated mpeg-ts file (%s) into a mp4 file: %s", tsInputFile, err)
+		return fmt.Errorf("failed to clip segments from %s: %w", tsInputFile, err)
 	}
 	return nil
 }


### PR DESCRIPTION
Add manifest handling logic to download a source manifest, call clipping methods on it, and then upload the returned segments to OS.

Note 1: The clipped manifest generation and upload step will be done in a follow-on PR.

Note 2: cucumber tests will be added in a future PR