### PR TITLE
Refactor thumbs to avoid storage egress

### DIFF
--- a/handlers/ffmpeg/ffmpeg.go
+++ b/handlers/ffmpeg/ffmpeg.go
@@ -85,13 +85,14 @@ func (h *HandlersCollection) NewFile() httprouter.Handle {
 				return
 			}
 
-			if job.ThumbnailsTargetURL != nil {
-				go func() {
-					if err := thumbnails.GenerateThumb(filename, content, job.ThumbnailsTargetURL); err != nil {
-						log.LogError(job.RequestID, "generate thumb failed", err, "in", path.Join(targetURLBase, filename), "out", job.ThumbnailsTargetURL)
-					}
-				}()
-			}
+			go func() {
+				if job.ThumbnailsTargetURL == nil {
+					return
+				}
+				if err := thumbnails.GenerateThumb(filename, content, job.ThumbnailsTargetURL); err != nil {
+					log.LogError(job.RequestID, "generate thumb failed", err, "in", path.Join(targetURLBase, filename), "out", job.ThumbnailsTargetURL)
+				}
+			}()
 		}
 
 		if err := backoff.Retry(func() error {

--- a/handlers/ffmpeg/ffmpeg.go
+++ b/handlers/ffmpeg/ffmpeg.go
@@ -15,6 +15,7 @@ import (
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 	"github.com/livepeer/catalyst-api/pipeline"
+	"github.com/livepeer/catalyst-api/thumbnails"
 )
 
 type HandlersCollection struct {
@@ -43,6 +44,12 @@ func (h *HandlersCollection) NewFile() httprouter.Handle {
 			err     error
 		)
 		reg := regexp.MustCompile(`[^/]+.m3u8$`)
+		// job.SegmentingTargetURL comes in the format the Mist wants, looking like:
+		//   protocol://abc@123:s3.com/a/b/c/<something>.m3u8
+		// but since this endpoint receives both .ts segments and m3u8 updates, we strip off the filename
+		// and pass the one ffmpeg gives us to UploadToOSURL instead
+		targetURLBase := reg.ReplaceAllString(job.SegmentingTargetURL, "")
+
 		if reg.MatchString(filename) {
 			// ensure that playlist type in the manifest is set to vod
 			buf := bytes.Buffer{}
@@ -77,12 +84,15 @@ func (h *HandlersCollection) NewFile() httprouter.Handle {
 				errors.WriteHTTPInternalServerError(w, "Error reading body", err)
 				return
 			}
+
+			if job.ThumbnailsTargetURL != nil {
+				go func() {
+					if err := thumbnails.GenerateThumb(filename, content, job.ThumbnailsTargetURL); err != nil {
+						log.LogError(job.RequestID, "generate thumb failed", err, "in", path.Join(targetURLBase, filename), "out", job.ThumbnailsTargetURL)
+					}
+				}()
+			}
 		}
-		// job.SegmentingTargetURL comes in the format the Mist wants, looking like:
-		//   protocol://abc@123:s3.com/a/b/c/<something>.m3u8
-		// but since this endpoint receives both .ts segments and m3u8 updates, we strip off the filename
-		// and pass the one ffmpeg gives us to UploadToOSURL instead
-		targetURLBase := reg.ReplaceAllString(job.SegmentingTargetURL, "")
 
 		if err := backoff.Retry(func() error {
 			err := clients.UploadToOSURL(targetURLBase, filename, bytes.NewReader(content), config.SEGMENT_WRITE_TIMEOUT)

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -71,6 +71,16 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 		}
 	} else {
 		job.SegmentingTargetURL = job.SourceFile
+
+		go func() {
+			if job.ThumbnailsTargetURL == nil {
+				return
+			}
+			err := thumbnails.GenerateThumbsFromManifest(job.RequestID, job.SegmentingTargetURL, job.ThumbnailsTargetURL)
+			if err != nil {
+				log.LogError(job.RequestID, "generate thumbs failed", err, "in", job.SegmentingTargetURL, "out", job.ThumbnailsTargetURL)
+			}
+		}()
 	}
 	job.SegmentingDone = time.Now()
 	if job.HlsTargetURL != nil {

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -78,18 +78,6 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 	}
 	job.ReportProgress(clients.TranscodeStatusPreparingCompleted, 1)
 
-	if job.ThumbnailsTargetURL != nil {
-		go func() {
-			log.Log(job.RequestID, "generating thumbs VTT")
-			err := thumbnails.GenerateThumbs(job.RequestID, job.SegmentingTargetURL, job.ThumbnailsTargetURL)
-			if err != nil {
-				log.LogError(job.RequestID, "generate thumbs failed", err, "in", job.SegmentingTargetURL, "out", job.ThumbnailsTargetURL)
-			} else {
-				log.Log(job.RequestID, "generate thumbs succeeded", "in", job.SegmentingTargetURL, "out", job.ThumbnailsTargetURL)
-			}
-		}()
-	}
-
 	// Transcode Beginning
 	log.Log(job.RequestID, "Beginning transcoding via FFMPEG/Livepeer pipeline")
 
@@ -168,7 +156,7 @@ func (f *ffmpeg) HandleStartUploadJob(job *JobInfo) (*HandlerOutput, error) {
 
 	// wait for thumbs background process
 	if job.ThumbnailsTargetURL != nil {
-		err := thumbnails.WaitForThumbs(job.RequestID, job.ThumbnailsTargetURL)
+		err := thumbnails.GenerateThumbsVTT(job.RequestID, job.SegmentingTargetURL, job.ThumbnailsTargetURL)
 		if err != nil {
 			log.LogError(job.RequestID, "waiting for thumbs failed", err, "out", job.ThumbnailsTargetURL)
 		} else {

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -87,8 +87,10 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 			return err
 		}
 	}
-
-	err = clients.UploadToOSURLFields(outputLocation.String(), vttFilename, builder, time.Minute, &drivers.FileProperties{ContentType: "text/vtt"})
+	vttContent := builder.Bytes()
+	err = backoff.Retry(func() error {
+		return clients.UploadToOSURLFields(outputLocation.String(), vttFilename, bytes.NewReader(vttContent), time.Minute, &drivers.FileProperties{ContentType: "text/vtt"})
+	}, clients.UploadRetryBackoff())
 	if err != nil {
 		return fmt.Errorf("failed to upload vtt: %w", err)
 	}

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -77,7 +77,7 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 		if err != nil {
 			return err
 		}
-		// check file exists on storage
+		// check thumbnail file exists on storage
 		err = backoff.Retry(func() error {
 			_, err := clients.GetFile(context.Background(), requestID, outputLocation.JoinPath(filename).String(), nil)
 			return err
@@ -94,6 +94,8 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 			return err
 		}
 	}
+
+	// upload VTT file
 	vttContent := builder.Bytes()
 	err = backoff.Retry(func() error {
 		return clients.UploadToOSURLFields(outputLocation.String(), vttFilename, bytes.NewReader(vttContent), time.Minute, &drivers.FileProperties{ContentType: "text/vtt"})
@@ -169,6 +171,7 @@ func GenerateThumbsFromManifest(requestID, input string, output *url.URL) error 
 				rc  io.ReadCloser
 				err error
 			)
+			// save the segment to memory
 			err = backoff.Retry(func() error {
 				rc, err = clients.GetFile(context.Background(), requestID, segURL.String(), nil)
 				return err
@@ -181,6 +184,7 @@ func GenerateThumbsFromManifest(requestID, input string, output *url.URL) error 
 				return err
 			}
 
+			// generate thumbnail for the segment
 			return GenerateThumb(path.Base(segment.URI), bs, output)
 		})
 	}

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -73,7 +73,7 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 	var currentTime time.Time
 	// loop through each segment, generate a vtt entry for it
 	for _, segment := range mediaPlaylist.GetAllSegments() {
-		filename, err := thumbFilename(segment.URI)
+		filename, err := thumbFilename(path.Base(segment.URI))
 		if err != nil {
 			return err
 		}
@@ -181,7 +181,7 @@ func GenerateThumbsFromManifest(requestID, input string, output *url.URL) error 
 				return err
 			}
 
-			return GenerateThumb(segment.URI, bs, output)
+			return GenerateThumb(path.Base(segment.URI), bs, output)
 		})
 	}
 	return uploadGroup.Wait()

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -8,6 +8,9 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
@@ -15,20 +18,21 @@ import (
 	"github.com/livepeer/catalyst-api/clients"
 	"github.com/livepeer/go-tools/drivers"
 	ffmpeg "github.com/u2takey/ffmpeg-go"
-	"golang.org/x/sync/errgroup"
 )
 
 const resolution = "854:480"
 const vttFilename = "thumbnails.vtt"
 const outputDir = "thumbnails"
 
-func GenerateThumbs(requestID, input string, output *url.URL) error {
-	inputURL, err := url.Parse(input)
-	if err != nil {
-		return err
-	}
+// Wait a maximum of 5 mins for thumbnails to finish
+var thumbWaitBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
+
+func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 	// download and parse the manifest
-	var rc io.ReadCloser
+	var (
+		rc  io.ReadCloser
+		err error
+	)
 	err = backoff.Retry(func() error {
 		rc, err = clients.GetFile(context.Background(), requestID, input, nil)
 		return err
@@ -49,14 +53,8 @@ func GenerateThumbs(requestID, input string, output *url.URL) error {
 		return fmt.Errorf("failed to parse playlist as MediaPlaylist")
 	}
 
-	tempDir, err := os.MkdirTemp(os.TempDir(), "thumbs-*")
-	if err != nil {
-		return fmt.Errorf("failed to make temp dir: %w", err)
-	}
-	defer os.RemoveAll(tempDir)
-
 	const layout = "15:04:05.000"
-	outputLocation := output.JoinPath(outputDir).String()
+	outputLocation := output.JoinPath(outputDir)
 	builder := &bytes.Buffer{}
 	_, err = builder.WriteString("WEBVTT\n")
 	if err != nil {
@@ -65,72 +63,89 @@ func GenerateThumbs(requestID, input string, output *url.URL) error {
 	var (
 		currentTime time.Time
 		segments    = mediaPlaylist.GetAllSegments()
-		thumbOuts   = make([]string, len(segments))
 	)
-	// loop through each segment, generate a thumbnail image and upload it to storage
-	for i, segment := range segments {
-		thumbOut, err := processSegment(inputURL, segment, tempDir, outputLocation)
+	// loop through each segment, generate a vtt entry for it
+	for _, segment := range segments {
+		filename, err := thumbFilename(segment.URI)
 		if err != nil {
 			return err
 		}
-		thumbOuts[i] = thumbOut
+		// check file exists on storage
+		err = backoff.Retry(func() error {
+			_, err := clients.GetFile(context.Background(), requestID, outputLocation.JoinPath(filename).String(), nil)
+			return err
+		}, thumbWaitBackoff)
+		if err != nil {
+			return fmt.Errorf("failed to find thumb %s: %w", filename, err)
+		}
 
 		start := currentTime.Format(layout)
 		currentTime = currentTime.Add(time.Duration(segment.Duration) * time.Second)
 		end := currentTime.Format(layout)
-		_, err = builder.WriteString(fmt.Sprintf("%s --> %s\n%s\n\n", start, end, path.Base(thumbOut)))
+		_, err = builder.WriteString(fmt.Sprintf("%s --> %s\n%s\n\n", start, end, filename))
 		if err != nil {
 			return err
 		}
 	}
 
-	// parallelise the thumb uploads
-	uploadGroup, _ := errgroup.WithContext(context.Background())
-	uploadGroup.SetLimit(5)
-	for _, thumbOut := range thumbOuts {
-		thumbOut := thumbOut
-		uploadGroup.Go(func() error {
-			return backoff.Retry(func() error {
-				// upload thumbnail to storage
-				fileReader, err := os.Open(thumbOut)
-				if err != nil {
-					return err
-				}
-				defer fileReader.Close()
-				err = clients.UploadToOSURL(outputLocation, path.Base(thumbOut), fileReader, 2*time.Minute)
-				if err != nil {
-					return fmt.Errorf("failed to upload thumbnail %s: %w", thumbOut, err)
-				}
-				return nil
-			}, clients.UploadRetryBackoff())
-		})
-	}
-	err = uploadGroup.Wait()
-	if err != nil {
-		return err
-	}
-
-	err = clients.UploadToOSURLFields(outputLocation, vttFilename, builder, time.Minute, &drivers.FileProperties{ContentType: "text/vtt"})
+	err = clients.UploadToOSURLFields(outputLocation.String(), vttFilename, builder, time.Minute, &drivers.FileProperties{ContentType: "text/vtt"})
 	if err != nil {
 		return fmt.Errorf("failed to upload vtt: %w", err)
 	}
 	return nil
 }
 
-func processSegment(inputURL *url.URL, segment *m3u8.MediaSegment, tempDir string, outputLocation string) (string, error) {
-	segURL := inputURL.JoinPath("..", segment.URI)
-	signed, err := clients.SignURL(segURL)
+func GenerateThumb(segmentURI string, input []byte, output *url.URL) error {
+	tempDir, err := os.MkdirTemp(os.TempDir(), "thumbs-*")
 	if err != nil {
-		return "", fmt.Errorf("error signing segment url %s: %w", segURL, err)
+		return fmt.Errorf("failed to make temp dir: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+	outputLocation := output.JoinPath(outputDir)
+
+	inFilename := filepath.Join(tempDir, segmentURI)
+	if err := os.WriteFile(inFilename, input, 0644); err != nil {
+		return err
 	}
 
+	filename, err := thumbFilename(segmentURI)
+	if err != nil {
+		return err
+	}
+
+	thumbOut := path.Join(tempDir, filename)
+	if err := processSegment(inFilename, thumbOut); err != nil {
+		return err
+	}
+
+	err = backoff.Retry(func() error {
+		// upload thumbnail to storage
+		fileReader, err := os.Open(thumbOut)
+		if err != nil {
+			return err
+		}
+		defer fileReader.Close()
+		err = clients.UploadToOSURL(outputLocation.String(), path.Base(thumbOut), fileReader, 2*time.Minute)
+		if err != nil {
+			return fmt.Errorf("failed to upload thumbnail %s: %w", thumbOut, err)
+		}
+		return nil
+	}, clients.UploadRetryBackoff())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func processSegment(input string, thumbOut string) error {
 	// generate thumbnail
 	var ffmpegErr bytes.Buffer
-	thumbOut := path.Join(tempDir, fmt.Sprintf("keyframes_%d.jpg", segment.SeqId))
-	err = backoff.Retry(func() error {
+
+	err := backoff.Retry(func() error {
 		ffmpegErr = bytes.Buffer{}
 		return ffmpeg.
-			Input(signed, ffmpeg.KwArgs{"skip_frame": "nokey"}). // only extract key frames
+			Input(input, ffmpeg.KwArgs{"skip_frame": "nokey"}). // only extract key frames
 			Output(
 				thumbOut,
 				ffmpeg.KwArgs{
@@ -142,19 +157,20 @@ func processSegment(inputURL *url.URL, segment *m3u8.MediaSegment, tempDir strin
 			).OverWriteOutput().WithErrorOutput(&ffmpegErr).Run()
 	}, clients.DownloadRetryBackoff())
 	if err != nil {
-		return "", fmt.Errorf("error running ffmpeg for thumbnails %s [%s]: %w", segURL, ffmpegErr.String(), err)
+		return fmt.Errorf("error running ffmpeg for thumbnails %s [%s]: %w", input, ffmpegErr.String(), err)
 	}
 
-	return thumbOut, nil
+	return nil
 }
 
-// Wait a maximum of 5 mins for thumbnails to finish
-var vttBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
+var segmentPrefix = "index"
 
-func WaitForThumbs(requestID string, output *url.URL) error {
-	vtt := output.JoinPath(outputDir, vttFilename).String()
-	return backoff.Retry(func() error {
-		_, err := clients.GetFile(context.Background(), requestID, vtt, nil)
-		return err
-	}, vttBackoff)
+func thumbFilename(segmentURI string) (string, error) {
+	// segmentURI will be index%d.ts
+	index := strings.TrimSuffix(strings.TrimPrefix(segmentURI, segmentPrefix), ".ts")
+	i, err := strconv.ParseInt(index, 10, 32)
+	if err != nil {
+		return "", fmt.Errorf("thumbFilename failed for %s: %w", segmentURI, err)
+	}
+	return fmt.Sprintf("keyframes_%d.jpg", i), nil
 }

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -20,19 +20,42 @@ func generateThumb(t *testing.T, filename string, out *url.URL) {
 }
 
 func TestGenerateThumbs(t *testing.T) {
+	segmentPrefix = "seg-"
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+
+	// Test the non-recording flow where GenerateThumb is called by handlers/ffmpeg/ffmpeg.go
 	outDir, err := os.MkdirTemp(os.TempDir(), "thumbs*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
 	out, err := url.Parse(outDir)
 	require.NoError(t, err)
 
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-
-	segmentPrefix = "seg-"
 	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-0.ts"), out)
 	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-1.ts"), out)
 	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-2.ts"), out)
+
+	testGenerateThumbsRun(t, outDir)
+
+	// Test the recording flow
+	outDir, err = os.MkdirTemp(os.TempDir(), "thumbs*")
+	require.NoError(t, err)
+	defer os.RemoveAll(outDir)
+	out, err = url.Parse(outDir)
+	require.NoError(t, err)
+
+	err = GenerateThumbsFromManifest("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
+	require.NoError(t, err)
+
+	testGenerateThumbsRun(t, outDir)
+}
+
+func testGenerateThumbsRun(t *testing.T, outDir string) {
+	out, err := url.Parse(outDir)
+	require.NoError(t, err)
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
 
 	err = GenerateThumbsVTT("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
 	require.NoError(t, err)

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -12,16 +12,29 @@ import (
 	"gopkg.in/vansante/go-ffprobe.v2"
 )
 
+func generateThumb(t *testing.T, filename string, out *url.URL) {
+	bs, err := os.ReadFile(filename)
+	require.NoError(t, err)
+	err = GenerateThumb(path.Base(filename), bs, out)
+	require.NoError(t, err)
+}
+
 func TestGenerateThumbs(t *testing.T) {
 	outDir, err := os.MkdirTemp(os.TempDir(), "thumbs*")
 	require.NoError(t, err)
 	defer os.RemoveAll(outDir)
-
 	out, err := url.Parse(outDir)
 	require.NoError(t, err)
+
 	wd, err := os.Getwd()
 	require.NoError(t, err)
-	err = GenerateThumbs("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
+
+	segmentPrefix = "seg-"
+	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-0.ts"), out)
+	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-1.ts"), out)
+	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-2.ts"), out)
+
+	err = GenerateThumbsVTT("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
 	require.NoError(t, err)
 
 	expectedVtt := `WEBVTT


### PR DESCRIPTION
Tested on staging ✅ 

Todo in future PR: disable thumbs for long recordings/inputs like we do for mp4 generation