### PR TITLE
Fix redirects to /analytics/log

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -77,6 +77,7 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 			// Redirect GET /analytics/log to the specific catalyst node, e.g. "mdw-staging-staging-catalyst-0.livepeer.monster"
 			// This is useful for the player, because then it can stick to one node while sending analytics logs
 			router.GET("/analytics/log", withLogging(withCORS(geoHandlers.RedirectConstPathHandler())))
+			router.HEAD("/analytics/log", withLogging(withCORS(geoHandlers.RedirectConstPathHandler())))
 		}
 	}
 

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -128,7 +128,7 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 	}
 }
 
-// RedirectConstPathHandler redirects const path into the self catalyst node if it was not already redirected.
+// RedirectConstPathHandler redirects const path into the self catalyst node if it was not yet redirected.
 func (c *GeolocationHandlersCollection) RedirectConstPathHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		if r.Host != c.Config.NodeName {

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -128,12 +128,14 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 	}
 }
 
-// RedirectConstPathHandler redirects const path into the self catalyst node
+// RedirectConstPathHandler redirects const path into the self catalyst node if it was not already redirected.
 func (c *GeolocationHandlersCollection) RedirectConstPathHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
-		rURL := fmt.Sprintf("%s://%s%s", protocol(r), c.Config.NodeName, r.URL.Path)
-		glog.V(6).Infof("generated redirect url=%s", rURL)
-		http.Redirect(w, r, rURL, http.StatusTemporaryRedirect)
+		if r.Host != c.Config.NodeName {
+			rURL := fmt.Sprintf("%s://%s:8989%s", protocol(r), c.Config.NodeName, r.URL.Path)
+			glog.V(6).Infof("generated redirect url=%s", rURL)
+			http.Redirect(w, r, rURL, http.StatusTemporaryRedirect)
+		}
 	}
 }
 

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -132,7 +132,7 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 func (c *GeolocationHandlersCollection) RedirectConstPathHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, params httprouter.Params) {
 		if r.Host != c.Config.NodeName {
-			rURL := fmt.Sprintf("%s://%s:8989%s", protocol(r), c.Config.NodeName, r.URL.Path)
+			rURL := fmt.Sprintf("%s://%s%s", protocol(r), c.Config.NodeName, r.URL.Path)
 			glog.V(6).Infof("generated redirect url=%s", rURL)
 			http.Redirect(w, r, rURL, http.StatusTemporaryRedirect)
 		}

--- a/middleware/cors.go
+++ b/middleware/cors.go
@@ -18,6 +18,7 @@ func AllowCORS() func(httprouter.Handle) httprouter.Handle {
 			w.Header().Set("Access-Control-Allow-Credentials", "true")
 			// Safari doesn't allow a wildcard for this so we just list them all
 			w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE")
+			w.Header().Set("Access-Control-Expose-Headers", "Location")
 
 			// If this is a preflight request, we don't need to call the next handler
 			if r.Method == "OPTIONS" {


### PR DESCRIPTION
3rd approach to fix redirects to the `/analytics/log` endpoint 🙈 

Changes:
- Redirect `/analytics/log` only if the `Location` header host is different than the host of the given node (prevents infinite redirect loop)
- Add redirects also for HEAD requests
- Add `Access-Control-Expose-Headers: Location` CORS headers

fix https://linear.app/livepeer/issue/ENG-1712/fix-redirects