### PR TITLE
transmux: use stream based concatenation for clips

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -193,14 +193,14 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 
 		var concatFiles []string
 		for rendition, segments := range renditionList.RenditionSegmentTable {
-			// a. create folder to hold transmux-ed files in local storage temporarily
+			// Create folder to hold transmux-ed files in local storage temporarily
 			err := os.MkdirAll(TransmuxStorageDir, 0700)
 			if err != nil && !os.IsExist(err) {
 				log.Log(transcodeRequest.RequestID, "failed to create temp dir for transmuxing", "dir", TransmuxStorageDir, "err", err)
 				return outputs, segmentsCount, err
 			}
 
-			// b. create a single .ts file for a given rendition by concatenating all segments in order
+			// Create a single .ts file for a given rendition by concatenating all segments in order
 			if rendition == "low-bitrate" {
 				// skip mp4 generation for low-bitrate profile
 				continue
@@ -208,13 +208,20 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 			concatTsFileName := filepath.Join(TransmuxStorageDir, transcodeRequest.RequestID+"_"+rendition+".ts")
 			concatFiles = append(concatFiles, concatTsFileName)
 			defer os.Remove(concatTsFileName)
-			totalBytes, err := video.ConcatTS(concatTsFileName, segments)
+			// For now, use the stream based concat for clipping only and file based concat for everything else.
+			// Eventually, all mp4 generation can be moved to stream based concat once proven effective.
+			var totalBytes int64
+			if transcodeRequest.IsClip {
+				totalBytes, err = video.ConcatTS(concatTsFileName, segments, true)
+			} else {
+				totalBytes, err = video.ConcatTS(concatTsFileName, segments, false)
+			}
 			if err != nil {
 				log.Log(transcodeRequest.RequestID, "error concatenating .ts", "file", concatTsFileName, "err", err)
 				continue
 			}
 
-			// c. Verify the total bytes written for the single .ts file for a given rendition matches the total # of bytes we received from T
+			// Verify the total bytes written for the single .ts file for a given rendition matches the total # of bytes we received from T
 			renditionIndex := getProfileIndex(transcodeProfiles, rendition)
 			var rendBytesWritten int64 = -1
 			for _, v := range transcodedStats {
@@ -227,7 +234,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 				break
 			}
 
-			// d. Mux the .ts file to generate either a regular MP4 (w/ faststart) or fMP4 packaged with HLS/DASH
+			// Mux the .ts file to generate either a regular MP4 (w/ faststart) or fMP4 packaged with HLS/DASH
 			if enableStandardMp4 {
 				// Transmux the single .ts file into an mp4 file
 				mp4OutputFileName := concatTsFileName[:len(concatTsFileName)-len(filepath.Ext(concatTsFileName))] + ".mp4"

--- a/video/transmux.go
+++ b/video/transmux.go
@@ -129,56 +129,73 @@ func ConcatTS(tsFileName string, segmentsList *TSegmentList, useStreamBasedConca
 		defer os.Remove(segmentListTxtFileName)
 		w := bufio.NewWriter(segmentListTxtFile)
 
+		// Save a list of segment filenames so that we can delete them once done
+		segmentFilenames := []string{}
+		defer func() {
+			for _, f := range segmentFilenames {
+				os.Remove(f)
+			}
+		}()
+
 		// Write each segment to disk and add segment filename to the text file
 		for segName, segData := range segmentsList.GetSortedSegments() {
 			// Open a new file to write each segment to disk
-			segmentFileName := fileBaseWithoutExt + "_" + strconv.Itoa(segName) + ".ts"
-			segmentFile, err := os.Create(segmentFileName)
+			segmentFilename := fileBaseWithoutExt + "_" + strconv.Itoa(segName) + ".ts"
+			segmentFile, err := os.Create(segmentFilename)
 			if err != nil {
-				return totalBytes, fmt.Errorf("error creating individual segment file (%s) err: %w", segmentFileName, err)
+				return totalBytes, fmt.Errorf("error creating individual segment file (%s) err: %w", segmentFilename, err)
 			}
 			defer segmentFile.Close()
-			//defer os.Remove(segmentFileName)
 			// Write the segment data to disk
 			segBytes, err := segmentFile.Write(segmentsList.SegmentDataTable[segData])
 			if err != nil {
 				return totalBytes, fmt.Errorf("error writing segment %d err: %w", segName, err)
 			}
+			segmentFilenames = append(segmentFilenames, segmentFilename)
 			totalBytes = totalBytes + int64(segBytes)
 			// Add filename to the text file
-			line := fmt.Sprintf("file '%s'\n", segmentFileName)
+			line := fmt.Sprintf("file '%s'\n", segmentFilename)
 			if _, err = w.WriteString(line); err != nil {
 				return totalBytes, fmt.Errorf("error writing segment %d to text file err: %w", segName, err)
 			}
 			// Flush to make sure all buffered operations are applied
 			if err = w.Flush(); err != nil {
-				return totalBytes, fmt.Errorf("error flushing text file %s err: %w", segmentFileName, err)
+				return totalBytes, fmt.Errorf("error flushing text file %s err: %w", segmentFilename, err)
 			}
 		}
-		// Create a .ts file for a given rendition
-		tsFile, err := os.Create(tsFileName)
+
+		// Use stream-based concatenation by reading segment files in text file
+		err = concatStreams(segmentListTxtFileName, tsFileName)
 		if err != nil {
-			return totalBytes, fmt.Errorf("error creating file (%s) err: %w", tsFileName, err)
-		}
-		defer tsFile.Close()
-		// Transmux the individual .ts files into a combined single ts file using stream based concatenation
-		err = ffmpeg.Input(segmentListTxtFileName, ffmpeg.KwArgs{
-			"f":    "concat", // Use stream based concatenation (instead of file based concatenation)
-			"safe": "0"}).    // Must be 0 since relative paths to segments are used in segmentListTxtFileName
-			Output(tsFileName, ffmpeg.KwArgs{
-				"c": "copy", // Don't accidentally transcode
-			}).
-			OverWriteOutput().ErrorToStdOut().Run()
-		if err != nil {
-			return totalBytes, fmt.Errorf("failed to transmux multiple ts files from %s into a ts file: %w", segmentListTxtFileName, err)
-		}
-		// Verify the ts output file was created
-		_, err = os.Stat(tsFileName)
-		if err != nil {
-			return totalBytes, fmt.Errorf("transmux error: failed to stat .ts media file: %w", err)
+			return totalBytes, fmt.Errorf("failed to stream-concat %s into a ts file: %w", segmentListTxtFileName, err)
 		}
 
 		return totalBytes, nil
 	}
+}
 
+func concatStreams(segmentList, outputTsFileName string) error {
+	// Create a .ts file for a given rendition
+	tsFile, err := os.Create(outputTsFileName)
+	if err != nil {
+		return fmt.Errorf("error creating file (%s) err: %w", outputTsFileName, err)
+	}
+	defer tsFile.Close()
+	// Transmux the individual .ts files into a combined single ts file using stream based concatenation
+	err = ffmpeg.Input(segmentList, ffmpeg.KwArgs{
+		"f":    "concat", // Use stream based concatenation (instead of file based concatenation)
+		"safe": "0"}).    // Must be 0 since relative paths to segments are used in segmentListTxtFileName
+		Output(outputTsFileName, ffmpeg.KwArgs{
+			"c": "copy", // Don't accidentally transcode
+		}).
+		OverWriteOutput().ErrorToStdOut().Run()
+	if err != nil {
+		return fmt.Errorf("failed to transmux multiple ts files from %s into a ts file: %w", segmentList, err)
+	}
+	// Verify the ts output file was created
+	_, err = os.Stat(outputTsFileName)
+	if err != nil {
+		return fmt.Errorf("transmux error: failed to stat .ts media file: %w", err)
+	}
+	return nil
 }

--- a/video/transmux_test.go
+++ b/video/transmux_test.go
@@ -1,0 +1,48 @@
+package video
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestItConcatsStreams(t *testing.T) {
+	// test pre-reqs
+	tr := populateRenditionSegmentList()
+	segmentList := tr.GetSegmentList("rendition-1080p0")
+	concatDir, err := os.MkdirTemp(os.TempDir(), "concat_stage_")
+	require.NoError(t, err)
+	// verify file-based concatenation
+	totalBytesWritten, err := ConcatTS(concatDir+"test.ts", segmentList, false)
+	require.NoError(t, err)
+	require.Equal(t, int64(594644), totalBytesWritten)
+	// verify stream-based concatenation
+	totalBytesW, err := ConcatTS(concatDir+"test.ts", segmentList, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(594644), totalBytesW)
+}
+
+func populateRenditionSegmentList() *TRenditionList {
+	segmentFiles := []string{"../test/fixtures/seg-0.ts", "../test/fixtures/seg-1.ts", "../test/fixtures/seg-2.ts"}
+
+	renditionList := &TRenditionList{
+		RenditionSegmentTable: make(map[string]*TSegmentList),
+	}
+	segmentList := &TSegmentList{
+		SegmentDataTable: make(map[int][]byte),
+	}
+
+	for i, filePath := range segmentFiles {
+		data := readSegmentData(filePath)
+		segmentList.AddSegmentData(i, data)
+	}
+
+	renditionList.AddRenditionSegment("rendition-1080p0", segmentList)
+
+	return renditionList
+}
+
+func readSegmentData(filePath string) []byte {
+	data, _ := os.ReadFile(filePath)
+	return data
+}


### PR DESCRIPTION
Occasionally, the mp4s of very short clips might stutter as it crosses segment boundaries. This was caused by incorrect PTS between segments which in turn is a result of us clipping and re-encoding the first and last segments "locally". Using a stream based concatenation instead of file based concatenation readjusts the timestamps and prevents these issues.

Note: Eventually, all mp4s will be generated using stream based concatenation if this works well for clipping.