### PR TITLE
Stop logging every trigger

### DIFF
--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -54,6 +54,7 @@ func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
 		ctx := log.WithLogValues(context.Background(),
 			"request_id", requestID,
 			"trigger_name", triggerName,
+			"mist_version", mistVersion,
 		)
 
 		body := MistTriggerBody(payload)

--- a/handlers/misttriggers/triggers.go
+++ b/handlers/misttriggers/triggers.go
@@ -55,12 +55,6 @@ func (d *MistCallbackHandlersCollection) Trigger() httprouter.Handle {
 			"request_id", requestID,
 			"trigger_name", triggerName,
 		)
-		log.LogCtx(
-			ctx,
-			"Received Mist Trigger",
-			"mist_version", mistVersion,
-			"payload", log.RedactLogs(string(payload), "\n"),
-		)
 
 		body := MistTriggerBody(payload)
 


### PR DESCRIPTION
This is accounting for ~1/3 of Catalyst logs at the moment