### PR TITLE
Add Analytics Log endpoint

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -66,7 +66,7 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	analyticsApiHandlers := &handlers.AnalyticsHandlersCollection{}
 
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
-	if cli.EnableAnalytics {
+	if cli.EnableAnalytics == "true" || cli.EnableAnalytics == "enabled" {
 		router.POST("/analytics/log", analyticsApiHandlers.Log())
 	}
 

--- a/api/http.go
+++ b/api/http.go
@@ -63,8 +63,12 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 		Config:   cli,
 		Lapi:     lapi,
 	}
+	analyticsApiHandlers := &handlers.AnalyticsHandlersCollection{}
 
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
+	if cli.EnableAnalytics {
+		router.POST("/analytics/log", analyticsApiHandlers.Log())
+	}
 
 	// Playback endpoint
 	playback := middleware.LogAndMetrics(metrics.Metrics.PlaybackRequestDurationSec)(

--- a/api/http.go
+++ b/api/http.go
@@ -63,10 +63,10 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 		Config:   cli,
 		Lapi:     lapi,
 	}
-	analyticsApiHandlers := &handlers.AnalyticsHandlersCollection{}
 
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
 	if cli.EnableAnalytics == "true" || cli.EnableAnalytics == "enabled" {
+		analyticsApiHandlers := handlers.NewAnalyticsHandlersCollection()
 		router.POST("/analytics/log", analyticsApiHandlers.Log())
 	}
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -64,7 +64,7 @@ type Cli struct {
 	DefaultQuality            int
 	MaxBitrateFactor          float64
 	BlockedJWTs               []string
-	EnableAnalytics           bool
+	EnableAnalytics           string
 
 	// mapping playbackId to value between 0.0 to 100.0
 	CdnRedirectPlaybackPct             map[string]float64

--- a/config/cli.go
+++ b/config/cli.go
@@ -64,6 +64,7 @@ type Cli struct {
 	DefaultQuality            int
 	MaxBitrateFactor          float64
 	BlockedJWTs               []string
+	EnableAnalytics           bool
 
 	// mapping playbackId to value between 0.0 to 100.0
 	CdnRedirectPlaybackPct             map[string]float64

--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	github.com/miekg/dns v1.1.50 // indirect
 	github.com/minio/minio-go/v7 v7.0.45 // indirect
 	github.com/minio/sha256-simd v1.0.1 // indirect
+	github.com/mmcloughlin/geohash v0.10.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/mr-tron/base58 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -493,6 +493,8 @@ github.com/minio/sha256-simd v1.0.1 h1:6kaan5IFmwTNynnKKpDHe6FWHohJOHhCPchzK49dz
 github.com/minio/sha256-simd v1.0.1/go.mod h1:Pz6AKMiUdngCLpeTL/RJY1M9rUuPMYujV5xJjtbRSN8=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
+github.com/mmcloughlin/geohash v0.10.0 h1:9w1HchfDfdeLc+jFEf/04D27KP7E2QmpDu52wPbJWRE=
+github.com/mmcloughlin/geohash v0.10.0/go.mod h1:oNZxQo5yWJh0eMQEP/8hwQuVx9Z9tjwFUqcTB1SmG0c=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -1,0 +1,130 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/errors"
+	"github.com/mmcloughlin/geohash"
+	"github.com/xeipuuv/gojsonschema"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+const GEO_HASH_PRECISION = 3
+
+type AnalyticsHandler struct {
+}
+
+type AnalyticsLog struct {
+	SessionID  string              `json:"session_id"`
+	PlaybackID string              `json:"playback_id"`
+	Protocol   string              `json:"protocol"`
+	PageURL    string              `json:"page_url"`
+	SourceURL  string              `json:"source_url"`
+	Player     string              `json:"player"`
+	UserAgent  string              `json:"user_agent"`
+	UID        string              `json:"uid"`
+	Events     []AnalyticsLogEvent `json:"events"`
+}
+
+type AnalyticsLogEvent struct {
+	Type           string `json:"type"`
+	Timestamp      int64  `json:"timestamp"`
+	Errors         int    `json:"errors,omitempty"`
+	PlaytimeMS     int    `json:"playtime_ms,omitempty"`
+	TTFFMS         int    `json:"ttff_ms,omitempty"`
+	PreloadTimeMS  int    `json:"preload_time_ms,omitempty"`
+	AutoplayStatus string `json:"autoplay_status,omitempty"`
+	BufferMS       int    `json:"buffer_ms,omitempty"`
+	ErrorMessage   string `json:"error_message,omitempty"`
+}
+
+type AnalyticsGeo struct {
+	GeoHash     string
+	Continent   string
+	Country     string
+	Subdivision string
+	Timezone    string
+}
+
+type AnalyticsHandlersCollection struct {
+}
+
+func (d *AnalyticsHandlersCollection) Log() httprouter.Handle {
+	schema := inputSchemasCompiled["AnalyticsLog"]
+
+	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+		log, err := parseAnalyticsLog(r, schema)
+		if log == nil {
+			errors.WriteHTTPBadRequest(w, "Invalid request payload", err)
+			return
+		}
+		geo, err := parseAnalyticsGeo(r)
+		if err != nil {
+			glog.Warning("error parsing geo info from analytics log request header, err=%v", err)
+		}
+
+		// TODO: ENG-1650, Process analytics data and remove logging
+		glog.Info("Processing analytics log: log=%v, geo=%v", log, geo)
+	}
+}
+
+func parseAnalyticsGeo(r *http.Request) (*AnalyticsGeo, error) {
+	res := AnalyticsGeo{}
+	var missingHeader []string
+
+	res.Continent, missingHeader = getOrAddMissing("X-Continent-Name", r.Header, missingHeader)
+	res.Country, missingHeader = getOrAddMissing("X-City-Country-Name", r.Header, missingHeader)
+	res.Subdivision, missingHeader = getOrAddMissing("X-Subregion-Name", r.Header, missingHeader)
+	res.Timezone, missingHeader = getOrAddMissing("X-Time-Zone", r.Header, missingHeader)
+
+	lat, missingHeader := getOrAddMissing("X-Latitude", r.Header, missingHeader)
+	lon, missingHeader := getOrAddMissing("X-Longitude", r.Header, missingHeader)
+	if lat != "" && lon != "" {
+		latF, err := strconv.ParseFloat(lat, 64)
+		if err != nil {
+			return &res, fmt.Errorf("error parsing header X-Latitude, err=%v", err)
+		}
+		lonF, err := strconv.ParseFloat(lon, 64)
+		if err != nil {
+			return &res, fmt.Errorf("error parsing header X-Longitude, err=%v", err)
+		}
+		res.GeoHash = geohash.EncodeWithPrecision(latF, lonF, GEO_HASH_PRECISION)
+	}
+	if len(missingHeader) > 0 {
+		return &res, fmt.Errorf("missing geo headers: %v", missingHeader)
+	}
+
+	return &res, nil
+}
+
+func getOrAddMissing(key string, headers http.Header, missingHeaders []string) (string, []string) {
+	if val, ok := headers[key]; ok {
+		return val[0], missingHeaders
+	}
+	missingHeaders = append(missingHeaders, key)
+	return "", missingHeaders
+}
+
+func parseAnalyticsLog(r *http.Request, schema *gojsonschema.Schema) (*AnalyticsLog, error) {
+	payload, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	result, err := schema.Validate(gojsonschema.NewBytesLoader(payload))
+	if err != nil {
+		return nil, err
+	}
+	if !result.Valid() {
+		return nil, err
+	}
+	var log AnalyticsLog
+	if err := json.Unmarshal(payload, &log); err != nil {
+		return nil, err
+	}
+
+	return &log, nil
+}

--- a/handlers/analytics_test.go
+++ b/handlers/analytics_test.go
@@ -1,0 +1,200 @@
+package handlers
+
+import (
+	"github.com/julienschmidt/httprouter"
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHandleLog(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name         string
+		requestBody  string
+		wantHttpCode int
+	}{
+		{
+			name: "valid payload",
+			requestBody: `{
+				"session_id": "abcdef",
+				"playback_id": "123456",
+				"protocol": "video/mp4",
+				"page_url": "https://www.fishtank.live/",
+				"source_url": "https://vod-cdn.lp-playback.studio/raw/jxf4iblf6wlsyor6526t4tcmtmqa/catalyst-vod-com/hls/362f9l7ekeoze518/1080p0.mp4?tkn=8b140ec6b404a",
+				"player": "video-@livepeer/react@3.1.9",
+				"user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+				"uid": "abcdef",
+				"events": [
+					{
+						"type": "heartbeat",
+						"timestamp": 1234567895,
+						"errors": 0,
+						"playtime_ms": 4500,
+						"ttff_ms": 300,
+						"preload_time_ms": 1000,
+						"buffer_ms": 50
+					}
+				]
+			}`,
+			wantHttpCode: 200,
+		},
+		{
+			name: "additional field",
+			requestBody: `{
+				"unknown_field: "12355",
+				"session_id": "abcdef",
+				"playback_id": "123456",
+				"protocol": "video/mp4",
+				"page_url": "https://www.fishtank.live/",
+				"source_url": "https://vod-cdn.lp-playback.studio/raw/jxf4iblf6wlsyor6526t4tcmtmqa/catalyst-vod-com/hls/362f9l7ekeoze518/1080p0.mp4?tkn=8b140ec6b404a",
+				"player": "video-@livepeer/react@3.1.9",
+				"user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+				"uid": "abcdef",
+				"events": [
+					{
+						"type": "heartbeat",
+						"timestamp": 1234567895,
+						"errors": 0,
+						"playtime_ms": 4500,
+						"ttff_ms": 300,
+						"preload_time_ms": 1000,
+						"buffer_ms": 50
+					}
+				]
+			}`,
+			wantHttpCode: 400,
+		},
+		{
+			name: "missing field",
+			requestBody: `{
+				"playback_id": "123456",
+				"protocol": "video/mp4",
+				"page_url": "https://www.fishtank.live/",
+				"source_url": "https://vod-cdn.lp-playback.studio/raw/jxf4iblf6wlsyor6526t4tcmtmqa/catalyst-vod-com/hls/362f9l7ekeoze518/1080p0.mp4?tkn=8b140ec6b404a",
+				"player": "video-@livepeer/react@3.1.9",
+				"user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.150 Safari/537.36",
+				"uid": "abcdef",
+				"events": [
+					{
+						"type": "heartbeat",
+						"timestamp": 1234567895,
+						"errors": 0,
+						"playtime_ms": 4500,
+						"ttff_ms": 300,
+						"preload_time_ms": 1000,
+						"buffer_ms": 50
+					}
+				]
+			}`,
+			wantHttpCode: 400,
+		},
+	}
+
+	analyticsApiHandlers := AnalyticsHandlersCollection{}
+	router := httprouter.New()
+	router.POST("/analytics/log", analyticsApiHandlers.Log())
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, _ := http.NewRequest("POST", "/analytics/log", strings.NewReader(tt.requestBody))
+			rr := httptest.NewRecorder()
+			router.ServeHTTP(rr, req)
+
+			require.Equal(rr.Result().StatusCode, tt.wantHttpCode)
+		})
+	}
+}
+
+func TestParseAnalyticsGeo(t *testing.T) {
+	require := require.New(t)
+
+	tests := []struct {
+		name              string
+		header            http.Header
+		exp               AnalyticsGeo
+		wantErrorContains []string
+	}{
+		{
+			name: "Correct Headers",
+			header: map[string][]string{
+				"X-Latitude":          {"50.06580"},
+				"X-Longitude":         {"19.94010"},
+				"X-Continent-Name":    {"Europe"},
+				"X-City-Country-Name": {"Poland"},
+				"X-Subregion-Name":    {"Lesser Poland"},
+				"X-Time-Zone":         {"Europe/Warsaw"},
+			},
+			exp: AnalyticsGeo{
+				GeoHash:     "u2yhvdpyqj",
+				Continent:   "Europe",
+				Country:     "Poland",
+				Subdivision: "Lesser Poland",
+				Timezone:    "Europe/Warsaw",
+			},
+			wantErrorContains: nil,
+		},
+		{
+			name: "Missing Headers",
+			header: map[string][]string{
+				"X-Latitude":          {"50.06580"},
+				"X-Longitude":         {"19.94010"},
+				"X-City-Country-Name": {"Poland"},
+			},
+			exp: AnalyticsGeo{
+				GeoHash: "u2yhvdpyqj",
+				Country: "Poland",
+			},
+			wantErrorContains: []string{
+				"missing geo headers",
+				"X-Continent-Name",
+				"X-Subregion-Name",
+				"X-Time-Zone",
+			},
+		},
+		{
+			name: "Incorrect X-Longitude",
+			header: map[string][]string{
+				"X-Latitude":  {"sometext"},
+				"X-Longitude": {"19.94010"},
+			},
+			exp:               AnalyticsGeo{},
+			wantErrorContains: []string{"error parsing header X-Latitude"},
+		},
+		{
+			name: "Incorrect Longitude",
+			header: map[string][]string{
+				"X-Latitude":  {"50.06580"},
+				"X-Longitude": {"sometext"},
+			},
+			exp:               AnalyticsGeo{},
+			wantErrorContains: []string{"error parsing header X-Longitude"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := http.Request{Header: tt.header}
+
+			res, err := parseAnalyticsGeo(&req)
+
+			if tt.wantErrorContains != nil {
+				for _, errMsg := range tt.wantErrorContains {
+					require.Contains(err.Error(), errMsg)
+				}
+			} else {
+				require.NoError(err)
+			}
+			require.NotNil(res)
+			if res.GeoHash != "" || tt.exp.GeoHash != "" {
+				require.Equal(tt.exp.GeoHash[:GEO_HASH_PRECISION], res.GeoHash)
+			}
+			require.Equal(tt.exp.Continent, res.Continent)
+			require.Equal(tt.exp.Country, res.Country)
+			require.Equal(tt.exp.Subdivision, res.Subdivision)
+			require.Equal(tt.exp.Timezone, res.Timezone)
+		})
+	}
+}

--- a/handlers/schemas/AnalyticsLog.yaml
+++ b/handlers/schemas/AnalyticsLog.yaml
@@ -1,0 +1,53 @@
+type: "object"
+properties:
+  session_id:
+    type: "string"
+  playback_id:
+    type: "string"
+  protocol:
+    type: "string"
+  page_url:
+    type: "string"
+  source_url:
+    type: "string"
+  player:
+    type: "string"
+  user_agent:
+    type: "string"
+  uid:
+    type: "string"
+  events:
+    type: "array"
+    items:
+      - type: "object"
+        properties:
+          type:
+            type: "string"
+          timestamp:
+            type: "integer"
+          errors:
+            type: "integer"
+          playtime_ms:
+            type: "integer"
+          ttff_ms:
+            type: "integer"
+          preload_time_ms:
+            type: "integer"
+          buffer_ms:
+            type: "integer"
+          autoplay_status:
+            type: "string"
+          error_message:
+            type: "string"
+        required:
+          - type
+          - timestamp
+required:
+  - session_id
+  - playback_id
+  - protocol
+  - page_url
+  - source_url
+  - player
+  - user_agent
+  - events

--- a/main.go
+++ b/main.go
@@ -121,7 +121,7 @@ func main() {
 	fs.IntVar(&cli.SerfQueueSize, "serf-queue-size", 100000, "Size of internal serf queue before messages are dropped")
 	fs.IntVar(&cli.SerfEventBuffer, "serf-event-buffer", 100000, "Size of serf 'recent event' buffer, outside of which things are dropped")
 	fs.IntVar(&cli.SerfMaxQueueDepth, "serf-max-queue-depth", 100000, "Size of Serf queue, outside of which things are dropped")
-	config.InvertedBoolFlag(fs, &cli.EnableAnalytics, "enable-analytics", true, "Enables analytics API")
+	fs.StringVar(&cli.EnableAnalytics, "analytics", "disabled", "Enables analytics API: enabled or disabled")
 	pprofPort := fs.Int("pprof-port", 6061, "Pprof listen port")
 
 	fs.String("send-audio", "", "[DEPRECATED] ignored, will be removed")

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func main() {
 	fs.IntVar(&cli.SerfQueueSize, "serf-queue-size", 100000, "Size of internal serf queue before messages are dropped")
 	fs.IntVar(&cli.SerfEventBuffer, "serf-event-buffer", 100000, "Size of serf 'recent event' buffer, outside of which things are dropped")
 	fs.IntVar(&cli.SerfMaxQueueDepth, "serf-max-queue-depth", 100000, "Size of Serf queue, outside of which things are dropped")
+	config.InvertedBoolFlag(fs, &cli.EnableAnalytics, "enable-analytics", true, "Enables analytics API")
 	pprofPort := fs.Int("pprof-port", 6061, "Pprof listen port")
 
 	fs.String("send-audio", "", "[DEPRECATED] ignored, will be removed")


### PR DESCRIPTION
Add `/analytics/log` endpoint which will be used to pass the analytics from player => analytics pipeline.

Design Doc: https://www.notion.so/livepeer/Studio-2-0-Realtime-Viewership-Backend-2511fd91b0854d09958eed1fa548f447

fix: https://linear.app/livepeer/issue/ENG-1649/implement-http-endpoint-for-periodic-events

Note that:
- Currently, the endpoint does not do anything other than logging, but I'd like to get it into staging, because:
  - It will help with the Player integration
  - It will help with checking if NGINX is passing geo data correctly
  - It will help with checking if the endpoint is exposed correctly with NGINX
- The features is behind the flag `analytics`
  - I plan to have it enabled in staging, but disabled for now in prod
  - The flag is string not bool, because bool is broken with passing from Mist => Catalyst API (the hack with inverted bool is ugly, we should not use it)
  
CC: @0xcadams 