### PR TITLE
Lock multiple stream pulls only from different Mist hosts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.18
+	github.com/livepeer/go-api-client v0.4.19
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.19
+	github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.19
+	github.com/livepeer/go-api-client v0.4.18
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/hashicorp/serf v0.10.1
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
-	github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c
+	github.com/livepeer/go-api-client v0.4.20
 	github.com/livepeer/go-tools v0.3.6
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -451,12 +451,6 @@ github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad h1:eSqYA
 github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.18 h1:grDZK6oMBm/6N9ZqsAk4ae2ohGDVzRPd2U12DrTRv2s=
 github.com/livepeer/go-api-client v0.4.18/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0 h1:qJAVOO2lzdRSuL4GBgvpvSCXA/OUq1yOxpwZ9Nv/Xis=
-github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d h1:DeO2VY8L2trThto7tc5KyiSjq+rTyLTnEz8je73kv6E=
-github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-api-client v0.4.19 h1:9YBSdYlYhCZdap08mIvptOR9B3Gf46AQOrWObJhvlkA=
-github.com/livepeer/go-api-client v0.4.19/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/go.sum
+++ b/go.sum
@@ -451,6 +451,12 @@ github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad h1:eSqYA
 github.com/livepeer/go-api-client v0.4.18-0.20240305122931-8f6d8c6543ad/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.18 h1:grDZK6oMBm/6N9ZqsAk4ae2ohGDVzRPd2U12DrTRv2s=
 github.com/livepeer/go-api-client v0.4.18/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0 h1:qJAVOO2lzdRSuL4GBgvpvSCXA/OUq1yOxpwZ9Nv/Xis=
+github.com/livepeer/go-api-client v0.4.19-0.20240321152123-03b5d097f6f0/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d h1:DeO2VY8L2trThto7tc5KyiSjq+rTyLTnEz8je73kv6E=
+github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.19 h1:9YBSdYlYhCZdap08mIvptOR9B3Gf46AQOrWObJhvlkA=
+github.com/livepeer/go-api-client v0.4.19/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/go.sum
+++ b/go.sum
@@ -459,6 +459,8 @@ github.com/livepeer/go-api-client v0.4.19 h1:9YBSdYlYhCZdap08mIvptOR9B3Gf46AQOrW
 github.com/livepeer/go-api-client v0.4.19/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c h1:VxGMyEwxFlosz7Y8zBSJZYqgniCsNfWpRN8Vz2Snsn4=
 github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.20 h1:1iqAcyg2X0ETwqF0nc45O2Qsr5wXkpfmWm/BV1YWdvM=
+github.com/livepeer/go-api-client v0.4.20/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/go.sum
+++ b/go.sum
@@ -457,6 +457,8 @@ github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d h1:DeO2V
 github.com/livepeer/go-api-client v0.4.19-0.20240325114751-e7cb002ff24d/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-api-client v0.4.19 h1:9YBSdYlYhCZdap08mIvptOR9B3Gf46AQOrWObJhvlkA=
 github.com/livepeer/go-api-client v0.4.19/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
+github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c h1:VxGMyEwxFlosz7Y8zBSJZYqgniCsNfWpRN8Vz2Snsn4=
+github.com/livepeer/go-api-client v0.4.20-0.20240328091009-e43267fbc91c/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
 github.com/livepeer/go-tools v0.3.6 h1:LhRnoVVGFCtfBh6WyKdwJ2bPD/h5gaRvsAszmCqKt1Q=
 github.com/livepeer/go-tools v0.3.6/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -231,8 +231,12 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 		return "", nil
 	}
 
-	if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout, c.Config.NodeName); err != nil {
-		return "", errLockPull
+	// Feature flag to lock only for test accounts
+	if isTestAccount(stream) {
+		glog.Infof("LockPull for stream %v", playbackID)
+		if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout, c.Config.NodeName); err != nil {
+			return "", errLockPull
+		}
 	}
 
 	if len(stream.Pull.Headers) == 0 {
@@ -355,4 +359,12 @@ func isValidGPSCoord(lat, lon string) bool {
 		return false
 	}
 	return latF >= -90 && latF <= 90 && lonF >= -180 && lonF <= 180
+}
+
+// Feature flag to check if the duplicate stream fix works
+// 67281_11889_11889, 67281_11879_11879, 67281_11889_11889 are test streams, so we can test it in Trovo Test website
+func isTestAccount(stream *api.Stream) bool {
+	return strings.Contains(stream.Pull.Source, "67281_11878_11878") ||
+		strings.Contains(stream.Pull.Source, "67281_11879_11879") ||
+		strings.Contains(stream.Pull.Source, "67281_11889_11889")
 }

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -9,7 +9,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
@@ -20,8 +19,6 @@ import (
 	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/livepeer/go-api-client"
 )
-
-const lockPullLeaseTimeout = 3 * time.Minute
 
 type GeolocationHandlersCollection struct {
 	Balancer balancer.Balancer
@@ -201,17 +198,6 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 
 	if stream.Pull == nil {
 		return "", nil
-	}
-
-	// Feature flag to check if the duplicate stream fix works
-	// 67281_11889_11889 is the test stream, so we can test it in Trovo Test website
-	if strings.Contains(stream.Pull.Source, "67281_11878_11878") ||
-		strings.Contains(stream.Pull.Source, "67281_11879_11879") ||
-		strings.Contains(stream.Pull.Source, "67281_11889_11889") {
-		glog.Infof("LockPull for stream %v", playbackID)
-		if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout); err != nil {
-			return "", fmt.Errorf("failed to lock pull, err=%v", err)
-		}
 	}
 
 	if len(stream.Pull.Headers) == 0 {

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/golang/glog"
 	"github.com/julienschmidt/httprouter"
@@ -19,6 +20,8 @@ import (
 	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/livepeer/go-api-client"
 )
+
+const lockPullLeaseTimeout = 3 * time.Minute
 
 type GeolocationHandlersCollection struct {
 	Balancer balancer.Balancer
@@ -198,6 +201,17 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 
 	if stream.Pull == nil {
 		return "", nil
+	}
+
+	// Feature flag to check if the duplicate stream fix works
+	// 67281_11889_11889 is the test stream, so we can test it in Trovo Test website
+	if strings.Contains(stream.Pull.Source, "67281_11878_11878") ||
+		strings.Contains(stream.Pull.Source, "67281_11879_11879") ||
+		strings.Contains(stream.Pull.Source, "67281_11889_11889") {
+		glog.Infof("LockPull for stream %v", playbackID)
+		if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout); err != nil {
+			return "", fmt.Errorf("failed to lock pull, err=%v", err)
+		}
 	}
 
 	if len(stream.Pull.Headers) == 0 {

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -231,7 +231,7 @@ func (c *GeolocationHandlersCollection) getStreamPull(playbackID string) (string
 		return "", nil
 	}
 
-	if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout); err != nil {
+	if err := c.Lapi.LockPull(stream.ID, lockPullLeaseTimeout, c.Config.NodeName); err != nil {
 		return "", errLockPull
 	}
 


### PR DESCRIPTION
It's the same PR that caused the prod failure https://github.com/livepeer/catalyst-api/commit/98aa62799d4391451b3746d7c2f44d20288569df with the following changes:
- Do not lock for the same host (re-entrant lock), this part is already covered by Mist (which does not allow 2 stream pulls on the same node)
- Add feature flag for our test streams => to not break prod again 🙃 