### PR TITLE
vod: update transcode ladder for output renditions

### DIFF
--- a/clients/manifest.go
+++ b/clients/manifest.go
@@ -104,11 +104,10 @@ func GenerateAndUploadManifests(sourceManifest m3u8.MediaPlaylist, targetOSURL s
 
 	//sort transcoded Stats and loop in order.
 	SortTranscodedStats(transcodedStats)
-
 	// If the first rendition is greater than 2k resolution, then swap with the second rendition. HLS players
 	// typically load the first rendition in a master playlist and this can result in long downloads (and
 	// hence long TTFF) for high-res video segments.
-	if len(transcodedStats) >= 2 && (transcodedStats[0].Width >= 2160 || transcodedStats[0].Height >= 2160) {
+	if len(transcodedStats) >= 2 && (transcodedStats[0].Width >= 960 || transcodedStats[0].Height >= 960) {
 		transcodedStats[0], transcodedStats[1] = transcodedStats[1], transcodedStats[0]
 	}
 

--- a/clients/manifest_test.go
+++ b/clients/manifest_test.go
@@ -199,6 +199,13 @@ func TestCompliantMasterManifestOrdering(t *testing.T) {
 				BitsPerSecond: 1000000,
 			},
 			{
+				Name:          "medium-high-def",
+				FPS:           60,
+				Width:         1280,
+				Height:        720,
+				BitsPerSecond: 1000000,
+			},
+			{
 				Name:          "super-high-def",
 				FPS:           30,
 				Width:         1080,
@@ -222,11 +229,13 @@ func TestCompliantMasterManifestOrdering(t *testing.T) {
 	require.NoError(t, err)
 	const expectedMasterManifest = `#EXTM3U
 #EXT-X-VERSION:3
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2000000,RESOLUTION=1080x720,NAME="0-super-high-def",FRAME-RATE=30.000
-super-high-def/index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2000000,RESOLUTION=800x600,NAME="1-small-high-def",FRAME-RATE=30.000
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2000000,RESOLUTION=800x600,NAME="0-small-high-def",FRAME-RATE=30.000
 small-high-def/index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000000,RESOLUTION=800x600,NAME="2-lowlowlow",FRAME-RATE=60.000
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=2000000,RESOLUTION=1080x720,NAME="1-super-high-def",FRAME-RATE=30.000
+super-high-def/index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000000,RESOLUTION=1280x720,NAME="2-medium-high-def",FRAME-RATE=60.000
+medium-high-def/index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=1000000,RESOLUTION=800x600,NAME="3-lowlowlow",FRAME-RATE=60.000
 lowlowlow/index.m3u8
 `
 	require.Equal(t, expectedMasterManifest, string(masterManifestContents))

--- a/transcode/transcode_test.go
+++ b/transcode/transcode_test.go
@@ -163,10 +163,10 @@ func TestItCanTranscode(t *testing.T) {
 	// Confirm the master manifest was created and that it looks like a manifest
 	var expectedMasterManifest = `#EXTM3U
 #EXT-X-VERSION:3
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=3195660,RESOLUTION=2020x2020,NAME="0-2020p0"
-2020p0/index.m3u8
-#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=532610,RESOLUTION=2020x2020,NAME="1-low-bitrate"
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=532610,RESOLUTION=2020x2020,NAME="0-low-bitrate"
 low-bitrate/index.m3u8
+#EXT-X-STREAM-INF:PROGRAM-ID=0,BANDWIDTH=3195660,RESOLUTION=2020x2020,NAME="1-2020p0"
+2020p0/index.m3u8
 `
 
 	masterManifestBytes, err := os.ReadFile(filepath.Join(topLevelDir, "index.m3u8"))


### PR DESCRIPTION
To optimize playback and TTFF, the output transcode ladder is being updated to use 960p as the threshold i.e. any width/height above 960p will be re-ordered such that it appears second in the list. This is optimal for typical resolutions. For example, if the highest quality is 1920x1080, then it will likely get swapped with 1280x720 in the transcode ladder ordering. Similarly, if the ladder has a highest quality of 1280x960, it will get swapped with the next likely occuring resolution like 1280x720.