### PR TITLE
access-control: allow redirects without caching

### DIFF
--- a/handlers/accesscontrol/access-control_test.go
+++ b/handlers/accesscontrol/access-control_test.go
@@ -103,6 +103,24 @@ func TestDeniedAccessInvalidToken(t *testing.T) {
 	require.Equal(t, "false", result)
 }
 
+func TestAllowedRedirect(t *testing.T) {
+	payloadUserNew := misttriggers.UserNewPayload{
+		StreamName: "1bbbqz6753hcli1t",
+		URL:        nil,
+		FullURL:    "http://localhost:8080/hls/1bbbqz6753hcli1t/index.m3u8?stream=1bbbqz6753hcli1t&jwt=",
+		AccessKey:  "123",
+		JWT:        "x",
+		OriginIP:   "1.1.1.1",
+		Referer:    "",
+		Origin:     "null",
+		Host:       "fra-prod-catalyst-0",
+	}
+
+	ctx := context.Background()
+	allowed, _ := testTriggerHandler()(ctx, &payloadUserNew)
+	require.Equal(t, false, allowed)
+}
+
 func TestDeniedMissingPlaybackID(t *testing.T) {
 	token, _ := craftToken(privateKey, publicKey, "", expiration)
 	payload := []byte(fmt.Sprint(playbackID, "\n1\n2\n3\nhttp://localhost:8080/hls/", playbackID, "/index.m3u8?stream=", playbackID, "&jwt=", token, "\n5"))

--- a/handlers/misttriggers/user_new.go
+++ b/handlers/misttriggers/user_new.go
@@ -22,7 +22,7 @@ type UserNewPayload struct {
 	JWT            string
 	OriginIP       string
 	OriginalURL    string
-	Referrer       string
+	Referer        string
 	UserAgent      string
 	ForwardedProto string
 	Host           string
@@ -74,7 +74,7 @@ func (d *MistCallbackHandlersCollection) TriggerUserNew(ctx context.Context, w h
 		case "X-Forwarded-For":
 			payload.OriginIP = cookie.Value
 		case "Referer":
-			payload.Referrer = cookie.Value
+			payload.Referer = cookie.Value
 		case "User-Agent":
 			payload.UserAgent = cookie.Value
 		case "X-Forwarded-Proto":

--- a/middleware/gating.go
+++ b/middleware/gating.go
@@ -42,7 +42,7 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 		}
 
 		originIP := req.Header.Get("X-Forwarded-For")
-		refrerer := req.Header.Get("Referer")
+		referer := req.Header.Get("Referer")
 		userAgent := req.Header.Get("User-Agent")
 		forwardedProto := req.Header.Get("X-Forwarded-Proto")
 		host := req.Header.Get("Host")
@@ -53,7 +53,7 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 			AccessKey:      accessKey,
 			JWT:            jwt,
 			OriginIP:       originIP,
-			Referrer:       refrerer,
+			Referer:        referer,
 			UserAgent:      userAgent,
 			ForwardedProto: forwardedProto,
 			Host:           host,


### PR DESCRIPTION
- When `Origin` is null due to browser policy on 307 and `Referer` is empty, allow without caching and without gate calls
- Fix some mistypes in variable names on userNewPayload