### PR TITLE
Only call stop sessions on the ingest node for a stream

### DIFF
--- a/main.go
+++ b/main.go
@@ -380,6 +380,7 @@ func processClusterEvent(mapic mistapiconnector.IMac, bal balancer.Balancer, use
 			glog.V(5).Infof("received serf StreamEvent: %v", event.PlaybackID)
 			mapic.RefreshStreamIfNeeded(event.PlaybackID)
 		case *events.NukeEvent:
+			glog.V(5).Infof("received serf NukeEvent: %v", event.PlaybackID)
 			mapic.NukeStream(event.PlaybackID)
 			return
 		case *events.StopSessionsEvent:

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -196,11 +196,22 @@ func (mc *mac) NukeStream(playbackID string) {
 }
 
 func (mc *mac) StopSessions(playbackID string) {
+	mistState, err := mc.mist.GetState()
+	if err != nil {
+		glog.Errorf("error stopping sessions, mist GetState failed playbackId=%s err=%q", playbackID, err)
+		return
+	}
+
 	streamNames := []string{
 		"video+" + playbackID,
 	}
 
 	for _, streamName := range streamNames {
+		if !mistState.IsIngestStream(streamName) {
+			// only call stop sessions if we are the ingest node for this stream
+			continue
+		}
+		glog.V(7).Infof("calling mist StopSessions playbackId=%s streamName=%s", playbackID, streamName)
 		err := mc.mist.StopSessions(streamName)
 		if err != nil {
 			glog.Errorf("error stopping sessions playbackId=%s streamName=%s err=%q", playbackID, streamName, err)


### PR DESCRIPTION
We only need to call this on the ingest node, it will then handle shutting down playback streams on other nodes.