### PR TITLE
Fix VTT thumbnails

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -24,7 +24,6 @@ import (
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 	"github.com/livepeer/catalyst-api/metrics"
-	"github.com/livepeer/catalyst-api/thumbnails"
 	"github.com/livepeer/catalyst-api/video"
 )
 
@@ -331,13 +330,6 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 
 		if si.GenerateMP4 {
 			log.Log(si.RequestID, "MP4s will be generated", "duration", si.InputFileInfo.Duration)
-		}
-
-		if si.ThumbnailsTargetURL != nil {
-			err = thumbnails.GenerateThumbs(osTransferURL, si.ThumbnailsTargetURL, si.InputFileInfo)
-			if err != nil {
-				log.LogError(si.RequestID, "generate thumbs failed", err, "in", osTransferURL, "out", si.ThumbnailsTargetURL)
-			}
 		}
 
 		c.startUploadJob(si)

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"github.com/livepeer/catalyst-api/thumbnails"
 	"net/url"
 	"os"
 	"path"
@@ -75,6 +76,13 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		f.sendSourcePlayback(job)
 	}
 	job.ReportProgress(clients.TranscodeStatusPreparingCompleted, 1)
+
+	if job.ThumbnailsTargetURL != nil {
+		err := thumbnails.GenerateThumbs(job.RequestID, job.SegmentingTargetURL, job.ThumbnailsTargetURL)
+		if err != nil {
+			log.LogError(job.RequestID, "generate thumbs failed", err, "in", job.SegmentingTargetURL, "out", job.ThumbnailsTargetURL)
+		}
+	}
 
 	// Transcode Beginning
 	log.Log(job.RequestID, "Beginning transcoding via FFMPEG/Livepeer pipeline")

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -2,108 +2,81 @@ package thumbnails
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"github.com/cenkalti/backoff/v4"
+	"io"
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
-	"strconv"
-	"strings"
 	"time"
 
+	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/clients"
-	"github.com/livepeer/catalyst-api/video"
+	"github.com/livepeer/catalyst-api/log"
 	"github.com/livepeer/go-tools/drivers"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
 )
 
 const resolution = "320:240"
 
-func GenerateThumbs(input *url.URL, output *url.URL, info video.InputVideo) error {
-	videoTrack, err := info.GetTrack(video.TrackTypeVideo)
+func GenerateThumbs(requestID, input string, output *url.URL) error {
+	log.Log(requestID, "generate thumbs start", "input", input)
+	inputURL, err := url.Parse(input)
 	if err != nil {
-		return nil
+		return err
 	}
-	if videoTrack.FPS <= 0 {
-		return fmt.Errorf("fps was invalid %v", videoTrack.FPS)
+	var rc io.ReadCloser
+	err = backoff.Retry(func() error {
+		rc, err = clients.GetFile(context.Background(), requestID, input, nil)
+		return err
+	}, clients.DownloadRetryBackoff())
+	if err != nil {
+		return fmt.Errorf("error downloading manifest: %w", err)
+	}
+	manifest, playlistType, err := m3u8.DecodeFrom(rc, true)
+	if err != nil {
+		return fmt.Errorf("failed to decode manifest: %w", err)
 	}
 
-	in, err := clients.SignURL(input)
-	if err != nil {
-		return fmt.Errorf("presigning failed: %w", err)
+	if playlistType != m3u8.MEDIA {
+		return fmt.Errorf("received non-Media manifest, but currently only Media playlists are supported")
 	}
+	mediaPlaylist, ok := manifest.(*m3u8.MediaPlaylist)
+	if !ok || mediaPlaylist == nil {
+		return fmt.Errorf("failed to parse playlist as MediaPlaylist")
+	}
+
 	tempDir, err := os.MkdirTemp(os.TempDir(), "thumbs-*")
 	if err != nil {
 		return fmt.Errorf("failed to make temp dir: %w", err)
 	}
 	defer os.RemoveAll(tempDir)
-
-	err = ffmpeg.
-		Input(in, ffmpeg.KwArgs{"skip_frame": "nokey"}). // only extract key frames
-		Output(
-			path.Join(tempDir, "/keyframes_%d.jpg"),
-			ffmpeg.KwArgs{
-				"vsync":     "0",
-				"frame_pts": "true", // PTS will be used as the filename suffix
-				// video filter to resize
-				"vf": fmt.Sprintf("scale=%s:force_original_aspect_ratio=decrease", resolution),
-			},
-		).OverWriteOutput().ErrorToStdOut().Run()
+	err = os.Mkdir(path.Join(tempDir, "segs"), 0755)
 	if err != nil {
-		return fmt.Errorf("error running ffmpeg for thumbnails %w", err)
+		return fmt.Errorf("failed to make segs dir: %w", err)
 	}
 
-	// generate the webvtt file
-	files, err := filepath.Glob(path.Join(tempDir, "keyframes*"))
-	if err != nil {
-		return fmt.Errorf("listing keyframes files failed: %w", err)
-	}
+	const layout = "15:04:05.000"
+	outputLocation := output.JoinPath("thumbnails").String()
 	builder := &bytes.Buffer{}
 	_, err = builder.WriteString("WEBVTT\n")
 	if err != nil {
 		return err
 	}
-	timestamp := time.Time{}
-	outputLocation := output.JoinPath("thumbnails").String()
-	for i, file := range files {
-		// we skip the first entry because we need to calculate the end timestamp of each frame by looking
-		// at the PTS of the next thumbnail, we then refer to the previous file when uploading at the bottom of the loop.
-		// e.g. keyframe_0.jpg we know starts at 00:00:00 but we need to check the PTS of the next file to know the end time.
-		if i == 0 {
-			continue
-		}
-		// extract the PTS value from the filename to be able to calculate the timestamp of the frame
-		filename := path.Base(file)                                        // e.g. keyframes_0.jpg
-		withoutExt := strings.TrimSuffix(filename, filepath.Ext(filename)) // e.g. keyframes_0
-		parts := strings.Split(withoutExt, "_")
-		if len(parts) < 2 {
-			return fmt.Errorf("thumbnail filename should contain an underscore %s", filename)
-		}
-		pts, err := strconv.ParseFloat(parts[1], 64)
-		if err != nil {
-			return fmt.Errorf("couldn't parse float for thumbnails %w", err)
-		}
-		seconds := pts / videoTrack.FPS
-
-		const layout = "15:04:05.000"
-		start := timestamp.Format(layout)
-		timestamp = time.Time{}.Add(time.Duration(seconds) * time.Second)
-		end := timestamp.Format(layout)
-
-		previousFile := files[i-1]
-		_, err = builder.WriteString(fmt.Sprintf("%s --> %s\n%s\n\n", start, end, path.Base(previousFile)))
+	var currentTime time.Time
+	for _, segment := range mediaPlaylist.GetAllSegments() {
+		thumbOut, err := processSegment(requestID, inputURL, segment, tempDir, outputLocation)
 		if err != nil {
 			return err
 		}
 
-		fileReader, err := os.Open(previousFile)
+		start := currentTime.Format(layout)
+		currentTime = currentTime.Add(time.Duration(segment.Duration) * time.Second)
+		end := currentTime.Format(layout)
+		_, err = builder.WriteString(fmt.Sprintf("%s --> %s\n%s\n\n", start, end, path.Base(thumbOut)))
 		if err != nil {
 			return err
-		}
-		defer fileReader.Close()
-		err = clients.UploadToOSURL(outputLocation, path.Base(previousFile), fileReader, time.Minute)
-		if err != nil {
-			return fmt.Errorf("failed to upload thumbnail: %w", err)
 		}
 	}
 
@@ -111,5 +84,63 @@ func GenerateThumbs(input *url.URL, output *url.URL, info video.InputVideo) erro
 	if err != nil {
 		return fmt.Errorf("failed to upload vtt: %w", err)
 	}
+	log.Log(requestID, "generate thumbs end", "input", input)
 	return nil
+}
+
+func processSegment(requestID string, inputURL *url.URL, segment *m3u8.MediaSegment, tempDir string, outputLocation string) (string, error) {
+	segURL := inputURL.JoinPath("..", segment.URI)
+	var (
+		rc  io.ReadCloser
+		err error
+	)
+	err = backoff.Retry(func() error {
+		rc, err = clients.GetFile(context.Background(), requestID, segURL.String(), nil)
+		return err
+	}, clients.DownloadRetryBackoff())
+	if err != nil {
+		return "", fmt.Errorf("error downloading segment %s: %w", segURL, err)
+	}
+	bs, err := io.ReadAll(rc)
+	if err != nil {
+		return "", fmt.Errorf("error reading segment %s: %w", segURL, err)
+	}
+
+	tmpSegFile := path.Join(tempDir, "segs", path.Base(segment.URI))
+	err = os.WriteFile(tmpSegFile, bs, 0644)
+	if err != nil {
+		return "", fmt.Errorf("error saving segment %s: %w", segURL, err)
+	}
+
+	thumbOut := path.Join(tempDir, fmt.Sprintf("keyframes_%d.jpg", segment.SeqId))
+	var ffmpegErr bytes.Buffer
+	err = ffmpeg.
+		Input(tmpSegFile, ffmpeg.KwArgs{"skip_frame": "nokey"}). // only extract key frames
+		Output(
+			thumbOut,
+			ffmpeg.KwArgs{
+				"ss":      "00:00:00",
+				"vframes": "1",
+				// video filter to resize
+				"vf": fmt.Sprintf("scale=%s:force_original_aspect_ratio=decrease", resolution),
+			},
+		).OverWriteOutput().WithErrorOutput(&ffmpegErr).Run()
+	if err != nil {
+		return "", fmt.Errorf("error running ffmpeg for thumbnails %s [%s]: %w", segURL, ffmpegErr.String(), err)
+	}
+	err = os.Remove(tmpSegFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to remove temp file %s: %w", segURL, err)
+	}
+
+	fileReader, err := os.Open(thumbOut)
+	if err != nil {
+		return "", err
+	}
+	defer fileReader.Close()
+	err = clients.UploadToOSURL(outputLocation, path.Base(thumbOut), fileReader, time.Minute)
+	if err != nil {
+		return "", fmt.Errorf("failed to upload thumbnail %s: %w", segURL, err)
+	}
+	return thumbOut, nil
 }

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -4,30 +4,24 @@ import (
 	"context"
 	"net/url"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
-	"github.com/livepeer/catalyst-api/video"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
 func TestGenerateThumbs(t *testing.T) {
-	u, err := url.Parse("../test/fixtures/tiny.mp4")
-	require.NoError(t, err)
-
 	outDir, err := os.MkdirTemp(os.TempDir(), "thumbs*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 
 	out, err := url.Parse(outDir)
 	require.NoError(t, err)
-	err = GenerateThumbs(u, out, video.InputVideo{
-		Tracks: []video.InputTrack{{
-			Type:       video.TrackTypeVideo,
-			VideoTrack: video.VideoTrack{FPS: 30},
-		}},
-	})
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	err = GenerateThumbs("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
 	require.NoError(t, err)
 
 	expectedVtt := `WEBVTT
@@ -35,10 +29,10 @@ func TestGenerateThumbs(t *testing.T) {
 keyframes_0.jpg
 
 00:00:10.000 --> 00:00:20.000
-keyframes_300.jpg
+keyframes_1.jpg
 
 00:00:20.000 --> 00:00:30.000
-keyframes_600.jpg
+keyframes_2.jpg
 
 `
 


### PR DESCRIPTION
I had to pretty much rewrite the thumbnail generation so the diff probably isn't that useful when reviewing sorry..
- The old code was reading the input file directly, I realised that wouldn't work for HLS input so it now processes the manifest (after segmenting for mp4 input)
- The old code had quite a complex way to work out the timestamps by parsing the PTS values from the filenames, fortunately that's way simpler now that we just loop through the manifest and get the timings based on the segment durations.
- Now that we're just using ffmpeg to fetch the starting frame of a segment the command is exactly the same as the one we use in catalyst-uploader for the live `latest.jpg`