### PR TITLE
transcode: add logic to force a session re-init

### DIFF
--- a/clients/broadcaster.go
+++ b/clients/broadcaster.go
@@ -34,8 +34,9 @@ type createStreamPayload struct {
 }
 
 type LivepeerTranscodeConfiguration struct {
-	Profiles          []video.EncodedProfile `json:"profiles"`
-	TimeoutMultiplier int                    `json:"timeoutMultiplier"`
+	Profiles           []video.EncodedProfile `json:"profiles"`
+	TimeoutMultiplier  int                    `json:"timeoutMultiplier"`
+	ForceSessionReinit bool                   `json:"forceSessionReinit"`
 }
 
 type Credentials struct {

--- a/clients/broadcaster_local.go
+++ b/clients/broadcaster_local.go
@@ -12,7 +12,7 @@ import (
 // Currently only implemented by LocalBroadcasterClient
 // TODO: Try to come up with a unified interface across Local and Remote
 type BroadcasterClient interface {
-	TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error)
+	TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string, conf LivepeerTranscodeConfiguration) (TranscodeResult, error)
 }
 
 type LocalBroadcasterClient struct {
@@ -29,15 +29,11 @@ func NewLocalBroadcasterClient(broadcasterURL string) (BroadcasterClient, error)
 	}, nil
 }
 
-func (c *LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string) (TranscodeResult, error) {
-	conf := LivepeerTranscodeConfiguration{
-		TimeoutMultiplier: 10,
-	}
+func (c *LocalBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string, conf LivepeerTranscodeConfiguration) (TranscodeResult, error) {
 	conf.Profiles = append(conf.Profiles, profiles...)
 	transcodeConfig, err := json.Marshal(&conf)
 	if err != nil {
 		return TranscodeResult{}, fmt.Errorf("for local B, profiles json encode failed: %v", err)
 	}
-
 	return transcodeSegment(segment, sequenceNumber, durationMillis, c.broadcasterURL, manifestID, profiles, string(transcodeConfig))
 }

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -81,6 +81,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		RequestID:         job.RequestID,
 		ReportProgress:    job.ReportProgress,
 		GenerateMP4:       job.GenerateMP4,
+		IsClip:            job.ClipStrategy.Enabled,
 	}
 
 	inputInfo := video.InputVideo{

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -428,6 +428,12 @@ func transcodeSegment(
 	} else {
 		transcodeConf.ForceSessionReinit = false
 	}
+	// This is a temporary workaround that implements the same logic
+	// as the previous if block -- a new manifestID will force a
+	// T session re-init between segment at index=0 and index=1.
+	if int64(segment.Index) == 0 {
+		manifestID = manifestID + "_clip"
+	}
 
 	var tr clients.TranscodeResult
 	err := backoff.Retry(func() error {

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -431,7 +431,7 @@ func transcodeSegment(
 	// This is a temporary workaround that implements the same logic
 	// as the previous if block -- a new manifestID will force a
 	// T session re-init between segment at index=0 and index=1.
-	if int64(segment.Index) == 0 {
+	if transcodeRequest.IsClip && int64(segment.Index) == 0 {
 		manifestID = manifestID + "_clip"
 	}
 

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -39,7 +39,7 @@ type StubBroadcasterClient struct {
 	tr clients.TranscodeResult
 }
 
-func (c StubBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string) (clients.TranscodeResult, error) {
+func (c StubBroadcasterClient) TranscodeSegment(segment io.Reader, sequenceNumber int64, profiles []video.EncodedProfile, durationMillis int64, manifestID string, conf clients.LivepeerTranscodeConfiguration) (clients.TranscodeResult, error) {
 	return c.tr, nil
 }
 


### PR DESCRIPTION
When a sequence of segments has a discontinuity (e.g. encoded differently), the transcoder at T must be re-initialized so that transcode operations can be completed correctly. The T takes some liberties and assumes a sequence of segments are encoded the same way and thus, ends up not re-initializing certain parts of the pipeline (e.g. demuxer, etc) to save time and improve efficiency. This can result in corrupted segments with two video tracks instead of one audio and one video track.

For clipping, the first segment (index=0) is encoded differently from the rest of the file. As such, a session reinit must be forced at the T using a header set in the request to B.