### PR TITLE
manifest: add DISCONTINUITY tags to clip playlist

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -98,7 +98,7 @@ func GetSourceSegmentURLs(sourceManifestURL string, manifest m3u8.MediaPlaylist)
 
 // Generate a Master manifest, plus one Rendition manifest for each Profile we're transcoding, then write them to storage
 // Returns the master manifest URL on success
-func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL string, transcodedStats []*video.RenditionStats) (string, error) {
+func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL string, transcodedStats []*video.RenditionStats, isClip bool) (string, error) {
 	// Generate the master + rendition output manifests
 	masterPlaylist := m3u8.NewMasterPlaylist()
 
@@ -144,6 +144,12 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 			if err != nil {
 				return "", fmt.Errorf("failed to append to rendition playlist number %d: %s", i, err)
 			}
+		}
+
+		if isClip {
+			_, totalSegs := video.GetTotalDurationAndSegments(renditionPlaylist)
+			renditionPlaylist.Segments[1].Discontinuity = true
+			renditionPlaylist.Segments[totalSegs-1].Discontinuity = true
 		}
 
 		// Write #EXT-X-ENDLIST

--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -146,6 +146,7 @@ func TestItCanGenerateAndWriteManifests(t *testing.T) {
 				BitsPerSecond: 1,
 			},
 		},
+		false,
 	)
 	require.NoError(t, err)
 
@@ -212,6 +213,7 @@ func TestCompliantMasterManifestOrdering(t *testing.T) {
 				BitsPerSecond: 2000000,
 			},
 		},
+		false,
 	)
 	require.NoError(t, err)
 

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -166,7 +166,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	}
 
 	// Build the manifests and push them to storage
-	manifestURL, err := clients.GenerateAndUploadManifests(sourceManifest, hlsTargetURL.String(), transcodedStats)
+	manifestURL, err := clients.GenerateAndUploadManifests(sourceManifest, hlsTargetURL.String(), transcodedStats, transcodeRequest.IsClip)
 	if err != nil {
 		return outputs, segmentsCount, err
 	}


### PR DESCRIPTION
A discontinuity tag is required in the clip playlist so that it shows the correct duration.