### PR TITLE
Add healthcheck endpoint

### DIFF
--- a/api/http.go
+++ b/api/http.go
@@ -67,6 +67,8 @@ func NewCatalystAPIRouter(cli config.Cli, vodEngine *pipeline.Coordinator, bal b
 	}
 
 	router.GET("/ok", withLogging(catalystApiHandlers.Ok()))
+	router.GET("/healthcheck", withLogging(catalystApiHandlers.Healthcheck()))
+
 	if cli.EnableAnalytics == "true" || cli.EnableAnalytics == "enabled" {
 		logProcessor, err := analytics.NewLogProcessor(cli.KafkaBootstrapServers, cli.KafkaUser, cli.KafkaPassword, cli.AnalyticsKafkaTopic)
 		if err != nil {

--- a/handlers/healthcheck.go
+++ b/handlers/healthcheck.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/log"
+)
+
+type HealthcheckResponse struct {
+	Status string `json:"status"`
+}
+
+// Returns an HTTP 200 if Catalyst API and related services are running
+// Used by the load balancer to determine whether to route to a node
+func (d *CatalystAPIHandlersCollection) Healthcheck() httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		responseObject := HealthcheckResponse{
+			Status: "healthy",
+		}
+
+		b, err := json.Marshal(responseObject)
+		if err != nil {
+			log.LogNoRequestID("Failed to marshal healthcheck status: " + err.Error())
+			b = []byte(`{"status": "marshalling status failed"}`)
+		}
+
+		if _, err := io.WriteString(w, string(b)); err != nil {
+			log.LogNoRequestID("Failed to write HTTP response for " + req.URL.RawPath)
+		}
+	}
+}

--- a/handlers/healthcheck_test.go
+++ b/handlers/healthcheck_test.go
@@ -1,0 +1,19 @@
+package handlers
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestItReturnsA200WithSuccessBody(t *testing.T) {
+	handlers := CatalystAPIHandlersCollection{}
+	healthcheckHandler := handlers.Healthcheck()
+
+	resp := httptest.NewRecorder()
+	healthcheckHandler(resp, nil, nil)
+
+	require.Equal(t, 200, resp.Code)
+	require.Equal(t, resp.Body.String(), `{"status":"healthy"}`)
+}

--- a/test/cucumber_test.go
+++ b/test/cucumber_test.go
@@ -71,6 +71,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 	ctx.Step(`^my "(failed|successful)" (vod|playback) request metrics get recorded$`, stepContext.CheckRecordedMetrics)
 	ctx.Step(`^a "([^"]*)" metric is recorded with a value of "([^"]*)"$`, stepContext.CheckMetricEqual)
 	ctx.Step(`^the body matches file "([^"]*)"$`, stepContext.CheckHTTPResponseBodyFromFile)
+	ctx.Step(`^the body matches '([^']*)'$`, stepContext.CheckHTTPResponseBody)
 	ctx.Step(`^the gate API will (allow|deny) playback$`, stepContext.SetGateAPIResponse)
 	ctx.Step(`^the gate API will be called (\d+) times$`, stepContext.CheckGateAPICallCount)
 	ctx.Step(`^the headers match$`, stepContext.CheckHTTPHeaders)

--- a/test/features/healthcheck.feature
+++ b/test/features/healthcheck.feature
@@ -1,0 +1,10 @@
+Feature: Playback
+
+  Background: The app is running
+    Given the VOD API is running
+
+  Scenario: Healthcheck is successful
+    When I query the "/healthcheck" endpoint
+    And receive a response within "3" seconds
+    Then I get an HTTP response with code "200"
+    And the body matches '{"status":"healthy"}'


### PR DESCRIPTION
The plan is for this to be available to load balancers to determine whether to route traffic to a node. The current for is simple, but can be extended to check other services on the box, third-party reachability etc.