### PR TITLE
clients: ignore SPS errors when probing input files

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -66,7 +66,11 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 	inputFileProbe, err := s.Probe.ProbeFile(requestID, signedURL)
 	if err != nil {
 		log.Log(requestID, "probe failed", "err", err, "source", inputFile.String(), "dest", osTransferURL.String())
-		return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)
+		if strings.Contains(err.Error(), "non-existing SPS") {
+			log.LogError(requestID, "probe warning", err)
+		} else {
+			return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)
+		}
 	}
 
 	log.Log(requestID, "probe succeeded", "source", inputFile.String(), "dest", osTransferURL.String())


### PR DESCRIPTION
SPS errors are indicative of an encoding issue but typically don't cause issues with transcode and playback. We should ignore these as they're already ignored post-segment and pre-transcode stage.

Follow-on change from VID-450 which was fixed here: https://github.com/livepeer/catalyst-api/pull/928/files