### PR TITLE
Revert "clients: ignore SPS errors when probing input files (#1006)"

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -66,11 +66,7 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 	inputFileProbe, err := s.Probe.ProbeFile(requestID, signedURL)
 	if err != nil {
 		log.Log(requestID, "probe failed", "err", err, "source", inputFile.String(), "dest", osTransferURL.String())
-		if strings.Contains(err.Error(), "non-existing SPS") {
-			log.LogError(requestID, "probe warning", err)
-		} else {
-			return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)
-		}
+		return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)
 	}
 
 	log.Log(requestID, "probe succeeded", "source", inputFile.String(), "dest", osTransferURL.String())


### PR DESCRIPTION
This is not working quite as expected and causing unnecessary failures. Reverting for now