### PR TITLE
Add lock to stream pull to prevent multiple nodes starting pulling for the same stream

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.18
+	github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0
+	github.com/livepeer/go-api-client v0.4.19
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -453,6 +453,10 @@ github.com/livepeer/go-api-client v0.4.18 h1:grDZK6oMBm/6N9ZqsAk4ae2ohGDVzRPd2U1
 github.com/livepeer/go-api-client v0.4.18/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0 h1:qJAVOO2lzdRSuL4GBgvpvSCXA/OUq1yOxpwZ9Nv/Xis=
 github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d h1:DeO2VY8L2trThto7tc5KyiSjq+rTyLTnEz8je73kv6E=
+github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19 h1:9YBSdYlYhCZdap08mIvptOR9B3Gf46AQOrWObJhvlkA=
+github.com/livepeer/go-api-client v0.4.19/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,8 @@ github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad h1:eSqYA
 github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.18 h1:grDZK6oMBm/6N9ZqsAk4ae2ohGDVzRPd2U12DrTRv2s=
 github.com/livepeer/go-api-client v0.4.18/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0 h1:qJAVOO2lzdRSuL4GBgvpvSCXA/OUq1yOxpwZ9Nv/Xis=
+github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -223,7 +223,7 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 	}
 
 	if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout); err != nil {
-		return "", fmt.Errorf("failed to lock pull, err=%v", err)
+		return "", errLockPull
 	}
 
 	if len(stream.Pull.Headers) == 0 {

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -175,7 +175,7 @@ func (c *GeolocationHandlersCollection) HandleStreamSource(ctx context.Context, 
 			glog.Infof("replying to Mist STREAM_SOURCE with stream pull request=%s response=%s", payload.StreamName, pullURL)
 			return pullURL, nil
 		}
-		// another Mist node is currently pulling the stream, sleep and retry
+		glog.Warningf("another node is currently pulling the stream, waiting %v and retrying", streamSourceRetryInterval)
 		time.Sleep(streamSourceRetryInterval)
 	}
 	return "push://", nil

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -167,7 +167,7 @@ func (c *GeolocationHandlersCollection) HandleStreamSource(ctx context.Context, 
 		}
 
 		glog.Errorf("error querying mist for STREAM_SOURCE: %s", err)
-		pullURL, err := c.getStreamPull(playbackID(payload.StreamName))
+		pullURL, err := c.getStreamPull(playbackIdFor(payload.StreamName))
 		if err != nil && !errors.Is(err, errLockPull) {
 			glog.Errorf("getStreamPull failed for %s: %s", payload.StreamName, err)
 			return "push://", nil
@@ -181,7 +181,7 @@ func (c *GeolocationHandlersCollection) HandleStreamSource(ctx context.Context, 
 	return "push://", nil
 }
 
-func playbackID(streamName string) string {
+func playbackIdFor(streamName string) string {
 	res := streamName
 	parts := strings.Split(res, "+")
 	if len(parts) == 2 {

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	streamSourceRetries       = 10
-	streamSourceRetryInterval = 15 * time.Second
+	streamSourceRetryInterval = 3 * time.Second
 	lockPullLeaseTimeout      = 3 * time.Minute
 )
 

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	streamSourceRetries       = 10
+	streamSourceRetries       = 20
 	streamSourceRetryInterval = 3 * time.Second
 	lockPullLeaseTimeout      = 3 * time.Minute
 )


### PR DESCRIPTION
Currently, when multiple playbacks are started for the same stream, different catalyst nodes start to pull the stream separately which results in a number of issues (like multiple same sessions created for the same stream, broadcaster fails because it's confused by the same `playbackId`/`manifestId`).

To solve it, Studio acts like a distributed lock with the lease timeout. In result what happens is that when the playback is started concurrently, then one of them will fail and need to retry until the stream is replicated between Mist nodes.

Note that we could consider some other distributed lock mechanism than Studio DB, e.g., we can consider replacing Serf with some other distributed in-memory DB which would act as a service discovery, distributed cache, etc. Some options are Redis, Hazelcast, Consul. 

Related PRs:
- https://github.com/livepeer/go-api-client/pull/61
- https://github.com/livepeer/studio/pull/2108

fix https://linear.app/livepeer/issue/PS-407/duplicate-streams