### PR TITLE
Enrich Mist Prometheus Metrics

### DIFF
--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -89,6 +89,10 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 	} else {
 		router.Handler("GET", "/metrics", promhttp.Handler())
 	}
+	if cli.MistPrometheus != "" {
+		// Enable Mist metrics enrichment
+		router.GET("/mistmetrics", mapic.MistMetricsHandler())
+	}
 
 	// Public Catalyst API
 	router.POST("/api/vod",

--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -138,6 +138,9 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 // Hack to combine main metrics and mapic metrics. To be refactored away with mapic.
 func concatHandlers(handlers ...http.Handler) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		// Response concat is string-based, so we don't accept any encoding
+		r.Header.Del("Accept-Encoding")
+
 		var outbuf bytes.Buffer
 		writer := bufio.NewWriter(&outbuf)
 		for _, handler := range handlers {

--- a/config/cli.go
+++ b/config/cli.go
@@ -24,6 +24,7 @@ type Cli struct {
 	MistHost                  string
 	MistUser                  string
 	MistPassword              string
+	MistPrometheus            string
 	MistPort                  int
 	MistConnectTimeout        time.Duration
 	MistStreamSource          string

--- a/main.go
+++ b/main.go
@@ -87,6 +87,7 @@ func main() {
 	fs.StringVar(&cli.MistHost, "mist-host", "127.0.0.1", "Hostname of the Mist server")
 	fs.StringVar(&cli.MistUser, "mist-user", "", "username of MistServer")
 	fs.StringVar(&cli.MistPassword, "mist-password", "", "password of MistServer")
+	fs.StringVar(&cli.MistPrometheus, "mist-prometheus", "", "Mist path for the prometheus metrics endpoint")
 	fs.DurationVar(&cli.MistConnectTimeout, "mist-connect-timeout", 5*time.Minute, "Max time to wait attempting to connect to Mist server")
 	fs.StringVar(&cli.MistStreamSource, "mist-stream-source", "push://", "Stream source we should use for created Mist stream")
 	fs.StringVar(&cli.MistHardcodedBroadcasters, "mist-hardcoded-broadcasters", "", "Hardcoded broadcasters for use by MistProcLivepeer")

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
@@ -40,6 +41,7 @@ type (
 	IMac interface {
 		Start(ctx context.Context) error
 		MetricsHandler() http.Handler
+		MistMetricsHandler() httprouter.Handle
 		RefreshStreamIfNeeded(playbackID string)
 		NukeStream(playbackID string)
 	}

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/golang/glog"
-	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
@@ -41,7 +40,7 @@ type (
 	IMac interface {
 		Start(ctx context.Context) error
 		MetricsHandler() http.Handler
-		MistMetricsHandler() httprouter.Handle
+		MistMetricsHandler() http.Handler
 		RefreshStreamIfNeeded(playbackID string)
 		NukeStream(playbackID string)
 	}

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -100,6 +101,7 @@ type (
 		mist                      clients.MistAPIClient
 		streamUpdated             chan struct{}
 		metricsCollector          *metricsCollector
+		streamMetricsRe           *regexp.Regexp
 	}
 )
 

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -3,21 +3,61 @@ package mistapiconnector
 import (
 	"fmt"
 	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"io"
+	"net/http"
 	"strings"
 )
 
+func (mc *mac) MistMetricsHandler() httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		mistMetrics, err := mc.queryMistMetrics()
+		if err != nil {
+			http.Error(w, fmt.Sprintf("error fetching Mist prometheus metrics: %s", err), http.StatusInternalServerError)
+			return
+		}
+
+		enrichedMistMetrics := mc.enrichMistMetrics(mistMetrics)
+		_, err = w.Write([]byte(enrichedMistMetrics))
+		if err != nil {
+			http.Error(w, fmt.Sprintf("error writing enriched metrics: %s", err), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func (mc *mac) queryMistMetrics() (string, error) {
+	mistMetricsURL := fmt.Sprintf("http://%s:%d/%s", mc.config.MistHost, mc.config.MistPort, mc.config.MistPrometheus)
+	resp, err := http.Get(mistMetricsURL)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	return string(body), nil
+}
+
+// enrichMistMetrics adds additional labels to Mist streams
 func (mc *mac) enrichMistMetrics(metrics string) string {
 	res := strings.Builder{}
 	lines := strings.Split(metrics, "\n")
 	for i, line := range lines {
 		playbackID, ok := mc.parsePlaybackID(line)
 		if ok {
+			// Enrich labels for the lines that contains playbackID
 			oldStr := mc.streamLabel(playbackID)
 			newStr := mc.enrichLabels(playbackID)
 			res.WriteString(strings.Replace(line, oldStr, newStr, -1))
 		} else {
+			// Do not enrich labels for lines that do not contain playbackID
 			res.WriteString(line)
 		}
+
+		// Skip last end of line to preserve the same number of lines as Mist
 		if i < len(lines)-1 {
 			res.WriteString("\n")
 		}
@@ -37,11 +77,11 @@ func (mc *mac) enrichLabels(playbackID string) string {
 	res := mc.streamLabel(playbackID)
 	si, err := mc.getStreamInfo(playbackID)
 	if err != nil {
-		glog.Warning("could not enrich Mist metrics for strm=%s err=%v", playbackID, err)
+		glog.Warning("could not enrich Mist metrics for stream=%s err=%v", playbackID, err)
 	} else if si == nil || si.stream == nil {
-		glog.Warning("could not enrich Mist metrics for strm=%s, cannot fetch stream info", playbackID)
+		glog.Warning("could not enrich Mist metrics for stream=%s, cannot fetch stream info", playbackID)
 	} else {
-		res += fmt.Sprintf(`,userId="%s"`, si.stream.UserID)
+		res += fmt.Sprintf(`,user_id="%s"`, si.stream.UserID)
 	}
 
 	return res

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -1,0 +1,52 @@
+package mistapiconnector
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"strings"
+)
+
+func (mc *mac) enrichMistMetrics(metrics string) string {
+	res := strings.Builder{}
+	lines := strings.Split(metrics, "\n")
+	for i, line := range lines {
+		playbackID, ok := mc.parsePlaybackID(line)
+		if ok {
+			oldStr := mc.streamLabel(playbackID)
+			newStr := mc.enrichLabels(playbackID)
+			res.WriteString(strings.Replace(line, oldStr, newStr, -1))
+		} else {
+			res.WriteString(line)
+		}
+		if i < len(lines)-1 {
+			res.WriteString("\n")
+		}
+	}
+	return res.String()
+}
+
+func (mc *mac) parsePlaybackID(line string) (string, bool) {
+	match := mc.streamMetricsRe.FindStringSubmatch(line)
+	if len(match) > 1 {
+		return match[1], true
+	}
+	return "", false
+}
+
+func (mc *mac) enrichLabels(playbackID string) string {
+	res := mc.streamLabel(playbackID)
+	si, err := mc.getStreamInfo(playbackID)
+	if err != nil {
+		glog.Warning("could not enrich Mist metrics for strm=%s err=%v", playbackID, err)
+	} else if si == nil || si.stream == nil {
+		glog.Warning("could not enrich Mist metrics for strm=%s, cannot fetch stream info", playbackID)
+	} else {
+		res += fmt.Sprintf(`,userId="%s"`, si.stream.UserID)
+	}
+
+	return res
+}
+
+func (mc *mac) streamLabel(playbackID string) string {
+	return fmt.Sprintf(`stream="%s+%s"`, mc.baseStreamName, playbackID)
+}

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -41,7 +41,7 @@ func (mc *mac) queryMistMetrics() (string, error) {
 	return string(body), nil
 }
 
-// enrichMistMetrics adds additional labels to Mist streams
+// enrichMistMetrics adds additional labels to Mist metrics
 func (mc *mac) enrichMistMetrics(metrics string) string {
 	res := strings.Builder{}
 	lines := strings.Split(metrics, "\n")

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -3,27 +3,27 @@ package mistapiconnector
 import (
 	"fmt"
 	"github.com/golang/glog"
-	"github.com/julienschmidt/httprouter"
 	"io"
 	"net/http"
 	"strings"
 )
 
-func (mc *mac) MistMetricsHandler() httprouter.Handle {
-	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-		mistMetrics, err := mc.queryMistMetrics()
-		if err != nil {
-			http.Error(w, fmt.Sprintf("error fetching Mist prometheus metrics: %s", err), http.StatusInternalServerError)
-			return
-		}
+func (mc *mac) MistMetricsHandler() http.Handler {
+	return http.HandlerFunc(
+		func(w http.ResponseWriter, req *http.Request) {
+			mistMetrics, err := mc.queryMistMetrics()
+			if err != nil {
+				http.Error(w, fmt.Sprintf("error fetching Mist prometheus metrics: %s", err), http.StatusInternalServerError)
+				return
+			}
 
-		enrichedMistMetrics := mc.enrichMistMetrics(mistMetrics)
-		_, err = w.Write([]byte(enrichedMistMetrics))
-		if err != nil {
-			http.Error(w, fmt.Sprintf("error writing enriched metrics: %s", err), http.StatusInternalServerError)
-			return
-		}
-	}
+			enrichedMistMetrics := mc.enrichMistMetrics(mistMetrics)
+			_, err = w.Write([]byte(enrichedMistMetrics))
+			if err != nil {
+				http.Error(w, fmt.Sprintf("error writing enriched metrics: %s", err), http.StatusInternalServerError)
+				return
+			}
+		})
 }
 
 func (mc *mac) queryMistMetrics() (string, error) {

--- a/mapic/mistmetrics_test.go
+++ b/mapic/mistmetrics_test.go
@@ -42,10 +42,10 @@ func TestEnrichMistMetrics(t *testing.T) {
 
 	expLines := []string{
 		`version{app="MistServer",version="729ddd4b42980d0124c72a46f13d8e0697293e94",release="Generic_x86_64"} 1`,
-		`mist_sessions{stream="video+077bh6xx5bx5tdua",userId="abcdefgh-123456789",sessType="viewers"}1`,
-		`mist_latency{stream="video+077bh6xx5bx5tdua",userId="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
-		`mist_sessions{stream="video+51b13mqy7sgw520w",userId="hgfedcba-987654321",sessType="viewers"}5`,
-		`mist_latency{stream="video+51b13mqy7sgw520w",userId="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
+		`mist_sessions{stream="video+077bh6xx5bx5tdua",user_id="abcdefgh-123456789",sessType="viewers"}1`,
+		`mist_latency{stream="video+077bh6xx5bx5tdua",user_id="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
+		`mist_sessions{stream="video+51b13mqy7sgw520w",user_id="hgfedcba-987654321",sessType="viewers"}5`,
+		`mist_latency{stream="video+51b13mqy7sgw520w",user_id="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
 	}
 	for _, exp := range expLines {
 		require.Contains(t, resLines, exp)

--- a/mapic/mistmetrics_test.go
+++ b/mapic/mistmetrics_test.go
@@ -1,0 +1,53 @@
+package mistapiconnector
+
+import (
+	"github.com/livepeer/go-api-client"
+	"github.com/stretchr/testify/require"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+const mistMetrics = `
+# HELP version Current software version as a tag, always 1
+# TYPE version gauge
+version{app="MistServer",version="729ddd4b42980d0124c72a46f13d8e0697293e94",release="Generic_x86_64"} 1
+
+# HELP mist_viewcount Count of unique viewer sessions since stream start, per stream.
+# TYPE mist_viewcount counter
+mist_sessions{stream="video+077bh6xx5bx5tdua",sessType="viewers"}1
+mist_latency{stream="video+077bh6xx5bx5tdua",source="sin-prod-catalyst-3.lp-playback.studio"}1795
+mist_sessions{stream="video+51b13mqy7sgw520w",sessType="viewers"}5
+mist_latency{stream="video+51b13mqy7sgw520w",source="prg-prod-catalyst-0.lp-playback.studio"}1156
+`
+
+func TestEnrichMistMetrics(t *testing.T) {
+	// given
+	mc := mac{
+		baseStreamName: "video",
+		streamInfo: map[string]*streamInfo{
+			"077bh6xx5bx5tdua": {stream: &api.Stream{UserID: "abcdefgh-123456789"}},
+			"51b13mqy7sgw520w": {stream: &api.Stream{UserID: "hgfedcba-987654321"}},
+		},
+		streamMetricsRe: regexp.MustCompile(`stream="video\+(.*?)"`),
+	}
+
+	// when
+	res := mc.enrichMistMetrics(mistMetrics)
+
+	// then
+	inLines := strings.Split(mistMetrics, "\n")
+	resLines := strings.Split(res, "\n")
+	require.Equal(t, len(inLines), len(resLines))
+
+	expLines := []string{
+		`version{app="MistServer",version="729ddd4b42980d0124c72a46f13d8e0697293e94",release="Generic_x86_64"} 1`,
+		`mist_sessions{stream="video+077bh6xx5bx5tdua",userId="abcdefgh-123456789",sessType="viewers"}1`,
+		`mist_latency{stream="video+077bh6xx5bx5tdua",userId="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
+		`mist_sessions{stream="video+51b13mqy7sgw520w",userId="hgfedcba-987654321",sessType="viewers"}5`,
+		`mist_latency{stream="video+51b13mqy7sgw520w",userId="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
+	}
+	for _, exp := range expLines {
+		require.Contains(t, resLines, exp)
+	}
+}

--- a/mapic/start_mapic.go
+++ b/mapic/start_mapic.go
@@ -1,14 +1,17 @@
 package mistapiconnector
 
 import (
+	"fmt"
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/mapic/metrics"
 	"github.com/livepeer/catalyst-api/mapic/model"
+	"regexp"
 )
 
 func NewMapic(cli *config.Cli, broker misttriggers.TriggerBroker, mist clients.MistAPIClient) IMac {
+	streamMetricsRe := regexp.MustCompile(fmt.Sprintf(`stream="%s\+(.*?)"`, cli.MistBaseStreamName))
 	mc := &mac{
 		config:                    cli,
 		nodeID:                    cli.NodeName,
@@ -21,6 +24,7 @@ func NewMapic(cli *config.Cli, broker misttriggers.TriggerBroker, mist clients.M
 		mistHardcodedBroadcasters: cli.MistHardcodedBroadcasters,
 		broker:                    broker,
 		mist:                      mist,
+		streamMetricsRe:           streamMetricsRe,
 	}
 	metrics.InitCensus(mc.config.NodeName, model.Version, "mistconnector")
 	return mc


### PR DESCRIPTION
Add `user_id` label to playback-related metrics. We can add more stream-related labels if needed.

Additional comments:
- Adding labels is done on-the-fly (if we see some performance issues, then we can include some caching)
- Mist metrics are exposed together with other metrics under `/metrics`
- Adding labels is done by a simple string replacement, I considered using some Prometheus metrics parsing, but it seemed to be more code and more works, so ended up with this solution

Related PRs:
- https://github.com/livepeer/catalyst/pull/835
- https://github.com/livepeer/livepeer-infra/pull/1931

fix https://linear.app/livepeer/issue/ENG-1581/whitelist-usersaccounts-so-they-never-raise-viewers-by-stream-alert