### PR TITLE
Fix isIngest for Stream Pull Source

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"reflect"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/livepeer/catalyst-api/metrics"
@@ -108,9 +109,11 @@ func (ms MistState) IsIngestStream(stream string) bool {
 		return false
 	}
 	as, ok := ms.ActiveStreams[stream]
-	// Mist returns "push://" for ingest streams and "push://INTERNAL_ONLY*" for playback streams, e.g.,
-	// "push://INTERNAL_ONLY:dtsc://mdw-staging-staging-catalyst-0.livepeer.monster:4200".
-	return ok && as.Source == "push://"
+	// Mist returns:
+	//  - "push://" for ingest streams
+	//  - "push://INTERNAL_ONLY:dtsc://*" for playback streams
+	//  - "push://INTERNAL_ONLY:<url>" for ingest pull-source streams
+	return ok && !(strings.HasPrefix(as.Source, "push://INTERNAL_ONLY:dtsc://"))
 }
 
 type MistPush struct {

--- a/clients/mist_client_test.go
+++ b/clients/mist_client_test.go
@@ -800,6 +800,10 @@ func TestIsIngestStream(t *testing.T) {
 			wantIsIngest: true,
 		},
 		{
+			stream:       "video+5678901234",
+			wantIsIngest: true,
+		},
+		{
 			stream:       "video+playback",
 			wantIsIngest: false,
 		},
@@ -813,6 +817,9 @@ func TestIsIngestStream(t *testing.T) {
 		ActiveStreams: map[string]*ActiveStream{
 			"video+123456789": {
 				Source: "push://",
+			},
+			"video+5678901234": {
+				Source: "push://INTERNAL_ONLY:https://test-liveplay-quic.trovo.live/live/abcdef-12345",
 			},
 			"video+playback": {
 				Source: "push://INTERNAL_ONLY:dtsc://mdw-staging-staging-catalyst-0.livepeer.monster:4200",


### PR DESCRIPTION
~~**WARNING: This PR needs to be merged AFTER we solve the issue with multiple ingest Mist nodes ([Discord](https://discord.com/channels/423160867534929930/1204065725896069170/1204740831609753660))**~~

This implements all the functionality we had for the ingest streams, in particular:
- multistream
- heartbeats sent to studio
- metrics collection