### PR TITLE
handlers: add playback-id to clipping request

### DIFF
--- a/handlers/schemas/UploadVOD.yaml
+++ b/handlers/schemas/UploadVOD.yaml
@@ -31,6 +31,8 @@ properties:
         type: "integer"
       end_time:
         type: "integer"
+      playback_id:
+        type: "string"
     required:
       -  "start_time"
     additionalProperties: false

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -276,7 +276,7 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 		if clients.IsHLSInput(sourceURL) {
 			// Currently we only clip an HLS source (e.g recordings or transcoded asset)
 			if p.ClipStrategy.Enabled {
-				log.Log(p.RequestID, "clippity clipping the input")
+				log.Log(p.RequestID, "clippity clipping the input", "Playback-ID", p.ClipStrategy.PlaybackID)
 				// Use new clipped manifest as the source URL
 				sourceURL, err = video.ClipInput(p.RequestID, sourceURL, p.ClipStrategy.StartTime, p.ClipStrategy.EndTime)
 				if err != nil {

--- a/video/clip.go
+++ b/video/clip.go
@@ -10,9 +10,10 @@ import (
 )
 
 type ClipStrategy struct {
-	Enabled   bool
-	StartTime float64 `json:"start_time,omitempty"`
-	EndTime   float64 `json:"end_time,omitempty"`
+	Enabled    bool
+	StartTime  float64 `json:"start_time,omitempty"`
+	EndTime    float64 `json:"end_time,omitempty"`
+	PlaybackID string  `json:"playback_id,omitempty"` // playback-id of asset to clip
 }
 
 // format time in secs to be copatible with ffmpeg's expected time syntax


### PR DESCRIPTION
This playback-id will be returned in the clipping response back to studio so that clipped assets can be tracked to the original asset's playback id. 