### PR TITLE
Fix Idle Stream Issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada
+	github.com/livepeer/go-api-client v0.4.12
 	github.com/livepeer/go-tools v0.3.3
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.7.4

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.10
+	github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada
 	github.com/livepeer/go-tools v0.3.3
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.7.4

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ github.com/livepeer/go-api-client v0.4.10 h1:WMWJ2guElf000TBcqQpbrC2zGGRlVlin/7w
 github.com/livepeer/go-api-client v0.4.10/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada h1:TN0jwa8hA/xBseYHj1nyRM/ZOm4ajdYc1xkbPOZwyAc=
 github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.12 h1:wxGBJKgvJ9vWuuwjI2RVGWUeKbBcJv8ihNQtwjdH4t4=
+github.com/livepeer/go-api-client v0.4.12/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.3 h1:Je2P+ovDIIlFWtlns5v+MmHtdIytsAJS6+XyeZ8sFJI=
 github.com/livepeer/go-tools v0.3.3/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/go.sum
+++ b/go.sum
@@ -417,6 +417,8 @@ github.com/libp2p/go-netroute v0.2.0 h1:0FpsbsvuSnAhXFnCY0VLFbJOzaK0VnP0r1QT/o4n
 github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+Ooo=
 github.com/livepeer/go-api-client v0.4.10 h1:WMWJ2guElf000TBcqQpbrC2zGGRlVlin/7w6lMvSGkY=
 github.com/livepeer/go-api-client v0.4.10/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada h1:TN0jwa8hA/xBseYHj1nyRM/ZOm4ajdYc1xkbPOZwyAc=
+github.com/livepeer/go-api-client v0.4.12-0.20231106122927-b996b8714ada/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.3 h1:Je2P+ovDIIlFWtlns5v+MmHtdIytsAJS6+XyeZ8sFJI=
 github.com/livepeer/go-tools v0.3.3/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/mapic/stats_collector.go
+++ b/mapic/stats_collector.go
@@ -87,7 +87,7 @@ func (c *metricsCollector) collectMetrics(ctx context.Context, mistState clients
 				return
 			}
 
-			if _, err := c.lapi.SetActive(info.stream.ID, true, info.startedAt); err != nil {
+			if err := c.lapi.Heartbeat(info.stream.ID); err != nil {
 				glog.Errorf("Error updating stream last seen. err=%q streamId=%q", err, info.stream.ID)
 				return
 			}


### PR DESCRIPTION
Fix https://linear.app/livepeer/issue/PS-91/switchboard-idlepending-status-inaccurate
Fix https://linear.app/livepeer/issue/VID-456/recording-stuck-in-progress
Fix https://linear.app/livepeer/issue/PS-84/livespace-webhooks-spamming

It fixes the issue that a stream is Idle (`"isActive": true,`) after finishing streaming for 90s.

**Explanation**

1. In https://github.com/livepeer/catalyst-api/pull/842 we started a loop in which every `1 min` we collect metrics from Mist and then call `setActive(true)` on studio.
2. That can lead to the race condition between this `setActive(true)` and `setActive(false)` sent from `STREAM_BUFFER` trigger when the stream is stopped
3. The root cause is that at the time of sending `setActive(true)` from the metrics collector, we're actually not sure that the stream is still active.
4. In this (and two other related PRs: https://github.com/livepeer/go-api-client/pull/52, https://github.com/livepeer/studio/pull/1957) I've added a new studio endpoint `/heartbeat` used to refresh the stream `lastSeen` state without stating if it's active or not

@gioelecerati FYI: There is also a race condition between calling `/setactive` and `/hook/health`, but I've never encountered them having different values. They are both triggered with the same Mist trigger, so I think we can leave it as it is right now.