### PR TITLE
access-control: fix rate-limit mutex

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -141,14 +141,12 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 
 	if _, ok := hitRecordCache.data[playbackID]; ok {
 		hitRecordCache.mux.Lock()
-		defer hitRecordCache.mux.Unlock()
-
 		if len(hitRecordCache.data[playbackID].hits) >= hitRecordCache.data[playbackID].rateLimit {
 			glog.Infof("Rate limit reached for playbackID %v", playbackID)
 			return false, nil
 		}
-
 		hitRecordCache.data[playbackID].hits = append(hitRecordCache.data[playbackID].hits, time.Now())
+		hitRecordCache.mux.Unlock()
 	}
 
 	if accessKey != "" {

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -70,8 +70,9 @@ func periodicCleanUpHitRecordCache() {
 		for {
 			time.Sleep(time.Duration(30) * time.Second)
 			hitRecordCache.mux.Lock()
-			hitRecordCache = HitRecords{
-				data: make(map[string]*HitRecord),
+			// Clear the map
+			for key := range hitRecordCache.data {
+				delete(hitRecordCache.data, key)
 			}
 			hitRecordCache.mux.Unlock()
 		}

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	"github.com/livepeer/catalyst-api/log"
@@ -42,7 +43,7 @@ type PlaybackAccessControlRequest struct {
 }
 
 type GateAPICaller interface {
-	QueryGate(body []byte) (bool, int32, int32, error)
+	QueryGate(body []byte) (bool, int32, int32, int32, error)
 }
 
 type GateClient struct {
@@ -50,7 +51,37 @@ type GateClient struct {
 	gateURL string
 }
 
+type HitRecord struct {
+	hits      []time.Time
+	rateLimit int
+}
+
+type HitRecords struct {
+	data map[string]*HitRecord
+	mux  sync.Mutex
+}
+
+var hitRecordCache = HitRecords{
+	data: make(map[string]*HitRecord),
+}
+
+func periodicCleanUpHitRecordCache() {
+	go func() {
+		for {
+			time.Sleep(time.Duration(30) * time.Second)
+			hitRecordCache.mux.Lock()
+			hitRecordCache = HitRecords{
+				data: make(map[string]*HitRecord),
+			}
+			hitRecordCache.mux.Unlock()
+		}
+	}()
+}
+
 func NewAccessControlHandlersCollection(cli config.Cli) *AccessControlHandlersCollection {
+
+	periodicCleanUpHitRecordCache()
+
 	return &AccessControlHandlersCollection{
 		cache: make(map[string]map[string]*PlaybackAccessControlEntry),
 		gateClient: &GateClient{
@@ -105,6 +136,18 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 
 	if jwt == "" {
 		jwt = payload.JWT
+	}
+
+	if _, ok := hitRecordCache.data[playbackID]; ok {
+		hitRecordCache.mux.Lock()
+		defer hitRecordCache.mux.Unlock()
+
+		if len(hitRecordCache.data[playbackID].hits) >= hitRecordCache.data[playbackID].rateLimit {
+			glog.Infof("Rate limit reached for playbackID %v", playbackID)
+			return false, nil
+		}
+
+		hitRecordCache.data[playbackID].hits = append(hitRecordCache.data[playbackID].hits, time.Now())
 	}
 
 	if accessKey != "" {
@@ -182,9 +225,15 @@ func isStale(entry *PlaybackAccessControlEntry) bool {
 }
 
 func (ac *AccessControlHandlersCollection) cachePlaybackAccessControlInfo(playbackID, cacheKey string, requestBody []byte) error {
-	allow, maxAge, stale, err := ac.gateClient.QueryGate(requestBody)
+	allow, rateLimit, maxAge, stale, err := ac.gateClient.QueryGate(requestBody)
 	if err != nil {
 		return err
+	}
+
+	if rateLimit > 0 {
+		if _, ok := hitRecordCache.data[playbackID]; !ok {
+			hitRecordCache.data[playbackID] = &HitRecord{hits: make([]time.Time, 0), rateLimit: int(rateLimit)}
+		}
 	}
 
 	var maxAgeTime = time.Now().Add(time.Duration(maxAge) * time.Second)
@@ -198,26 +247,50 @@ func (ac *AccessControlHandlersCollection) cachePlaybackAccessControlInfo(playba
 	return nil
 }
 
-func (g *GateClient) QueryGate(body []byte) (bool, int32, int32, error) {
+// Returns:
+// - bool: whether the request was successful
+// - int32: the rate limit for the request
+// - int32: the max age for the request
+// - int32: the stale while revalidate for the request
+// - error: if any
+func (g *GateClient) QueryGate(body []byte) (bool, int32, int32, int32, error) {
 	req, err := http.NewRequest("POST", g.gateURL, bytes.NewReader(body))
 	if err != nil {
-		return false, 0, 0, err
+		return false, 0, 0, 0, err
 	}
 
 	req.Header.Set("Content-Type", "application/json")
 
 	res, err := g.Client.Do(req)
 	if err != nil {
-		return false, 0, 0, err
+		return false, 0, 0, 0, err
 	}
 
 	defer res.Body.Close()
 	cc, err := cacheobject.ParseResponseCacheControl(res.Header.Get("Cache-Control"))
 	if err != nil {
-		return false, 0, 0, err
+		return false, 0, 0, 0, err
 	}
 
-	return res.StatusCode/100 == 2, int32(cc.MaxAge), int32(cc.StaleWhileRevalidate), nil
+	var rateLimit int32 = 0
+
+	if res.ContentLength != 0 {
+		var result map[string]interface{}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		if err != nil {
+			return false, 0, 0, 0, err
+		}
+
+		if rl, ok := result["rateLimit"]; ok {
+			rateLimitFloat64, ok := rl.(float64)
+			if !ok {
+				return false, 0, 0, 0, fmt.Errorf("rateLimit is not a number")
+			}
+			rateLimit = int32(rateLimitFloat64)
+		}
+	}
+
+	return res.StatusCode/100 == 2, rateLimit, int32(cc.MaxAge), int32(cc.StaleWhileRevalidate), nil
 }
 
 type PlaybackGateClaims struct {


### PR DESCRIPTION
Clear the map instead of reassigning the struct to avoid race conditions