### PR TITLE
access-control: send info payload & headers to gate for webhook trigger

### DIFF
--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -142,6 +142,8 @@ func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, pla
 	webhookHeaders["X-Forwarded-Proto"] = payload.ForwardedProto
 	webhookHeaders["X-Tlive-Spanid"] = payload.SessionID
 	webhookHeaders["Tx-Stream-Id"] = playbackID
+	webhookHeaders["Host"] = payload.Host
+	webhookHeaders["Origin"] = payload.Origin
 
 	acReq := PlaybackAccessControlRequest{
 		Stream: playbackID,

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -36,10 +36,19 @@ type PlaybackAccessControlEntry struct {
 }
 
 type PlaybackAccessControlRequest struct {
-	Type      string `json:"type"`
-	Pub       string `json:"pub"`
-	AccessKey string `json:"accessKey"`
-	Stream    string `json:"stream"`
+	Type           string                      `json:"type"`
+	Pub            string                      `json:"pub"`
+	AccessKey      string                      `json:"accessKey"`
+	Stream         string                      `json:"stream"`
+	WebhookPayload AccessControlWebhookPayload `json:"webhookPayload"`
+	WebhookHeaders map[string]string           `json:"webhookHeaders"`
+}
+
+type AccessControlWebhookPayload struct {
+	UserIP     string            `json:"userIP"`
+	PlayDomain string            `json:"playDomain"`
+	PlayURL    string            `json:"playURL"`
+	Headers    map[string]string `json:"headers"`
 }
 
 type GateAPICaller interface {
@@ -126,7 +135,26 @@ func (ac *AccessControlHandlersCollection) IsAuthorized(ctx context.Context, pla
 }
 
 func (ac *AccessControlHandlersCollection) isAuthorized(ctx context.Context, playbackID string, payload *misttriggers.UserNewPayload) (bool, error) {
-	acReq := PlaybackAccessControlRequest{Stream: playbackID, Type: "accessKey"}
+	webhookHeaders := make(map[string]string)
+
+	webhookHeaders["User-Agent"] = payload.UserAgent
+	webhookHeaders["Referer"] = payload.Referrer
+	webhookHeaders["X-Forwarded-Proto"] = payload.ForwardedProto
+	webhookHeaders["X-Tlive-Spanid"] = payload.SessionID
+	webhookHeaders["Tx-Stream-Id"] = playbackID
+
+	acReq := PlaybackAccessControlRequest{
+		Stream: playbackID,
+		Type:   "accessKey",
+		WebhookPayload: AccessControlWebhookPayload{
+			UserIP:     payload.OriginIP,
+			PlayDomain: payload.URL.Host,
+			Headers:    webhookHeaders,
+			PlayURL:    payload.URL.String(),
+		},
+		WebhookHeaders: webhookHeaders,
+	}
+
 	cacheKey := ""
 	accessKey := payload.URL.Query().Get("accessKey")
 	jwt := payload.URL.Query().Get("jwt")

--- a/handlers/misttriggers/user_new.go
+++ b/handlers/misttriggers/user_new.go
@@ -24,6 +24,8 @@ type UserNewPayload struct {
 	Referrer       string
 	UserAgent      string
 	ForwardedProto string
+	Host           string
+	Origin         string
 }
 
 func ParseUserNewPayload(payload MistTriggerBody) (UserNewPayload, error) {
@@ -59,6 +61,18 @@ func (d *MistCallbackHandlersCollection) TriggerUserNew(ctx context.Context, w h
 			accessKey = cookie.Value
 		case "Livepeer-Jwt":
 			jwt = cookie.Value
+		case "X-Fowarded-For":
+			payload.OriginIP = cookie.Value
+		case "Referer":
+			payload.Referrer = cookie.Value
+		case "User-Agent":
+			payload.UserAgent = cookie.Value
+		case "X-Forwarded-Proto":
+			payload.ForwardedProto = cookie.Value
+		case "Host":
+			payload.Host = cookie.Value
+		case "Origin":
+			payload.Host = cookie.Value
 		}
 	}
 

--- a/handlers/misttriggers/user_new.go
+++ b/handlers/misttriggers/user_new.go
@@ -72,7 +72,7 @@ func (d *MistCallbackHandlersCollection) TriggerUserNew(ctx context.Context, w h
 		case "Host":
 			payload.Host = cookie.Value
 		case "Origin":
-			payload.Host = cookie.Value
+			payload.Origin = cookie.Value
 		}
 	}
 

--- a/handlers/misttriggers/user_new.go
+++ b/handlers/misttriggers/user_new.go
@@ -11,15 +11,19 @@ import (
 )
 
 type UserNewPayload struct {
-	StreamName   string
-	Hostname     string
-	ConnectionID string
-	Protocol     string
-	URL          *url.URL
-	FullURL      string
-	SessionID    string
-	AccessKey    string
-	JWT          string
+	StreamName     string
+	Hostname       string
+	ConnectionID   string
+	Protocol       string
+	URL            *url.URL
+	FullURL        string
+	SessionID      string
+	AccessKey      string
+	JWT            string
+	OriginIP       string
+	Referrer       string
+	UserAgent      string
+	ForwardedProto string
 }
 
 func ParseUserNewPayload(payload MistTriggerBody) (UserNewPayload, error) {

--- a/middleware/gating.go
+++ b/middleware/gating.go
@@ -44,6 +44,8 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 		refrerer := req.Header.Get("Referer")
 		userAgent := req.Header.Get("User-Agent")
 		forwardedProto := req.Header.Get("X-Forwarded-Proto")
+		host := req.Header.Get("Host")
+		origin := req.Header.Get("Origin")
 
 		payload := misttriggers.UserNewPayload{
 			URL:            req.URL,
@@ -53,6 +55,8 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 			Referrer:       refrerer,
 			UserAgent:      userAgent,
 			ForwardedProto: forwardedProto,
+			Host:           host,
+			Origin:         origin,
 		}
 
 		playbackAccessControlAllowed, err := h.AccessControl.IsAuthorized(req.Context(), playbackID, &payload)

--- a/middleware/gating.go
+++ b/middleware/gating.go
@@ -40,10 +40,19 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 			jwt = req.Header.Get("Livepeer-Jwt")
 		}
 
+		originIP := req.Header.Get("X-Forwarded-For")
+		refrerer := req.Header.Get("Referer")
+		userAgent := req.Header.Get("User-Agent")
+		forwardedProto := req.Header.Get("X-Forwarded-Proto")
+
 		payload := misttriggers.UserNewPayload{
-			URL:       req.URL,
-			AccessKey: accessKey,
-			JWT:       jwt,
+			URL:            req.URL,
+			AccessKey:      accessKey,
+			JWT:            jwt,
+			OriginIP:       originIP,
+			Referrer:       refrerer,
+			UserAgent:      userAgent,
+			ForwardedProto: forwardedProto,
 		}
 
 		playbackAccessControlAllowed, err := h.AccessControl.IsAuthorized(req.Context(), playbackID, &payload)


### PR DESCRIPTION
Adding custom headers and payload to Gate call, passing them to the webhook in Studio
Currently unsure on how to fetch properly some of the info - in the box some of the items are blank

Potentially we want some of the fields to be set only if the stream `isTrvoAuth=true`