### PR TITLE
ignore SPS errors when probing

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -27,6 +27,7 @@ const PresignDuration = 24 * time.Hour
 var ignoreProbeErrs = []string{
 	"parametric stereo signaled to be not-present but was found in the bitstream",
 	"non-existing pps 0 referenced",
+	"non-existing sps 0",
 }
 
 type InputCopier interface {

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -97,7 +97,11 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	if err != nil {
 		return outputs, segmentsCount, fmt.Errorf("failed to create signed url for last segment %s: %w", lastSegment.URL, err)
 	}
-	p := video.Probe{}
+	// ignore the following probe errors when checking the last segment
+	var ignoreProbeErrs = []string{
+		"non-existing sps 0",
+	}
+	p := video.Probe{IgnoreErrMessages: ignoreProbeErrs}
 	// ProbeFile will return err for various reasons so we use the subsequent GetTrack method to check for video tracks
 	lastSegmentProbe, _ := p.ProbeFile(transcodeRequest.RequestID, lastSegmentURL)
 	// GetTrack will return an err if TrackTypeVideo was not found


### PR DESCRIPTION
When probing, we should ignore SPS errors as they indicate a slightly out-of-spec H264 stream. These files can
still be transcoded successfully so we should be less stringent here.