### PR TITLE
cors: allow credentials and remove wildcard to allow cookie access key

### DIFF
--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -10,6 +10,9 @@ func AllowCORS() func(httprouter.Handle) httprouter.Handle {
 	return func(next httprouter.Handle) httprouter.Handle {
 		handler := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 			originDomain := r.Header.Get("Origin")
+			if originDomain == "" {
+				originDomain = "*"
+			}
 			w.Header().Set("Access-Control-Allow-Origin", originDomain)
 			w.Header().Set("Access-Control-Allow-Headers", "*")
 			w.Header().Set("Access-Control-Allow-Credentials", "true")

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -9,8 +9,10 @@ import (
 func AllowCORS() func(httprouter.Handle) httprouter.Handle {
 	return func(next httprouter.Handle) httprouter.Handle {
 		handler := func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
+			originDomain := r.Header.Get("Origin")
+			w.Header().Set("Access-Control-Allow-Origin", originDomain)
 			w.Header().Set("Access-Control-Allow-Headers", "*")
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			// Safari doesn't allow a wildcard for this so we just list them all
 			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE")
 


### PR DESCRIPTION
Allow credentials must be `true` to allow cookies to be passed in the `m3u8` request. 
Also, the allow origin header cannot be a wildcard