### PR TITLE
UploadVOD yaml: do not set start_time as required

### DIFF
--- a/handlers/schemas/UploadVOD.yaml
+++ b/handlers/schemas/UploadVOD.yaml
@@ -33,8 +33,6 @@ properties:
         type: "integer"
       playback_id:
         type: "string"
-    required:
-      -  "start_time"
     additionalProperties: false
   pipeline_strategy:
     type: string


### PR DESCRIPTION
The clipping request is already validated in catalyst-api so we should not be setting start_time in the vod request as this will prevent recordings/vod from working.