### PR TITLE
Turn down Serf memberlist logging

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -112,6 +112,7 @@ func (c *ClusterImpl) Start(ctx context.Context) error {
 	memberlistConfig.EnableCompression = true
 	memberlistConfig.SecretKey = encryptBytes
 	memberlistConfig.RetransmitMult = 1
+	memberlistConfig.LogOutput = serfLogger{}
 	serfConfig := serf.DefaultConfig()
 	serfConfig.UserEventSizeLimit = 1024
 	serfConfig.MemberlistConfig = memberlistConfig


### PR DESCRIPTION
Turns out we need to configure a logger for this too to avoid DEBUG messages