### PR TITLE
Add additional User Agent fields to Kafka Event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -145,6 +145,7 @@ require (
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 // indirect
 	github.com/u2takey/go-utils v0.3.1 // indirect
+	github.com/ua-parser/uap-go v0.0.0-20240113215029-33f8e6d47f38 // indirect
 	github.com/whyrusleeping/cbor-gen v0.0.0-20230418232409-daab9ece03a0 // indirect
 	github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -701,6 +701,8 @@ github.com/u2takey/ffmpeg-go v0.5.0 h1:r7d86XuL7uLWJ5mzSeQ03uvjfIhiJYvsRAJFCW4uk
 github.com/u2takey/ffmpeg-go v0.5.0/go.mod h1:ruZWkvC1FEiUNjmROowOAps3ZcWxEiOpFoHCvk97kGc=
 github.com/u2takey/go-utils v0.3.1 h1:TaQTgmEZZeDHQFYfd+AdUT1cT4QJgJn/XVPELhHw4ys=
 github.com/u2takey/go-utils v0.3.1/go.mod h1:6e+v5vEZ/6gu12w/DC2ixZdZtCrNokVxD0JUklcqdCs=
+github.com/ua-parser/uap-go v0.0.0-20240113215029-33f8e6d47f38 h1:F04Na0QJP9GJrwmK3vQDuDrCuGllrrfngW8CIeF1aag=
+github.com/ua-parser/uap-go v0.0.0-20240113215029-33f8e6d47f38/go.mod h1:BUbeWZiieNxAuuADTBNb3/aeje6on3DhU3rpWsQSB1E=
 github.com/urfave/cli v1.22.10/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/vimeo/go-util v1.2.0/go.mod h1:s13SMDTSO7AjH1nbgp707mfN5JFIWUFDU5MDDuRRtKs=
 github.com/warpfork/go-testmark v0.11.0 h1:J6LnV8KpceDvo7spaNU4+DauH2n1x+6RaO2rJrmpQ9U=

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -4,6 +4,13 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"github.com/ua-parser/uap-go/uaparser"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
 	cerrors "github.com/livepeer/catalyst-api/errors"
@@ -13,11 +20,6 @@ import (
 	"github.com/mileusna/useragent"
 	"github.com/mmcloughlin/geohash"
 	"github.com/xeipuuv/gojsonschema"
-	"io"
-	"net"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 const (
@@ -82,12 +84,14 @@ type AnalyticsGeo struct {
 type AnalyticsHandlersCollection struct {
 	extFetcher   analytics.IExternalDataFetcher
 	logProcessor analytics.ILogProcessor
+	uaParser     *uaparser.Parser
 }
 
 func NewAnalyticsHandlersCollection(streamCache mistapiconnector.IStreamCache, lapi *api.Client, lp analytics.ILogProcessor) AnalyticsHandlersCollection {
 	return AnalyticsHandlersCollection{
 		extFetcher:   analytics.NewExternalDataFetcher(streamCache, lapi),
 		logProcessor: lp,
+		uaParser:     uaparser.NewFromSaved(),
 	}
 }
 
@@ -113,7 +117,7 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 			cerrors.WriteHTTPBadRequest(w, "Invalid playback_id", nil)
 		}
 
-		for _, ad := range toAnalyticsData(log, geo, extData) {
+		for _, ad := range c.toAnalyticsData(log, geo, extData) {
 			select {
 			case dataCh <- ad:
 				// process data async
@@ -191,8 +195,10 @@ func getOrAddMissing(key string, headers http.Header, missingHeaders []string) (
 	return "", missingHeaders
 }
 
-func toAnalyticsData(log *AnalyticsLog, geo AnalyticsGeo, extData analytics.ExternalData) []analytics.LogData {
+func (c *AnalyticsHandlersCollection) toAnalyticsData(log *AnalyticsLog, geo AnalyticsGeo, extData analytics.ExternalData) []analytics.LogData {
 	ua := useragent.Parse(log.UserAgent)
+	ua2 := c.uaParser.Parse(log.UserAgent)
+
 	var res []analytics.LogData
 	for _, e := range log.Events {
 		if !isSupportedEvent(e.Type) {
@@ -213,7 +219,8 @@ func toAnalyticsData(log *AnalyticsLog, geo AnalyticsGeo, extData analytics.Exte
 			Source:                extData.SourceType,
 			CreatorID:             extData.CreatorID,
 			DeviceType:            deviceTypeOf(ua),
-			DeviceModel:           ua.Device,
+			DeviceModel:           ua2.Device.Model,
+			DeviceBrand:           ua2.Device.Brand,
 			Browser:               ua.Name,
 			OS:                    ua.OS,
 			PlaybackGeoHash:       geo.GeoHash,

--- a/handlers/analytics/log_processor.go
+++ b/handlers/analytics/log_processor.go
@@ -71,7 +71,6 @@ type LogData struct {
 	DeviceBrand           string       `json:"device_brand"`
 	Browser               string       `json:"browser"`
 	OS                    string       `json:"os"`
-	CPU                   string       `json:"cpu"`
 	PlaybackGeoHash       string       `json:"playback_geo_hash"`
 	PlaybackContinentName string       `json:"playback_continent_name"`
 	PlaybackCountryCode   string       `json:"playback_country_code"`

--- a/handlers/analytics_test.go
+++ b/handlers/analytics_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/handlers/analytics"
 	"github.com/stretchr/testify/require"
+	"github.com/ua-parser/uap-go/uaparser"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,6 +104,8 @@ func TestHandleLog(t *testing.T) {
 					UserID:         userID,
 					Source:         "stream",
 					DeviceType:     "desktop",
+					DeviceModel:    "Mac",
+					DeviceBrand:    "Apple",
 					Browser:        "Chrome",
 					OS:             "macOS",
 					EventType:      "heartbeat",
@@ -141,6 +144,8 @@ func TestHandleLog(t *testing.T) {
 					UserID:         userID,
 					Source:         "stream",
 					DeviceType:     "desktop",
+					DeviceModel:    "Mac",
+					DeviceBrand:    "Apple",
 					Browser:        "Chrome",
 					OS:             "macOS",
 					EventType:      "error",
@@ -213,6 +218,7 @@ func TestHandleLog(t *testing.T) {
 			analyticsApiHandlers := AnalyticsHandlersCollection{
 				extFetcher:   &mockFetcher,
 				logProcessor: &mockProcessor,
+				uaParser:     uaparser.NewFromSaved(),
 			}
 			router := httprouter.New()
 			router.POST("/analytics/log", analyticsApiHandlers.Log())


### PR DESCRIPTION
- Remove `cpu`
- Add `device_model` and `device_brand`

fix https://linear.app/livepeer/issue/ENG-1722/additional-fields-to-kafka-event-cpu-device-brand-device-model