### PR TITLE
[SRE-221] Reduce logs printend on the default verbosity level

### DIFF
--- a/middleware/logging.go
+++ b/middleware/logging.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/errors"
@@ -62,14 +63,17 @@ func logRequest(metric *prometheus.SummaryVec) func(httprouter.Handle) httproute
 
 			next(wrapped, r, ps)
 			duration := time.Since(start)
-			log.LogNoRequestID("received HTTP request",
-				"remote", r.RemoteAddr,
-				"proto", r.Proto,
-				"method", r.Method,
-				"uri", r.URL.RequestURI(),
-				"duration", duration,
-				"status", wrapped.status,
-			)
+
+			if glog.V(4) || wrapped.status >= 400 {
+				log.LogNoRequestID("received HTTP request",
+					"remote", r.RemoteAddr,
+					"proto", r.Proto,
+					"method", r.Method,
+					"uri", r.URL.RequestURI(),
+					"duration", duration,
+					"status", wrapped.status,
+				)
+			}
 
 			if metric != nil {
 				success := wrapped.status < 400


### PR DESCRIPTION
https://eu-metrics-monitoring.livepeer.live/grafana/goto/zop13OFIg?orgId=1
```
  |   | 2024-01-03 17:34:57.481 | ts=2024-01-03T17:34:57.481838188Z msg="received HTTP request" remote=127.0.0.1:60130 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=939.986µs status=0 |  
-- | -- | -- | -- | --
  |   | 2024-01-03 17:34:57.473 | ts=2024-01-03T17:34:57.473426935Z msg="received HTTP request" remote=127.0.0.1:60118 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=528.616µs status=200 |  
  |   | 2024-01-03 17:34:57.458 | ts=2024-01-03T17:34:57.458237384Z msg="received HTTP request" remote=127.0.0.1:60104 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=271µs status=200 |  
  |   | 2024-01-03 17:34:57.407 | ts=2024-01-03T17:34:57.407490592Z msg="received HTTP request" remote=127.0.0.1:48558 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=214.338µs status=0 |  
  |   | 2024-01-03 17:34:57.385 | [2024-01-03 17:34:57] ts=2024-01-03T17:34:57.385382489Z msg="received HTTP request" remote=127.0.0.1:48552 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=208.285µs status=200 |  
  |   | 2024-01-03 17:34:57.332 | ts=2024-01-03T17:34:57.332800822Z msg="received HTTP request" remote=127.0.0.1:48550 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=190.144µs status=200 |  
  |   | 2024-01-03 17:34:57.109 | ts=2024-01-03T17:34:57.109005137Z msg="received HTTP request" remote=127.0.0.1:48544 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=310.892µs status=200 |  
  |   | 2024-01-03 17:34:57.063 | ts=2024-01-03T17:34:57.063733195Z msg="received HTTP request" remote=127.0.0.1:48534 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=344.519µs status=0 |  
  |   | 2024-01-03 17:34:57.024 | ts=2024-01-03T17:34:57.024134797Z msg="received HTTP request" remote=127.0.0.1:55602 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=794.277µs status=0 |  
  |   | 2024-01-03 17:34:56.982 | ts=2024-01-03T17:34:56.982063035Z msg="received HTTP request" remote=127.0.0.1:48518 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=210.358µs status=200 |  
  |   | 2024-01-03 17:34:56.951 | ts=2024-01-03T17:34:56.951479966Z msg="received HTTP request" remote=127.0.0.1:36382 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=629.695µs status=0 |  
  |   | 2024-01-03 17:34:56.902 | ts=2024-01-03T17:34:56.902221265Z msg="received HTTP request" remote=127.0.0.1:36376 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=681.264µs status=0 |  
  |   | 2024-01-03 17:34:56.878 | ts=2024-01-03T17:34:56.877908942Z msg="received HTTP request" remote=127.0.0.1:60094 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.54671ms status=0 |  
  |   | 2024-01-03 17:34:56.856 | ts=2024-01-03T17:34:56.855918475Z msg="received HTTP request" remote=127.0.0.1:48510 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=218.594µs status=0 |  
  |   | 2024-01-03 17:34:56.840 | ts=2024-01-03T17:34:56.840164621Z msg="received HTTP request" remote=127.0.0.1:40704 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.00455ms status=0 |  
  |   | 2024-01-03 17:34:56.773 | ts=2024-01-03T17:34:56.773208446Z msg="received HTTP request" remote=127.0.0.1:50256 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=826.765µs status=0 |  
  |   | 2024-01-03 17:34:56.770 | ts=2024-01-03T17:34:56.770504182Z msg="received HTTP request" remote=127.0.0.1:45616 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.168698ms status=0 |  
  |   | 2024-01-03 17:34:56.758 | ts=2024-01-03T17:34:56.757900874Z msg="received HTTP request" remote=127.0.0.1:55594 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=330.074µs status=200 |  
  |   | 2024-01-03 17:34:56.757 | ts=2024-01-03T17:34:56.756950466Z msg="received HTTP request" remote=127.0.0.1:54396 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=272.64µs status=200 |  
  |   | 2024-01-03 17:34:56.740 | ts=2024-01-03T17:34:56.740382299Z msg="received HTTP request" remote=127.0.0.1:40692 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=850.94µs status=0 |  
  |   | 2024-01-03 17:34:56.740 | ts=2024-01-03T17:34:56.740234315Z msg="received HTTP request" remote=127.0.0.1:54888 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.141264ms status=0 |  
  |   | 2024-01-03 17:34:56.736 | ts=2024-01-03T17:34:56.736281006Z msg="received HTTP request" remote=127.0.0.1:47786 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=205.335µs status=200 |  
  |   | 2024-01-03 17:34:56.718 | ts=2024-01-03T17:34:56.718527047Z msg="received HTTP request" remote=127.0.0.1:54886 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.113899ms status=0 |  
  |   | 2024-01-03 17:34:56.713 | ts=2024-01-03T17:34:56.713416851Z msg="received HTTP request" remote=127.0.0.1:53510 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=345.809µs status=200 |  
  |   | 2024-01-03 17:34:56.688 | ts=2024-01-03T17:34:56.688622319Z msg="received HTTP request" remote=127.0.0.1:55980 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=224.905µs status=200 |  
  |   | 2024-01-03 17:34:56.667 | ts=2024-01-03T17:34:56.667525576Z msg="received HTTP request" remote=127.0.0.1:55588 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=324.662µs status=200 |  
  |   | 2024-01-03 17:34:56.597 | ts=2024-01-03T17:34:56.597828947Z msg="received HTTP request" remote=127.0.0.1:34500 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.158487ms status=0 |  
  |   | 2024-01-03 17:34:56.591 | ts=2024-01-03T17:34:56.591865564Z msg="received HTTP request" remote=127.0.0.1:45604 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=961.805µs status=0 |  
  |   | 2024-01-03 17:34:56.582 | [2024-01-03 17:34:56] ts=2024-01-03T17:34:56.582591546Z msg="received HTTP request" remote=127.0.0.1:60080 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=199.113µs status=200 |  
  |   | 2024-01-03 17:34:56.581 | ts=2024-01-03T17:34:56.581248177Z msg="received HTTP request" remote=127.0.0.1:51736 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=231.525µs status=200 |  
  |   | 2024-01-03 17:34:56.569 | ts=2024-01-03T17:34:56.569011353Z msg="received HTTP request" remote=127.0.0.1:34484 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.208111ms status=0 |  
  |   | 2024-01-03 17:34:56.556 | ts=2024-01-03T17:34:56.55630549Z msg="received HTTP request" remote=127.0.0.1:47818 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=229.115µs status=200 |  
  |   | 2024-01-03 17:34:56.525 | ts=2024-01-03T17:34:56.525459801Z msg="received HTTP request" remote=127.0.0.1:45602 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=1.237225ms status=0 |  
  |   | 2024-01-03 17:34:56.516 | ts=2024-01-03T17:34:56.515873355Z msg="received HTTP request" remote=127.0.0.1:47802 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=265.997µs status=200 |  
  |   | 2024-01-03 17:34:56.509 | ts=2024-01-03T17:34:56.508868708Z msg="received HTTP request" remote=10.42.1.6:46900 proto=HTTP/1.1 method=GET uri=/asset/hls/145bcizprq7a4hmx/1080p0/147.ts duration=918.905015ms status=200 |  
  |   | 2024-01-03 17:34:56.498 | [2024-01-03 17:34:56] ts=2024-01-03T17:34:56.498445056Z msg="received HTTP request" remote=127.0.0.1:54502 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=200.889µs status=200 |  
  |   | 2024-01-03 17:34:56.498 | ts=2024-01-03T17:34:56.49841329Z msg="received HTTP request" remote=127.0.0.1:36368 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=154.37µs status=200 |  
  |   | 2024-01-03 17:34:56.474 | ts=2024-01-03T17:34:56.47473674Z msg="received HTTP request" remote=127.0.0.1:54486 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=699.95µs status=0 |  
  |   | 2024-01-03 17:34:56.457 | ts=2024-01-03T17:34:56.457839703Z msg="received HTTP request" remote=127.0.0.1:36356 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=356.191µs status=200 |  
  |   | 2024-01-03 17:34:56.452 | ts=2024-01-03T17:34:56.452064943Z msg="received HTTP request" remote=127.0.0.1:50240 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=203.863µs status=200 |  
  |   | 2024-01-03 17:34:56.442 | ts=2024-01-03T17:34:56.442086369Z msg="received HTTP request" remote=127.0.0.1:50896 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=192.246411ms status=0 |  
  |   | 2024-01-03 17:34:56.435 | ts=2024-01-03T17:34:56.435447863Z msg="received HTTP request" remote=127.0.0.1:54874 proto=HTTP/1.1 method=POST uri=/api/mist/trigger duration=644.709µs status=0


```