### PR TITLE
mist_balancer: start MistUtilLoad with debug level 4 to print scores

### DIFF
--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -243,7 +243,7 @@ func (b *MistBalancer) formatNodeAddress(server string) string {
 }
 
 func (b *MistBalancer) execBalancer(ctx context.Context, balancerArgs []string) error {
-	args := append(balancerArgs, "-p", fmt.Sprintf("%d", b.config.MistUtilLoadPort))
+	args := append(balancerArgs, "-p", fmt.Sprintf("%d", b.config.MistUtilLoadPort), "-g", "4")
 	glog.Infof("Running MistUtilLoad with %v", args)
 	b.cmd = exec.CommandContext(ctx, "MistUtilLoad", args...)
 


### PR DESCRIPTION
Prints scores like this: 
```
[2024-04-13 06:05:18] MistUtilLoad (3661948) INFO: Balancing stream video d44ciei8jtwva8
[2024-04-13 06:05:18] MistUtilLoad (3661948) INFO: Winner: fin-prod-catalyst-0.lp-playback.studio scores 2654
```
It might be helpful in debugging routing. 