### PR TITLE
mediaconvert: allow video without audio tracks to be processed

### DIFF
--- a/clients/fixtures/mediaconvert_payloads/accelerated.txt
+++ b/clients/fixtures/mediaconvert_payloads/accelerated.txt
@@ -8,9 +8,9 @@
         AudioSelectors: {
           Audio Selector 1: {
             DefaultSelection: "DEFAULT",
-            Offset:           0,
+            Offset: 0,
             ProgramSelection: 1,
-            SelectorType:     "TRACK",
+            SelectorType: "TRACK"
           }
         },
         FileInput: "input",

--- a/clients/fixtures/mediaconvert_payloads/accelerated.txt
+++ b/clients/fixtures/mediaconvert_payloads/accelerated.txt
@@ -7,7 +7,10 @@
     Inputs: [{
         AudioSelectors: {
           Audio Selector 1: {
-            DefaultSelection: "DEFAULT"
+            DefaultSelection: "DEFAULT",
+            Offset:           0,
+            ProgramSelection: 1,
+            SelectorType:     "TRACK",
           }
         },
         FileInput: "input",

--- a/clients/fixtures/mediaconvert_payloads/happy.txt
+++ b/clients/fixtures/mediaconvert_payloads/happy.txt
@@ -5,9 +5,9 @@
         AudioSelectors: {
           Audio Selector 1: {
             DefaultSelection: "DEFAULT",
-            Offset:           0,
+            Offset: 0,
             ProgramSelection: 1,
-            SelectorType:     "TRACK",
+            SelectorType: "TRACK"
           }
         },
         FileInput: "input",

--- a/clients/fixtures/mediaconvert_payloads/happy.txt
+++ b/clients/fixtures/mediaconvert_payloads/happy.txt
@@ -4,7 +4,10 @@
     Inputs: [{
         AudioSelectors: {
           Audio Selector 1: {
-            DefaultSelection: "DEFAULT"
+            DefaultSelection: "DEFAULT",
+            Offset:           0,
+            ProgramSelection: 1,
+            SelectorType:     "TRACK",
           }
         },
         FileInput: "input",

--- a/clients/fixtures/mediaconvert_payloads/no-mp4.txt
+++ b/clients/fixtures/mediaconvert_payloads/no-mp4.txt
@@ -5,9 +5,9 @@
         AudioSelectors: {
           Audio Selector 1: {
             DefaultSelection: "DEFAULT",
-            Offset:           0,
+            Offset: 0,
             ProgramSelection: 1,
-            SelectorType:     "TRACK",
+            SelectorType: "TRACK"
           }
         },
         FileInput: "input",

--- a/clients/fixtures/mediaconvert_payloads/no-mp4.txt
+++ b/clients/fixtures/mediaconvert_payloads/no-mp4.txt
@@ -4,7 +4,10 @@
     Inputs: [{
         AudioSelectors: {
           Audio Selector 1: {
-            DefaultSelection: "DEFAULT"
+            DefaultSelection: "DEFAULT",
+            Offset:           0,
+            ProgramSelection: 1,
+            SelectorType:     "TRACK",
           }
         },
         FileInput: "input",

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -322,7 +322,10 @@ func createJobPayload(inputFile, hlsOutputFile, mp4OutputFile, role string, acce
 				{
 					AudioSelectors: map[string]*mediaconvert.AudioSelector{
 						"Audio Selector 1": {
+							Offset:           aws.Int64(0),
 							DefaultSelection: aws.String("DEFAULT"),
+							SelectorType:     aws.String("TRACK"),
+							ProgramSelection: aws.Int64(1),
 						},
 					},
 					FileInput:      aws.String(inputFile),


### PR DESCRIPTION
Fix VID-461, based on suggestion in https://stackoverflow.com/questions/54527221/aws-mediaconvert-on-media-that-has-no-audio