### PR TITLE
access-control: implement in-memory rate limiting

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -123,6 +123,7 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 
 	if _, ok := hitRecordCache.data[playbackID]; ok {
 		hitRecordCache.mux.Lock()
+		defer hitRecordCache.mux.Unlock()
 
 		if len(hitRecordCache.data[playbackID].hits) >= hitRecordCache.data[playbackID].rateLimit {
 			return false, nil

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -271,18 +271,20 @@ func (g *GateClient) QueryGate(body []byte) (bool, int32, int32, int32, error) {
 
 	var rateLimit int32 = 0
 
-	var result map[string]interface{}
-	err = json.NewDecoder(res.Body).Decode(&result)
-	if err != nil {
-		return false, 0, 0, 0, err
-	}
-
-	if rl, ok := result["rateLimit"]; ok {
-		rateLimitFloat64, ok := rl.(float64)
-		if !ok {
-			return false, 0, 0, 0, fmt.Errorf("rateLimit is not a number")
+	if res.ContentLength != 0 {
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		if err != nil {
+			return false, 0, 0, 0, err
 		}
-		rateLimit = int32(rateLimitFloat64)
+
+		if rl, ok := result["rateLimit"]; ok {
+			rateLimitFloat64, ok := rl.(float64)
+			if !ok {
+				return false, 0, 0, 0, fmt.Errorf("rateLimit is not a number")
+			}
+			rateLimit = int32(rateLimitFloat64)
+		}
 	}
 
 	return res.StatusCode/100 == 2, rateLimit, int32(cc.MaxAge), int32(cc.StaleWhileRevalidate), nil

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -129,7 +129,7 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 
 		if len(hitRecordCache.data[playbackID].hits) >= hitRecordCache.data[playbackID].rateLimit {
 			glog.Infof("rate limit exeeded for playbackId=%v cacheKey=%v rateLimit=%v", playbackID, cacheKey, hitRecordCache.data[playbackID].rateLimit)
-			return false, fmt.Errorf("rate limit exceeded for playbackId=%v", playbackID)
+			return false, nil
 		}
 
 		hitRecordCache.data[playbackID].hits = append(hitRecordCache.data[playbackID].hits, time.Now())

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -251,6 +251,12 @@ func (ac *AccessControlHandlersCollection) cachePlaybackAccessControlInfo(playba
 	return nil
 }
 
+// Returns:
+// - bool: whether the request was successful
+// - int32: the rate limit for the request
+// - int32: the max age for the request
+// - int32: the stale while revalidate for the request
+// - error: if any
 func (g *GateClient) QueryGate(body []byte) (bool, int32, int32, int32, error) {
 	req, err := http.NewRequest("POST", g.gateURL, bytes.NewReader(body))
 	if err != nil {

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/log"
@@ -27,7 +26,6 @@ type AccessControlHandlersCollection struct {
 	mutex       sync.RWMutex
 	gateClient  GateAPICaller
 	blockedJWTs []string
-	cacheHits   map[string]*HitRecord
 }
 
 type PlaybackAccessControlEntry struct {
@@ -124,11 +122,9 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 	}
 
 	if _, ok := hitRecordCache.data[playbackID]; ok {
-
 		hitRecordCache.mux.Lock()
 
 		if len(hitRecordCache.data[playbackID].hits) >= hitRecordCache.data[playbackID].rateLimit {
-			glog.Infof("rate limit exeeded for playbackId=%v cacheKey=%v rateLimit=%v", playbackID, cacheKey, hitRecordCache.data[playbackID].rateLimit)
 			return false, nil
 		}
 


### PR DESCRIPTION
This should fix rate limiting, handling it in memory in catalyst instead of Studio
Goes along with https://github.com/livepeer/studio/pull/1982