### PR TITLE
mapic: remove videorec

### DIFF
--- a/clients/mist_client_test.go
+++ b/clients/mist_client_test.go
@@ -354,7 +354,7 @@ func TestItCanGetStreamStats(t *testing.T) {
 		},
         "push_auto_list": [
           [
-            "videorec+",
+            "video+",
             "s3+https://***:***@storage.googleapis.com/target",
             null,
             null,
@@ -390,7 +390,7 @@ func TestItCanGetStreamStats(t *testing.T) {
 	require.Equal(t, ok, true)
 	require.Equal(t, streamStats.MediaTimeMs, int64(265458))
 	require.Len(t, status.PushAutoList, 1)
-	require.Equal(t, status.PushAutoList[0].Stream, "videorec+")
+	require.Equal(t, status.PushAutoList[0].Stream, "video+")
 	require.Equal(t, status.PushAutoList[0].Target, "s3+https://***:***@storage.googleapis.com/target")
 	require.Len(t, status.ActiveStreams, 1)
 	require.Equal(t, status.ActiveStreams["video+c447r0acdmqhhhpb"].Source, "push://")
@@ -526,7 +526,7 @@ func TestMistPushAutoUnmarshal(t *testing.T) {
 		{
 			mistPushAutoBody: `
 				[
-					"videorec+",
+					"video+",
 					"s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source",
 					null,
 					null,
@@ -536,7 +536,7 @@ func TestMistPushAutoUnmarshal(t *testing.T) {
 					null
 				]
 			`,
-			wantStream: "videorec+",
+			wantStream: "video+",
 			wantTarget: "s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source",
 		},
 		{
@@ -560,7 +560,7 @@ func TestMistPushAutoUnmarshal(t *testing.T) {
 		{
 			mistPushAutoBody: `
 				[
-					"videorec+",
+					"video+",
 					null,
 					null,
 					null,

--- a/config/cli.go
+++ b/config/cli.go
@@ -28,7 +28,6 @@ type Cli struct {
 	MistStreamSource          string
 	MistHardcodedBroadcasters string
 	MistScrapeMetrics         bool
-	MistSendAudio             string
 	MistBaseStreamName        string
 	MistLoadBalancerPort      int
 	MistLoadBalancerTemplate  string

--- a/main.go
+++ b/main.go
@@ -84,7 +84,6 @@ func main() {
 	fs.StringVar(&cli.MistStreamSource, "mist-stream-source", "push://", "Stream source we should use for created Mist stream")
 	fs.StringVar(&cli.MistHardcodedBroadcasters, "mist-hardcoded-broadcasters", "", "Hardcoded broadcasters for use by MistProcLivepeer")
 	config.InvertedBoolFlag(fs, &cli.MistScrapeMetrics, "mist-scrape-metrics", true, "Scrape statistics from MistServer and publish to RabbitMQ")
-	fs.StringVar(&cli.MistSendAudio, "send-audio", "record", "when should we send audio?  {always|never|record}")
 	fs.StringVar(&cli.MistBaseStreamName, "mist-base-stream-name", "video", "Base stream name to be used in wildcard-based routing scheme")
 	fs.StringVar(&cli.APIServer, "api-server", "", "Livepeer API server to use")
 	fs.StringVar(&cli.AMQPURL, "amqp-url", "", "RabbitMQ url")
@@ -111,6 +110,8 @@ func main() {
 	fs.StringVar(&cli.GateURL, "gate-url", "http://localhost:3004/api/access-control/gate", "Address to contact playback gating API for access control verification")
 	config.InvertedBoolFlag(fs, &cli.MistTriggerSetup, "mist-trigger-setup", true, "Overwrite Mist triggers with the ones built into catalyst-api")
 	pprofPort := fs.Int("pprof-port", 6061, "Pprof listen port")
+
+	fs.String("send-audio", "", "[DEPRECATED] ignored, will be removed")
 
 	// special parameters
 	mistJson := fs.Bool("j", false, "Print application info as JSON. Used by Mist to present flags in its UI.")

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -23,9 +23,6 @@ import (
 )
 
 const streamPlaybackPrefix = "playback_"
-const audioAlways = "always"
-const audioRecord = "record"
-const audioEnabledStreamSuffix = "rec"
 const waitForPushError = 7 * time.Second
 const waitForPushErrorIncreased = 2 * time.Minute
 const keepStreamAfterEnd = 15 * time.Second
@@ -495,25 +492,7 @@ func (mc *mac) removeInfoLocked(playbackID string) {
 }
 
 func (mc *mac) wildcardPlaybackID(stream *api.Stream) string {
-	return mc.baseNameForStream(stream) + "+" + stream.PlaybackID
-}
-
-func (mc *mac) baseNameForStream(stream *api.Stream) string {
-	baseName := mc.baseStreamName
-	if mc.shouldEnableAudio(stream) {
-		baseName += audioEnabledStreamSuffix
-	}
-	return baseName
-}
-
-func (mc *mac) shouldEnableAudio(stream *api.Stream) bool {
-	audio := false
-	if mc.config.MistSendAudio == audioAlways {
-		audio = true
-	} else if mc.config.MistSendAudio == audioRecord {
-		audio = stream.Record
-	}
-	return audio
+	return mc.baseStreamName + "+" + stream.PlaybackID
 }
 
 // reconcileLoop calls reconcileStream, reconcileMultistream and processStats

--- a/mapic/mistapiconnector_app_test.go
+++ b/mapic/mistapiconnector_app_test.go
@@ -40,7 +40,7 @@ func TestReconcileMultistream(t *testing.T) {
 				// Ignore, PUSH used for recordings
 				{
 					ID:          1,
-					Stream:      "videorec+",
+					Stream:      "video+",
 					OriginalURL: "s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source",
 				},
 				// Stop, does not exist in cached stream info
@@ -59,9 +59,9 @@ func TestReconcileMultistream(t *testing.T) {
 			PushAutoList: []*clients.MistPushAuto{
 				// Ignore, PUSH_AUTO used for recordings
 				{
-					Stream:       "videorec+",
+					Stream:       "video+",
 					Target:       "s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source",
-					StreamParams: []interface{}{"videorec+", "s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source", nil, nil, nil, nil, nil},
+					StreamParams: []interface{}{"video+", "s3+https://***:***@storage.googleapis.com/lp-us-catalyst-recordings-monster/hls/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=source", nil, nil, nil, nil, nil},
 				},
 				// Remove, does not exist in cached stream info
 				{
@@ -187,9 +187,7 @@ func TestReconcileStreams(t *testing.T) {
 	mc := mac{
 		mist:           mm,
 		baseStreamName: "video",
-		config: &config.Cli{
-			MistSendAudio: audioRecord,
-		},
+		config:         &config.Cli{},
 	}
 
 	mm.EXPECT().GetState().DoAndReturn(func() (clients.MistState, error) {
@@ -254,10 +252,10 @@ func TestReconcileStreams(t *testing.T) {
 	expectedNuked := []string{
 		// Deleted stream
 		"video+6736xac7u1hj36pa",
-		"videorec+6736xac7u1hj36pa",
+		"video+6736xac7u1hj36pa",
 		// Suspended stream
 		"video+abcdefghi",
-		"videorec+abcdefghi",
+		"video+abcdefghi",
 	}
 	require.ElementsMatch(t, expectedNuked, recodedNuked)
 }


### PR DESCRIPTION
We no longer send audio to MistProcLivepeer ever and we record every stream so we can finally ditch `videorec` and go with `video` every time. Hooray!