### PR TITLE
clip: format start/end times passed to ffmpeg to use milliseconds

### DIFF
--- a/video/clip.go
+++ b/video/clip.go
@@ -16,10 +16,11 @@ type ClipStrategy struct {
 }
 
 // format time in secs to be copatible with ffmpeg's expected time syntax
-func formatTime(seconds float64) string {
-	duration := time.Duration(seconds * float64(time.Second))
-	timeObj := time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC).Add(duration)
-	return timeObj.Format("15:04:05")
+func formatTime(timeSeconds float64) string {
+	timeMillis := int64(timeSeconds * 1000)
+	duration := time.Duration(timeMillis) * time.Millisecond
+	formattedTime := time.Date(0, 1, 1, 0, 0, 0, 0, time.UTC).Add(duration)
+	return formattedTime.Format("15:04:05.000")
 }
 
 func GetTotalDurationAndSegments(manifest *m3u8.MediaPlaylist) (float64, uint64) {


### PR DESCRIPTION
The -ss and -to parameters used by ffmpeg was previously only converting to HH:MM:SS and the milliseconds portion was being dropped. Update the time formatting logic so that a format of HH:MM:SS.m... is used. This allows millisecond accuracy for clipping.