### PR TITLE
Revert "access-control: return 200 false on triggerUserNew fail (#1014)"

### DIFF
--- a/handlers/misttriggers/user_new.go
+++ b/handlers/misttriggers/user_new.go
@@ -69,7 +69,7 @@ func (d *MistCallbackHandlersCollection) TriggerUserNew(ctx context.Context, w h
 	resp, err := d.broker.TriggerUserNew(ctx, &payload)
 	if err != nil {
 		glog.Infof("Error handling USER_NEW payload error=%q payload=%q", err, string(body))
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusInternalServerError)
 		w.Write([]byte("false")) // nolint:errcheck
 		return
 	}

--- a/handlers/misttriggers/user_new_test.go
+++ b/handlers/misttriggers/user_new_test.go
@@ -90,7 +90,7 @@ func TestItCanHandleFailureToHandle(t *testing.T) {
 		rr := doUserNewRequest(t, userNewPayload, func(ctx context.Context, p *UserNewPayload) (bool, error) {
 			return state, fmt.Errorf("something went wrong")
 		})
-		require.Equal(t, rr.Result().StatusCode, 200)
+		require.Equal(t, rr.Result().StatusCode, 500)
 		require.Equal(t, rr.Body.String(), "false")
 	}
 }


### PR DESCRIPTION
This reverts commit 2a04b39368746a497b621a9c90b02ffcd485f9fd. Seemed to be causing catalyst e2e failures