### PR TITLE
manifest/clip: re-encode last segment as well and add DISCONTINUITY tag

### DIFF
--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -240,6 +240,7 @@ source/0.ts
 #EXT-X-DISCONTINUITY
 #EXTINF:15.000,blah1
 ../source/1.ts
+#EXT-X-DISCONTINUITY
 #EXTINF:10.000,blah2
 source/2.ts
 #EXT-X-ENDLIST

--- a/video/clip.go
+++ b/video/clip.go
@@ -176,10 +176,14 @@ func ClipSegment(tsInputFile, tsOutputFile string, startTime, endTime float64) e
 		// Clip from beginning of segment to specified end time
 		// without re-encoding (when clipping ending segment)
 		end := formatTime(endTime)
-		args = ffmpeg.KwArgs{"c:a": "copy",
-			"c:v": "copy",
-			"ss":  "00:00:00.000",
-			"to":  end}
+		args = ffmpeg.KwArgs{"bf": "0",
+			"c:a":          "aac",
+			"c:v":          "libx264",
+			"g":            "48",
+			"keyint_min":   "48",
+			"sc_threshold": 50,
+			"ss":           "00:00:00.000",
+			"to":           end}
 	} else {
 		// Clip from specified start/end times (when
 		// start/end falls within same segment)


### PR DESCRIPTION
If the last segment is not re-encoded, some hls players take additional audio from the last segment and overlap with the beginning of the video - the symptom is that you hear mismatched audio track. This doesn't always reproduce on the same hls player at times when reloading multiple times.

Re-encoding the last segment and adding a DISCONTINUITY tag seems to resolve the issue here as well.