### PR TITLE
clients: input-copy: add -analyzeduration to input probe logic

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -64,7 +64,7 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 	}
 
 	log.Log(requestID, "starting probe", "source", inputFile.String(), "dest", osTransferURL.String())
-	inputFileProbe, err := s.Probe.ProbeFile(requestID, signedURL)
+	inputFileProbe, err := s.Probe.ProbeFile(requestID, signedURL, "-analyzeduration", "15000000")
 	if err != nil {
 		log.Log(requestID, "probe failed", "err", err, "source", inputFile.String(), "dest", osTransferURL.String())
 		return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)


### PR DESCRIPTION
For recordings, the first segment can have missing or delayed audio and video tracks as the streamer begins the stream. Currently, the probe of an m3u8 file will fail as ffprobe attempts opening the first segment (e.g. 0.ts) and fails to determing codec information for either the audio or video track. This causes the InputVideo struct to get populated with incorrect info (e.g. width and height is set to 0) which causes downstream transcode issues. Setting -analyzeduration 15M allows ffprobe to inspect up to 15s of audio and video tracks to determine the track information.