### PR TITLE
log: fix bugs, add "caller" logging, add 100% test coverage

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/log"
@@ -145,13 +144,15 @@ func (ac *AccessControlHandlersCollection) GetPlaybackAccessControlInfo(ctx cont
 	ac.mutex.RUnlock()
 
 	if isExpired(entry) {
-		glog.V(7).Infof("Cache expired for playbackId=%v cacheKey=%v", playbackID, cacheKey)
+		log.V(7).LogCtx(ctx, "Cache expired",
+			"cache_key", cacheKey)
 		err := ac.cachePlaybackAccessControlInfo(playbackID, cacheKey, requestBody)
 		if err != nil {
 			return false, err
 		}
 	} else if isStale(entry) {
-		glog.V(7).Infof("Cache stale for playbackId=%v cacheKey=%v\n", playbackID, cacheKey)
+		log.V(7).LogCtx(ctx, "Cache stale",
+			"cache_key", cacheKey)
 		go func() {
 			ac.mutex.RLock()
 			stillStale := isStale(ac.cache[playbackID][cacheKey])

--- a/log/clog.go
+++ b/log/clog.go
@@ -5,6 +5,8 @@ package log
 
 import (
 	"context"
+
+	kitlog "github.com/go-kit/log"
 )
 
 // unique type to prevent assignment.
@@ -54,6 +56,7 @@ func LogCtx(ctx context.Context, message string, args ...any) {
 	}
 	allArgs := append([]any{}, meta.Flat()...)
 	allArgs = append(allArgs, args...)
+	allArgs = append(allArgs, "caller", kitlog.Caller(2)())
 	if requestID == "" {
 		LogNoRequestID(message, allArgs...)
 	} else {

--- a/log/clog.go
+++ b/log/clog.go
@@ -49,7 +49,7 @@ func WithLogValues(ctx context.Context, args ...string) context.Context {
 func LogCtx(ctx context.Context, message string, args ...any) {
 	var requestID string
 	meta, _ := ctx.Value(clogContextKey).(metadata)
-	if meta == nil {
+	if meta != nil {
 		requestID, _ = meta["request_id"].(string)
 	}
 	allArgs := append([]any{}, meta.Flat()...)

--- a/log/clog.go
+++ b/log/clog.go
@@ -5,8 +5,9 @@ package log
 
 import (
 	"context"
-
-	kitlog "github.com/go-kit/log"
+	"path/filepath"
+	"runtime"
+	"strconv"
 )
 
 // unique type to prevent assignment.
@@ -56,10 +57,20 @@ func LogCtx(ctx context.Context, message string, args ...any) {
 	}
 	allArgs := append([]any{}, meta.Flat()...)
 	allArgs = append(allArgs, args...)
-	allArgs = append(allArgs, "caller", kitlog.Caller(2)())
+	allArgs = append(allArgs, "caller", caller(2))
 	if requestID == "" {
 		LogNoRequestID(message, allArgs...)
 	} else {
 		Log(requestID, message, allArgs...)
 	}
+}
+
+func caller(depth int) string {
+	_, myfile, _, _ := runtime.Caller(0)
+	// This assumes that the root directory of catalyst-api is one level above this folder.
+	// If that changes, please update this rootDir resolution.
+	rootDir := filepath.Join(filepath.Dir(myfile), "..")
+	_, file, line, _ := runtime.Caller(depth)
+	rel, _ := filepath.Rel(rootDir, file)
+	return rel + ":" + strconv.Itoa(line)
 }

--- a/log/clog.go
+++ b/log/clog.go
@@ -29,6 +29,7 @@ type metadata map[string]any
 func init() {
 	// Set default v level to 3; this is overridden in main() but is useful for tests
 	vFlag := flag.Lookup("v")
+	// nolint:errcheck
 	vFlag.Value.Set(fmt.Sprintf("%d", defaultLogLevel))
 }
 

--- a/log/clog_test.go
+++ b/log/clog_test.go
@@ -33,10 +33,11 @@ func TestContextLog(t *testing.T) {
 	result := toMap(&b)
 	require.Len(t, result, 1)
 	line := result[0]
-	require.Len(t, line, 3)
+	require.Len(t, line, 4)
 	require.NotEmpty(t, line["ts"])
 	require.Equal(t, "test message", line["msg"])
 	require.Equal(t, "bar", line["foo"])
+	require.Contains(t, line["caller"], "clog_test.go")
 	b.Truncate(0)
 
 	ctx2 := WithLogValues(ctx, "request_id", "my_request", "other_field", "other_value")
@@ -44,10 +45,11 @@ func TestContextLog(t *testing.T) {
 	result = toMap(&b)
 	require.Len(t, result, 1)
 	line = result[0]
-	require.Len(t, line, 5)
+	require.Len(t, line, 6)
 	require.NotEmpty(t, line["ts"])
 	require.Equal(t, "child context message", line["msg"])
 	require.Equal(t, "bar", line["foo"])
 	require.Equal(t, "my_request", line["request_id"])
 	require.Equal(t, "other_value", line["other_field"])
+	require.Contains(t, line["caller"], "clog_test.go")
 }

--- a/log/clog_test.go
+++ b/log/clog_test.go
@@ -1,0 +1,53 @@
+package log
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"testing"
+
+	"github.com/go-logfmt/logfmt"
+	"github.com/stretchr/testify/require"
+)
+
+func toMap(r io.Reader) []map[string]string {
+	d := logfmt.NewDecoder(r)
+	out := []map[string]string{}
+	for d.ScanRecord() {
+		m := map[string]string{}
+		for d.ScanKeyval() {
+			m[string(d.Key())] = string(d.Value())
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestContextLog(t *testing.T) {
+	var b bytes.Buffer
+	original := logDestination
+	logDestination = &b
+	defer func() { logDestination = original }()
+	ctx := WithLogValues(context.TODO(), "foo", "bar")
+	LogCtx(ctx, "test message")
+	result := toMap(&b)
+	require.Len(t, result, 1)
+	line := result[0]
+	require.Len(t, line, 3)
+	require.NotEmpty(t, line["ts"])
+	require.Equal(t, "test message", line["msg"])
+	require.Equal(t, "bar", line["foo"])
+	b.Truncate(0)
+
+	ctx2 := WithLogValues(ctx, "request_id", "my_request", "other_field", "other_value")
+	LogCtx(ctx2, "child context message")
+	result = toMap(&b)
+	require.Len(t, result, 1)
+	line = result[0]
+	require.Len(t, line, 5)
+	require.NotEmpty(t, line["ts"])
+	require.Equal(t, "child context message", line["msg"])
+	require.Equal(t, "bar", line["foo"])
+	require.Equal(t, "my_request", line["request_id"])
+	require.Equal(t, "other_value", line["other_field"])
+}

--- a/log/clog_test.go
+++ b/log/clog_test.go
@@ -53,3 +53,26 @@ func TestContextLog(t *testing.T) {
 	require.Equal(t, "other_value", line["other_field"])
 	require.Contains(t, line["caller"], "log/clog_test.go")
 }
+
+func TestVerboseLogging(t *testing.T) {
+	var b bytes.Buffer
+	original := logDestination
+	logDestination = &b
+	defer func() { logDestination = original }()
+	ctx := WithLogValues(context.TODO(), "foo", "bar")
+	V(2).LogCtx(ctx, "test message")
+	result := toMap(&b)
+	require.Len(t, result, 1)
+	line := result[0]
+	require.Len(t, line, 4)
+	require.NotEmpty(t, line["ts"])
+	require.Equal(t, "test message", line["msg"])
+	require.Equal(t, "bar", line["foo"])
+	require.Contains(t, line["caller"], "log/clog_test.go")
+	b.Truncate(0)
+
+	ctx2 := WithLogValues(ctx, "request_id", "my_request", "other_field", "other_value")
+	V(4).LogCtx(ctx2, "should not be printed")
+	result = toMap(&b)
+	require.Len(t, result, 0)
+}

--- a/log/clog_test.go
+++ b/log/clog_test.go
@@ -37,7 +37,7 @@ func TestContextLog(t *testing.T) {
 	require.NotEmpty(t, line["ts"])
 	require.Equal(t, "test message", line["msg"])
 	require.Equal(t, "bar", line["foo"])
-	require.Contains(t, line["caller"], "clog_test.go")
+	require.Contains(t, line["caller"], "log/clog_test.go")
 	b.Truncate(0)
 
 	ctx2 := WithLogValues(ctx, "request_id", "my_request", "other_field", "other_value")
@@ -51,5 +51,5 @@ func TestContextLog(t *testing.T) {
 	require.Equal(t, "bar", line["foo"])
 	require.Equal(t, "my_request", line["request_id"])
 	require.Equal(t, "other_value", line["other_field"])
-	require.Contains(t, line["caller"], "clog_test.go")
+	require.Contains(t, line["caller"], "log/clog_test.go")
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"io"
 	"net/url"
 	"os"
 	"strings"
@@ -57,8 +58,10 @@ func getLogger(requestID string) kitlog.Logger {
 	return newLogger
 }
 
+var logDestination io.Writer = os.Stderr
+
 func newLogger() kitlog.Logger {
-	newLogger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stderr))
+	newLogger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(logDestination))
 	return kitlog.With(newLogger, "ts", kitlog.DefaultTimestampUTC)
 }
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -29,13 +29,13 @@ func AddContext(requestID string, keyvals ...interface{}) {
 }
 
 func Log(requestID string, message string, keyvals ...interface{}) {
-	_ = kitlog.With(getLogger(requestID), "msg", message).Log(redactKeyvals(keyvals...)...)
+	_ = kitlog.With(getLogger(requestID), "msg", message).Log(keyvals...)
 }
 
 // Log in situations where we don't have access to the Request ID.
 // Should be used sparingly and with as much context inserted into the message as possible
 func LogNoRequestID(message string, keyvals ...interface{}) {
-	_ = kitlog.With(newLogger(), "msg", message).Log(redactKeyvals(keyvals...)...)
+	_ = kitlog.With(newLogger(), "msg", message).Log(keyvals...)
 }
 
 func LogError(requestID string, message string, err error, keyvals ...interface{}) {


### PR DESCRIPTION
Turns out I made _several_ mistakes putting this together! Whoops. Here's a new version with 100% test coverage and also I added a "caller" field so we can see the file stuff came from. Here's an example of a new log message!

```
ts=2023-12-21T22:24:08.87999834Z request_id=MistTrigger-hmhkyeyu msg="Received Mist Trigger" request_id=MistTrigger-hmhkyeyu trigger_name=PUSH_OUT_START mist_version=c111e8bf474a12434548c6b2d94d99dd00e67bdf payload="video+4444444444444444\ns3+http://admin:xxxxx@localhost:9000/os-recordings/$wildcard/$uuid/source/$segmentCounter.ts?m3u8=../output.m3u8&split=5&video=source&audio=AAC&append=1&waittrackcount=2&recstart=-1" caller=triggers.go:58
```