### PR TITLE
geolocation: Allow overriding lat/lon with qs

### DIFF
--- a/handlers/geolocation/gelocation_test.go
+++ b/handlers/geolocation/gelocation_test.go
@@ -39,6 +39,11 @@ var fakeSerfMember = cluster.Member{
 
 var prefixes = [...]string{"video", "videorec", "stream", "playback", "vod"}
 
+var coordinates = []struct{ lat, lon string }{
+	{"-22.952595041532618", "-43.194387810060256"},
+	{"41.37409383123628", "2.161971651333584"},
+}
+
 func randomPrefix() string {
 	return prefixes[rand.Intn(len(prefixes))]
 }
@@ -92,10 +97,10 @@ func TestPlaybackIDParserWithoutPrefix(t *testing.T) {
 	}
 }
 
-func getHLSURLs(proto, host string) []string {
+func getHLSURLs(proto, host, query string) []string {
 	var urls []string
 	for _, prefix := range prefixes {
-		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/index.m3u8", proto, host, prefix, playbackID))
+		urls = append(urls, fmt.Sprintf("%s://%s/hls/%s+%s/index.m3u8%s", proto, host, prefix, playbackID, query))
 	}
 	return urls
 }
@@ -179,13 +184,67 @@ func TestRedirectHandler404(t *testing.T) {
 	requireReq(t, path).
 		result(n).
 		hasStatus(http.StatusTemporaryRedirect).
-		hasHeader("Location", getHLSURLs("http", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, "")...)
 
 	requireReq(t, path).
 		withHeader("X-Forwarded-Proto", "https").
 		result(n).
 		hasStatus(http.StatusTemporaryRedirect).
-		hasHeader("Location", getHLSURLs("https", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("https", closestNodeAddr, "")...)
+}
+
+func TestRedirectHandler_LatLonHeaders(t *testing.T) {
+	n := mockHandlers(t)
+
+	n.Balancer.(*mockbalancer.MockBalancer).EXPECT().
+		GetBestNode(context.Background(), prefixes[:], playbackID, coordinates[0].lat, coordinates[0].lon, "").
+		Return(closestNodeAddr, fmt.Sprintf("%s+%s", prefixes[0], playbackID), nil)
+
+	pathHLS := fmt.Sprintf("/hls/%s/index.m3u8", playbackID)
+
+	requireReq(t, pathHLS).
+		withHeader("X-Latitude", coordinates[0].lat).
+		withHeader("X-Longitude", coordinates[0].lon).
+		result(n).
+		hasStatus(http.StatusTemporaryRedirect).
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, "")...)
+}
+
+func TestRedirectHandler_LatLonQueryOverride(t *testing.T) {
+	n := mockHandlers(t)
+
+	n.Balancer.(*mockbalancer.MockBalancer).EXPECT().
+		GetBestNode(context.Background(), prefixes[:], playbackID, coordinates[1].lat, coordinates[1].lon, "").
+		Return(closestNodeAddr, fmt.Sprintf("%s+%s", prefixes[0], playbackID), nil)
+
+	query := fmt.Sprintf("?lat=%s&lon=%s", coordinates[1].lat, coordinates[1].lon)
+	pathHLS := fmt.Sprintf("/hls/%s/index.m3u8%s", playbackID, query)
+
+	requireReq(t, pathHLS).
+		withHeader("X-Latitude", coordinates[0].lat).
+		withHeader("X-Longitude", coordinates[0].lon).
+		result(n).
+		hasStatus(http.StatusTemporaryRedirect).
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, query)...)
+}
+
+func TestRedirectHandler_IncompleteLatLonQuery(t *testing.T) {
+	n := mockHandlers(t)
+
+	// Make sure values are not overridden if either lat or lon are missing
+	n.Balancer.(*mockbalancer.MockBalancer).EXPECT().
+		GetBestNode(context.Background(), prefixes[:], playbackID, coordinates[0].lat, coordinates[0].lon, "").
+		Return(closestNodeAddr, fmt.Sprintf("%s+%s", prefixes[0], playbackID), nil)
+
+	query := fmt.Sprintf("?lat=&lon=%s", coordinates[1].lon)
+	pathHLS := fmt.Sprintf("/hls/%s/index.m3u8%s", playbackID, query)
+
+	requireReq(t, pathHLS).
+		withHeader("X-Latitude", coordinates[0].lat).
+		withHeader("X-Longitude", coordinates[0].lon).
+		result(n).
+		hasStatus(http.StatusTemporaryRedirect).
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, query)...)
 }
 
 func TestRedirectHandlerHLS_Correct(t *testing.T) {
@@ -196,13 +255,13 @@ func TestRedirectHandlerHLS_Correct(t *testing.T) {
 	requireReq(t, path).
 		result(n).
 		hasStatus(http.StatusTemporaryRedirect).
-		hasHeader("Location", getHLSURLs("http", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, "")...)
 
 	requireReq(t, path).
 		withHeader("X-Forwarded-Proto", "https").
 		result(n).
 		hasStatus(http.StatusTemporaryRedirect).
-		hasHeader("Location", getHLSURLs("https", closestNodeAddr)...)
+		hasHeader("Location", getHLSURLs("https", closestNodeAddr, "")...)
 }
 
 func TestRedirectHandlerHLSVOD_Correct(t *testing.T) {

--- a/handlers/geolocation/gelocation_test.go
+++ b/handlers/geolocation/gelocation_test.go
@@ -247,6 +247,29 @@ func TestRedirectHandler_IncompleteLatLonQuery(t *testing.T) {
 		hasHeader("Location", getHLSURLs("http", closestNodeAddr, query)...)
 }
 
+func TestRedirectHandler_InvalidLatLonValues(t *testing.T) {
+	n := mockHandlers(t)
+
+	// coordinates should fallback to empty strings if invalid. so just rely on
+	// the default `EXPECT`s from `mockHandlers`.
+
+	pathHLS := fmt.Sprintf("/hls/%s/index.m3u8", playbackID)
+	requireReq(t, pathHLS).
+		withHeader("X-Latitude", "-123").
+		withHeader("X-Longitude", "420").
+		result(n).
+		hasStatus(http.StatusTemporaryRedirect).
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, "")...)
+
+	query := "?lat=-112&lon=NaN"
+	pathHLS = fmt.Sprintf("/hls/%s/index.m3u8%s", playbackID, query)
+
+	requireReq(t, pathHLS).
+		result(n).
+		hasStatus(http.StatusTemporaryRedirect).
+		hasHeader("Location", getHLSURLs("http", closestNodeAddr, query)...)
+}
+
 func TestRedirectHandlerHLS_Correct(t *testing.T) {
 	n := mockHandlers(t)
 

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/golang/glog"
@@ -37,11 +38,17 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 		pathType, prefix, playbackID, pathTmpl := parsePlaybackID(r.URL.Path)
 		redirectPrefixes := c.Config.RedirectPrefixes
 
+		// `X-Latitude` and `X-Longitude` headers are populated by nginx/geoip when requests come from viewers. The `lat`
+		// and `lon` queries can override these and are used by the `studio API` to trigger stream pulls from a desired loc.
 		query := r.URL.Query()
 		lat, lon := query.Get("lat"), query.Get("lon")
-		if lat == "" || lon == "" {
+		if !isValidGPSCoord(lat, lon) {
 			lat = r.Header.Get("X-Latitude")
 			lon = r.Header.Get("X-Longitude")
+
+			if !isValidGPSCoord(lat, lon) {
+				lat, lon = "", ""
+			}
 		}
 
 		if c.Config.CdnRedirectPrefix != nil && (pathType == "hls" || pathType == "webrtc") {
@@ -289,4 +296,17 @@ func protocol(r *http.Request) string {
 		return "https"
 	}
 	return "http"
+}
+
+func isValidGPSCoord(lat, lon string) bool {
+	if lat == "" || lon == "" {
+		return false
+	}
+
+	latF, errLat := strconv.ParseFloat(lat, 64)
+	lonF, errLon := strconv.ParseFloat(lon, 64)
+	if errLat != nil || errLon != nil {
+		return false
+	}
+	return latF >= -90 && latF <= 90 && lonF >= -180 && lonF <= 180
 }

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -36,8 +36,13 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 		host := r.Host
 		pathType, prefix, playbackID, pathTmpl := parsePlaybackID(r.URL.Path)
 		redirectPrefixes := c.Config.RedirectPrefixes
-		lat := r.Header.Get("X-Latitude")
-		lon := r.Header.Get("X-Longitude")
+
+		query := r.URL.Query()
+		lat, lon := query.Get("lat"), query.Get("lon")
+		if lat == "" || lon == "" {
+			lat = r.Header.Get("X-Latitude")
+			lon = r.Header.Get("X-Longitude")
+		}
 
 		if c.Config.CdnRedirectPrefix != nil && (pathType == "hls" || pathType == "webrtc") {
 			cdnPercentage, toBeRedirected := c.Config.CdnRedirectPlaybackPct[playbackID]


### PR DESCRIPTION
This is to allow overriding the lat/lon used for load balancing with custom values.

It is needed for the API service to be able to trigger the pull stream to start in a location
close to the pull source, instead of close to where the API is.

The headers themselves are not overridable, since our nginx configuration uses `proxy_set_header`
which forces the value even if one is already present.

I thought about adding some kind of authorization for the override, but it feels like this context
there's no problem if a user tried to override this. They will just get redirected to a worse node. If
they are malicious, they could just hit that (and all other) nodes directly anyway.

Usage: https://github.com/livepeer/studio/pull/2073