### PR TITLE
Handle large a/v offset in first segment of recordings.

### DIFF
--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -123,7 +123,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 				Codec:        job.sourceCodecVideo,
 				Bitrate:      job.sourceBitrateVideo,
 				DurationSec:  job.InputFileInfo.Duration,
-				StartTimeSec: 0,
+				StartTimeSec: job.sourceVideoStartTimeSec,
 				VideoTrack: video.VideoTrack{
 					Width:  job.sourceWidth,
 					Height: job.sourceHeight,
@@ -136,7 +136,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 				Codec:        job.sourceCodecAudio,
 				Bitrate:      job.sourceBitrateAudio,
 				DurationSec:  job.InputFileInfo.Duration,
-				StartTimeSec: 0,
+				StartTimeSec: job.sourceAudioStartTimeSec,
 				AudioTrack: video.AudioTrack{
 					Channels:   job.sourceChannels,
 					SampleRate: job.sourceSampleRate,

--- a/test/steps/callbacks.go
+++ b/test/steps/callbacks.go
@@ -24,7 +24,7 @@ type Callback struct {
 			Bitrate   int     `json:"bitrate"`
 			Duration  float64 `json:"duration"`
 			Size      int     `json:"size"`
-			StartTime int     `json:"start_time"`
+			StartTime float64 `json:"start_time"`
 			Width     int     `json:"width,omitempty"`
 			Height    int     `json:"height,omitempty"`
 			Fps       int     `json:"fps,omitempty"`


### PR DESCRIPTION
    transcode: drop first segment if a/v tracks have a large offset

For HLS input (recordings), sometimes the first segment can experience a
    large delta between the audio and video track's start time (in seconds).
    This is mainly because when a streamer begins the stream, the user's
    hardware config and OBS settings might cause the video track to start
    later than the audio (or vice versa). These segments can be transcoded
    but muxing them into an MP4 will fail. For these cases, the first segment
    should be dropped from the transcode payload.