### PR TITLE
Stagger transcode goroutines to avoid switching Os

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ const MaxInputFileSizeBytes = 30 * 1024 * 1024 * 1024 // 30 GiB
 
 var TranscodingParallelJobs int = 2
 
-var TranscodingParallelSleep time.Duration = 713 * time.Millisecond
+var TranscodingParallelSleep time.Duration = 5 * time.Second
 
 var DownloadOSURLRetries uint64 = 10
 

--- a/test/features/vod.feature
+++ b/test/features/vod.feature
@@ -35,13 +35,13 @@ Feature: VOD Streaming
     And receive a response within "3" seconds
     Then I get an HTTP response with code "200"
     And I receive a Request ID in the response body
-    And the source playback manifest is written to storage within "5" seconds
+    And the source playback manifest is written to storage within "10" seconds
     And a "jobs_in_flight" metric is recorded with a value of "1"
     And my "successful" vod request metrics get recorded
-    And "4" source segments are written to storage within "5" seconds
+    And "4" source segments are written to storage within "10" seconds
     And the source manifest is written to storage within "3" seconds and contains "4" segments
     And the Broadcaster receives "4" segments for transcoding within "10" seconds
-    And "4" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "5" seconds
+    And "4" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "10" seconds
     And a source copy <source_copy> been written to disk
     And I receive a "success" callback within "20" seconds
 
@@ -57,7 +57,7 @@ Feature: VOD Streaming
     And I receive a Request ID in the response body
     And my "successful" vod request metrics get recorded
     And the Broadcaster receives "3" segments for transcoding within "10" seconds
-    And "3" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "5" seconds
+    And "3" transcoded segments and manifests have been written to disk for profiles "270p0,low-bitrate" within "10" seconds
     And a source copy has not been written to disk
     And I receive a "success" callback within "20" seconds
 

--- a/transcode/transcode_jobs.go
+++ b/transcode/transcode_jobs.go
@@ -41,7 +41,9 @@ func (t *ParallelTranscoding) Start() {
 	t.completed.Add(config.TranscodingParallelJobs)
 	for index := 0; index < config.TranscodingParallelJobs; index++ {
 		go t.workerRoutine()
-		// Add some desync interval to avoid load spikes on segment-encode-end
+		// Add a sleep after the first transcoding goroutine starts, to avoid the situation where 2 segments
+		// hit the Broadcaster at once and get routed to different Os, then immediately switch away from
+		// one of them
 		time.Sleep(config.TranscodingParallelSleep)
 	}
 }


### PR DESCRIPTION
This is an attempt to mitigate the number of first segment swaps we see, based on the issue described in https://github.com/livepeer/go-livepeer/pull/2860