### PR TITLE
access-control: Avoid fail open when JWT is blocked

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -99,7 +99,7 @@ func (ac *AccessControlHandlersCollection) IsAuthorized(playbackID string, paylo
 		for _, blocked := range ac.blockedJWTs {
 			if jwt == blocked {
 				glog.Errorf("blocking JWT. playbackId=%v jwt=%v", acReq.Stream, jwt)
-				return false, fmt.Errorf("JWT is blocked: %s", jwt)
+				return false, nil
 			}
 		}
 


### PR DESCRIPTION
Fixes https://github.com/livepeer/catalyst-api/pull/1048#discussion_r1431910746