### PR TITLE
Implement logger for Retryable http client

### DIFF
--- a/clients/broadcaster_remote.go
+++ b/clients/broadcaster_remote.go
@@ -182,6 +182,7 @@ func newRetryableClient(httpClient *http.Client) *http.Client {
 	if httpClient != nil {
 		client.HTTPClient = httpClient
 	}
+	client.Logger = log.NewRetryableHTTPLogger()
 
 	return client.StandardClient()
 }

--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -44,6 +44,7 @@ func NewPeriodicCallbackClient(callbackInterval time.Duration, headers map[strin
 	client.HTTPClient = &http.Client{
 		Timeout: 5 * time.Second, // Give up on requests that take more than this long
 	}
+	client.Logger = log.NewRetryableHTTPLogger()
 
 	return &PeriodicCallbackClient{
 		httpClient:               client.StandardClient(),

--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -293,6 +293,7 @@ func newRetryableHttpClient() *http.Client {
 		// or something else has gone wrong and the request is hanging
 		Timeout: MaxCopyFileDuration,
 	}
+	client.Logger = log.NewRetryableHTTPLogger()
 
 	return client.StandardClient()
 }

--- a/go.mod
+++ b/go.mod
@@ -170,7 +170,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-kit/log v0.2.1
-	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-logfmt/logfmt v0.5.1
 	github.com/grafov/m3u8 v0.12.0
 	github.com/hashicorp/go-retryablehttp v0.7.4
 	github.com/patrickmn/go-cache v2.1.0+incompatible

--- a/handlers/misttriggers/stream_buffer.go
+++ b/handlers/misttriggers/stream_buffer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/livepeer/catalyst-api/errors"
+	"github.com/livepeer/catalyst-api/log"
 )
 
 var hookClient *http.Client
@@ -24,6 +25,7 @@ func init() {
 	client.HTTPClient = &http.Client{
 		Timeout: 5 * time.Second, // Give up on requests that take more than this long
 	}
+	client.Logger = log.NewRetryableHTTPLogger()
 
 	hookClient = client.StandardClient()
 }

--- a/log/httpLogger.go
+++ b/log/httpLogger.go
@@ -1,0 +1,39 @@
+package log
+
+import (
+	"github.com/golang/glog"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+var _ retryablehttp.LeveledLogger = retryableHTTPLogger{}
+
+type retryableHTTPLogger struct {
+}
+
+func NewRetryableHTTPLogger() retryablehttp.LeveledLogger {
+	return retryableHTTPLogger{}
+}
+
+func (r retryableHTTPLogger) Error(msg string, keysAndValues ...interface{}) {
+	if glog.V(3) {
+		LogNoRequestID(msg, keysAndValues...)
+	}
+}
+
+func (r retryableHTTPLogger) Warn(msg string, keysAndValues ...interface{}) {
+	if glog.V(4) {
+		LogNoRequestID(msg, keysAndValues...)
+	}
+}
+
+func (r retryableHTTPLogger) Info(msg string, keysAndValues ...interface{}) {
+	if glog.V(5) {
+		LogNoRequestID(msg, keysAndValues...)
+	}
+}
+
+func (r retryableHTTPLogger) Debug(msg string, keysAndValues ...interface{}) {
+	if glog.V(6) {
+		LogNoRequestID(msg, keysAndValues...)
+	}
+}

--- a/log/httpLogger.go
+++ b/log/httpLogger.go
@@ -5,8 +5,6 @@ import (
 	"github.com/hashicorp/go-retryablehttp"
 )
 
-var _ retryablehttp.LeveledLogger = retryableHTTPLogger{}
-
 type retryableHTTPLogger struct {
 }
 


### PR DESCRIPTION
The default was to always produce logs which we don't generally need