### PR TITLE
analytics: write to database nonblocking

### DIFF
--- a/handlers/analytics/user_end.go
+++ b/handlers/analytics/user_end.go
@@ -28,6 +28,11 @@ func (a *AnalyticsHandler) HandleUserEnd(ctx context.Context, payload *misttrigg
 
 	// No need to block our response to Mist; everything else in a goroutine
 	go func() {
+		defer func() {
+			if rec := recover(); rec != nil {
+				glog.Errorf("panic writing to analytics database err=%s payload=%v", rec, payload)
+			}
+		}()
 		insertDynStmt := `insert into "` + USER_END_TABLE_NAME + `"(
 			"uuid",
 			"timestamp_ms",

--- a/handlers/analytics/user_end.go
+++ b/handlers/analytics/user_end.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 )
 
@@ -25,41 +26,44 @@ func (a *AnalyticsHandler) HandleUserEnd(ctx context.Context, payload *misttrigg
 		return nil
 	}
 
-	insertDynStmt := `insert into "` + USER_END_TABLE_NAME + `"(
-		"uuid",
-		"timestamp_ms",
-		"connection_token",
-		"downloaded_bytes",
-		"uploaded_bytes",
-		"session_duration_s",
-		"stream_id",
-		"stream_id_count",
-		"protocol",
-		"protocol_count",
-		"ip_address",
-		"ip_address_count",
-		"tags"
-		) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
-	_, err := a.db.Exec(
-		insertDynStmt,
-		payload.TriggerID,                               // uuid
-		time.Now().UnixMilli(),                          // timestamp_ms
-		payload.ConnectionToken,                         // connection_token
-		payload.DownloadedBytes,                         // downloaded_bytes
-		payload.UploadedBytes,                           // uploaded_bytes
-		payload.TimeActiveSecs,                          // session_duration_s
-		payload.StreamNames[len(payload.StreamNames)-1], // stream_id
-		len(payload.StreamNames),                        // stream_id_count
-		payload.Protocols[len(payload.Protocols)-1],     // protocol
-		len(payload.Protocols),                          // protocol_count
-		payload.IPs[len(payload.IPs)-1],                 // ip_address
-		len(payload.IPs),                                // ip_address_count
-		strings.Join(payload.Tags, ","),                 // tags
+	// No need to block our response to Mist; everything else in a goroutine
+	go func() {
+		insertDynStmt := `insert into "` + USER_END_TABLE_NAME + `"(
+			"uuid",
+			"timestamp_ms",
+			"connection_token",
+			"downloaded_bytes",
+			"uploaded_bytes",
+			"session_duration_s",
+			"stream_id",
+			"stream_id_count",
+			"protocol",
+			"protocol_count",
+			"ip_address",
+			"ip_address_count",
+			"tags"
+			) values($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)`
+		_, err := a.db.Exec(
+			insertDynStmt,
+			payload.TriggerID,                               // uuid
+			time.Now().UnixMilli(),                          // timestamp_ms
+			payload.ConnectionToken,                         // connection_token
+			payload.DownloadedBytes,                         // downloaded_bytes
+			payload.UploadedBytes,                           // uploaded_bytes
+			payload.TimeActiveSecs,                          // session_duration_s
+			payload.StreamNames[len(payload.StreamNames)-1], // stream_id
+			len(payload.StreamNames),                        // stream_id_count
+			payload.Protocols[len(payload.Protocols)-1],     // protocol
+			len(payload.Protocols),                          // protocol_count
+			payload.IPs[len(payload.IPs)-1],                 // ip_address
+			len(payload.IPs),                                // ip_address_count
+			strings.Join(payload.Tags, ","),                 // tags
 
-	)
-	if err != nil {
-		return err
-	}
+		)
+		if err != nil {
+			glog.Errorf("error writing to analytics database err=%s payload=%v", err, payload)
+		}
+	}()
 
 	return nil
 }

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -84,6 +84,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^I receive a "([^"]*)" callback within "(\d+)" seconds$`, stepContext.CheckCallback)
 	ctx.Step(`^a source copy (has|has not) been written to disk$`, stepContext.SourceCopyWrittenToDisk)
 	ctx.Step(`^a row is written to the "([^"]*)" database table containing the following values$`, stepContext.CheckDatabase)
+	ctx.Step(`^a row is written within "(\d+)" seconds to the "([^"]*)" database table containing the following values$`, stepContext.CheckDatabasePoll)
 	ctx.Step(`^thumbnails are written to storage within "(\d+)" seconds$`, stepContext.ThumbnailsWrittenToStorage)
 
 	// Mediaconvert Steps

--- a/test/features/triggers.feature
+++ b/test/features/triggers.feature
@@ -8,7 +8,7 @@ Feature: Mist trigger handling
         When Mist calls the "USER_END" trigger with "valid-user-end" and ID "abc-123"
         And receives a response within "3" seconds
         Then Mist gets an HTTP response with code "200"
-        And a row is written to the "user_end_trigger" database table containing the following values
+        And a row is written within "3" seconds to the "user_end_trigger" database table containing the following values
             | column           | value                  |
             | uuid             | abc-123                |
             | stream_id        | video+111dip9jqar876kl |

--- a/test/steps/database.go
+++ b/test/steps/database.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cucumber/godog"
 	embeddedpostgres "github.com/fergusstrange/embedded-postgres"
@@ -157,4 +158,17 @@ func (s *StepContext) CheckDatabase(table string, keyValues *godog.Table) error 
 		}
 	}
 	return nil
+}
+
+func (s *StepContext) CheckDatabasePoll(seconds int, table string, keyValues *godog.Table) error {
+	var err error
+	for i := 0; i < 2*seconds; i++ {
+		err = s.CheckDatabase(table, keyValues)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	return fmt.Errorf("failed to meet database criteria in %d seconds: %w", seconds, err)
 }


### PR DESCRIPTION
So that if it's slow we don't block responding to Mist's USER_END.