### PR TITLE
use file-based concatenation during mp4 generation for non-clips

### DIFF
--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -261,7 +261,12 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 			defer os.Remove(concatTsFileName)
 
 			var totalBytes int64
-			totalBytes, err = video.ConcatTS(concatTsFileName, segments, sourceManifest, true)
+
+			if transcodeRequest.IsClip {
+				totalBytes, err = video.ConcatTS(concatTsFileName, segments, sourceManifest, true)
+			} else {
+				totalBytes, err = video.ConcatTS(concatTsFileName, segments, sourceManifest, false)
+			}
 			if err != nil {
 				log.Log(transcodeRequest.RequestID, "error concatenating .ts", "file", concatTsFileName, "err", err)
 				continue

--- a/video/transmux.go
+++ b/video/transmux.go
@@ -215,9 +215,7 @@ func concatStreams(segmentList, outputTsFileName string) error {
 		"f":    "concat", // Use stream based concatenation (instead of file based concatenation)
 		"safe": "0"}).    // Must be 0 since relative paths to segments are used in segmentListTxtFileName
 		Output(outputTsFileName, ffmpeg.KwArgs{
-			"c:v": "copy",                // Don't accidentally transcode video
-			"c:a": "aac",                 // Re-encode audio to avoid audio/video sync issues
-			"af":  "aresample=async=100", // Re-sample audio with 0.1s buffer
+			"c": "copy", // Don't accidentally transcode
 		}).
 		OverWriteOutput().ErrorToStdOut().Run()
 	if err != nil {

--- a/video/transmux_test.go
+++ b/video/transmux_test.go
@@ -70,10 +70,50 @@ func TestItConcatsStreams(t *testing.T) {
 	require.NoError(t, err)
 	pl := *sourceManifest.(*m3u8.MediaPlaylist)
 
-	// verify file-based concatenation
-	totalBytesWritten, err := ConcatTS(concatDir+"test.ts", segmentList, pl, false)
+	// write segments to disk to test stream-based concatenation
+	err = WriteSegmentsToDisk(concatDir, tr, sb)
 	require.NoError(t, err)
-	require.Equal(t, int64(594644), totalBytesWritten)
+	// verify segments are not held in memory anymore
+	for _, v := range segmentList.SegmentDataTable {
+		require.Equal(t, int(0), len(v))
+	}
+
+	// verify stream-based concatenation
+	totalBytesW, err := ConcatTS(concatTsFileName, segmentList, pl, true)
+	require.NoError(t, err)
+	require.Equal(t, int64(594644), totalBytesW)
+
+}
+
+func TestItConcatsFiles(t *testing.T) {
+	// setup pre-reqs for testing stream concatenation
+	tr := populateRenditionSegmentList()
+	segmentList := tr.GetSegmentList(rendition)
+	concatDir, err := os.MkdirTemp(os.TempDir(), "concat_stage_")
+	require.NoError(t, err)
+	concatTsFileName := filepath.Join(concatDir, request+"_"+rendition+".ts")
+	// setup a fake struct to simulate what will be sent in the channel
+	sb := []TranscodedSegmentInfo{
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  0,
+		},
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  1,
+		},
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  2,
+		},
+	}
+	// setup a fake playlist
+	sourceManifest, _, err := m3u8.DecodeFrom(strings.NewReader(normalManifest), true)
+	require.NoError(t, err)
+	pl := *sourceManifest.(*m3u8.MediaPlaylist)
 
 	// write segments to disk to test stream-based concatenation
 	err = WriteSegmentsToDisk(concatDir, tr, sb)
@@ -82,11 +122,53 @@ func TestItConcatsStreams(t *testing.T) {
 	for _, v := range segmentList.SegmentDataTable {
 		require.Equal(t, int(0), len(v))
 	}
-	// verify stream-based concatenation
-	totalBytesW, err := ConcatTS(concatTsFileName, segmentList, pl, true)
+	// verify file-based concatenation
+	totalBytesWritten, err := ConcatTS(concatTsFileName, segmentList, pl, false)
 	require.NoError(t, err)
-	require.Equal(t, int64(594644), totalBytesW)
+	require.Equal(t, int64(594644), totalBytesWritten)
 
+}
+
+func TestItConcatsFilesOnlyUptoMP4DurationLimit(t *testing.T) {
+	// setup pre-reqs for testing stream concatenation
+	tr := populateRenditionSegmentList()
+	segmentList := tr.GetSegmentList(rendition)
+	concatDir, err := os.MkdirTemp(os.TempDir(), "concat_stage_")
+	require.NoError(t, err)
+	concatTsFileName := filepath.Join(concatDir, request+"_"+rendition+".ts")
+	// setup a fake struct to simulate what will be sent in the channel
+	sb := []TranscodedSegmentInfo{
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  0,
+		},
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  1,
+		},
+		{
+			RequestID:     request,
+			RenditionName: rendition,
+			SegmentIndex:  2,
+		},
+	}
+	// setup a fake playlist
+	sourceManifest, _, err := m3u8.DecodeFrom(strings.NewReader(weirdManifest), true)
+	require.NoError(t, err)
+	pl := *sourceManifest.(*m3u8.MediaPlaylist)
+	// write segments to disk to test stream-based concatenation
+	err = WriteSegmentsToDisk(concatDir, tr, sb)
+	require.NoError(t, err)
+	// verify file-based concatenation
+	totalBytesW, err := ConcatTS(concatTsFileName, segmentList, pl, false)
+	require.NoError(t, err)
+	// Only first two segments are written since duration exceeded Mp4DurationLimit
+	//206612 seg-0.ts
+	//199656 seg-1.ts
+	//188376 seg-2.ts
+	require.Equal(t, int64(406268), totalBytesW)
 }
 
 func TestItConcatsStreamsOnlyUptoMP4DurationLimit(t *testing.T) {


### PR DESCRIPTION
    Certain input files have a/v sync issues in the output mp4s when they
    are played in the browser -- adjusting the playhead fixes the sync
    issues. This seems to only occur on browsers and not standalone players
    like vlc and qt. It was found that using file based concatenation fixes
    this issue. The root cause is under investigation but likely caused by
    incorrect timestamps between audio and video tracks. This commit updates
    the mp4 generation logic to use stream-based concat for only clips and
    use file-based concat for non-clips.