### PR TITLE
Don't return a STREAM_SOURCE for suspended / deleted streams

### DIFF
--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -165,6 +165,14 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 		return "", fmt.Errorf("failed to get stream to check stream pull: %w", err)
 	}
 
+	if stream.Suspended {
+		return "", fmt.Errorf("stream is suspended")
+	}
+
+	if stream.Deleted {
+		return "", fmt.Errorf("stream is deleted")
+	}
+
 	if stream.Pull == nil {
 		return "", nil
 	}


### PR DESCRIPTION
The current behaviour meant that the first playback after a stream was deleted would cause it to become active again