### PR TITLE
transcode-api: disable source playback if hls target url is not set

### DIFF
--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -61,7 +61,9 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		job.SegmentingTargetURL = job.SourceFile
 	}
 	job.SegmentingDone = time.Now()
-	f.sendSourcePlayback(job)
+	if job.HlsTargetURL != nil {
+		f.sendSourcePlayback(job)
+	}
 	job.ReportProgress(clients.TranscodeStatusPreparingCompleted, 1)
 
 	// Transcode Beginning


### PR DESCRIPTION
In the transcode-api, an hls target may not be set in which case source playback doesn't apply.