### PR TITLE
Add logging and redirect for /analytics/log requests

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -67,7 +67,8 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
 	if cli.EnableAnalytics == "true" || cli.EnableAnalytics == "enabled" {
 		analyticsApiHandlers := handlers.NewAnalyticsHandlersCollection(mapic, lapi, cli.AnalyticsMetricsURL, cli.NodeName)
-		router.POST("/analytics/log", withCORS(analyticsApiHandlers.Log()))
+		router.POST("/analytics/log", withLogging(withCORS(analyticsApiHandlers.Log())))
+		router.GET("/analytics/log", withLogging(withCORS(geoHandlers.RedirectHandler())))
 	}
 
 	// Playback endpoint


### PR DESCRIPTION
Redirect: We want to redirect `GET /analytics/log` from `https://playback.livepeer.monster/analytics/log` => `https://mdw-staging-staging-catalyst-0.livepeer.monster/analytics/log`, so that player sticks to one catalyst node while sending analytics logs for assets (for stream it's already covered by the playback redirects).

Logging: I'm actually not sure if we should log every analytics log request. A Catalyst node currently can serve ~2.5k viewers, which means that during the peak, we'll log additional `500` logs / second (~2.5k req each 5s). It seems fine, but I'd like to double check with @pwilczynskiclearcode if that's not excessive.


fix https://linear.app/livepeer/issue/ENG-1712/fix-redirects-and-cors