### PR TITLE
manifest: set the clipped manifest URL correctly for storj

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -336,23 +336,18 @@ func ClipInputManifest(requestID, sourceURL, clipTargetUrl string, startTimeUnix
 	// to the clipped manifest file using the public source url. This logic should be
 	// simplified by setting an output folder explicitly as a param in the ClippingStrategy
 	// struct as part of the clipping request
-	clipTargetOSURL, err := url.Parse(clipTargetUrl)
-	if err != nil {
-		return nil, fmt.Errorf("error clipping: failed to parse clipped playlist: %s", err)
-	}
+
 	// extract the folder where clip segments/manifests are saved
-	clipPlaybackRelPath := path.Base(clipTargetOSURL.String())
+	clipPlaybackRelPath := path.Base(clipTargetUrl)
 	// create a new publically accessible base url from the source url
-	clipTargetPublicBaseUrl := strings.TrimSuffix(sourceURL, "output.m3u8")
-	clipTargetPublicURL, err := url.Parse(clipTargetPublicBaseUrl)
+	source, err := url.Parse(sourceURL)
 	if err != nil {
-		return nil, fmt.Errorf("error clipping: failed to parse clipped playlist: %s", err)
+		return nil, fmt.Errorf("error clipping: failed to parse sourceURL: %s", err)
 	}
 	// set the correct path to clip.m3u8 file in the base url that will be used as the
 	// input file to next VOD (transcode) stage.
-	clipTargetPublicURL.Path += clipPlaybackRelPath + "/" + ClipManifestFilename
 
-	return clipTargetPublicURL, nil
+	return source.JoinPath("..", clipPlaybackRelPath, ClipManifestFilename), nil
 }
 
 func CreateClippedPlaylist(origManifest m3u8.MediaPlaylist, segs []*m3u8.MediaSegment) (*m3u8.MediaPlaylist, error) {

--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -332,16 +332,27 @@ func ClipInputManifest(requestID, sourceURL, clipTargetUrl string, startTimeUnix
 		return nil, fmt.Errorf("error clipping: failed to upload clipped playlist: %s", err)
 	}
 
-	// Parse the clipTargetUrl so that it can be used as the new source in the transcode stage.
+	//TODO/HACK: With Storj being used for recordings/clips, generate an URL pointing
+	// to the clipped manifest file using the public source url. This logic should be
+	// simplified by setting an output folder explicitly as a param in the ClippingStrategy
+	// struct as part of the clipping request
 	clipTargetOSURL, err := url.Parse(clipTargetUrl)
 	if err != nil {
 		return nil, fmt.Errorf("error clipping: failed to parse clipped playlist: %s", err)
 	}
-	clipTargetOSURL.Scheme = strings.TrimPrefix(clipTargetOSURL.Scheme, "s3+")
-	clipTargetOSURL.User = nil
-	clipTargetOSURL.Path += "/" + ClipManifestFilename
+	// extract the folder where clip segments/manifests are saved
+	clipPlaybackRelPath := path.Base(clipTargetOSURL.String())
+	// create a new publically accessible base url from the source url
+	clipTargetPublicBaseUrl := strings.TrimSuffix(sourceURL, "output.m3u8")
+	clipTargetPublicURL, err := url.Parse(clipTargetPublicBaseUrl)
+	if err != nil {
+		return nil, fmt.Errorf("error clipping: failed to parse clipped playlist: %s", err)
+	}
+	// set the correct path to clip.m3u8 file in the base url that will be used as the
+	// input file to next VOD (transcode) stage.
+	clipTargetPublicURL.Path += clipPlaybackRelPath + "/" + ClipManifestFilename
 
-	return clipTargetOSURL, nil
+	return clipTargetPublicURL, nil
 }
 
 func CreateClippedPlaylist(origManifest m3u8.MediaPlaylist, segs []*m3u8.MediaSegment) (*m3u8.MediaPlaylist, error) {


### PR DESCRIPTION
This is a bit of a workaround (hack) to correctly set storj URLs for the clipped manifest file. A follow-on PR will be used to set the output relative path in the request directly which will will simplify this logic.