### PR TITLE
add Mist load-balancing tags

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -4,6 +4,7 @@ package balancer
 
 import (
 	"context"
+
 	"github.com/livepeer/catalyst-api/balancer/catabalancer"
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/livepeer/catalyst-api/log"
@@ -122,4 +123,5 @@ type Config struct {
 	NodeName                 string
 	MistPort                 int
 	MistHost                 string
+	OwnRegion                string
 }

--- a/balancer/mist/mist_balancer_test.go
+++ b/balancer/mist/mist_balancer_test.go
@@ -180,6 +180,8 @@ func TestGetBestNode(t *testing.T) {
 	bal, mul := start(t)
 	defer mul.Close()
 
+	bal.config.OwnRegion = "fra"
+
 	mul.BalancedHosts = map[string]string{
 		"http://one.example.com:4242": "Online",
 		"http://two.example.com:4242": "Online",
@@ -251,7 +253,7 @@ func (mul *mockMistUtilLoad) Handle(t *testing.T) http.HandlerFunc {
 		}
 
 		// Default balancer implementation
-		if len(queryVals) == 0 {
+		if len(queryVals) == 0 || (len(queryVals) == 1 && queryVals.Has("tag_adjust")) {
 			for node := range mul.BalancedHosts {
 				u, err := url.Parse(node)
 				require.NoError(t, err)

--- a/handlers/geolocation/geolocation.go
+++ b/handlers/geolocation/geolocation.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"encoding/json"
+
 	"github.com/golang/glog"
 
 	"github.com/julienschmidt/httprouter"
@@ -135,6 +136,7 @@ func (c *GeolocationHandlersCollection) RedirectHandler() httprouter.Handle {
 		}
 
 		bestNode, fullPlaybackID, err := c.Balancer.GetBestNode(context.Background(), redirectPrefixes, playbackID, lat, lon, prefix)
+
 		if err != nil {
 			glog.Errorf("failed to find either origin or fallback server for playbackID=%s err=%s", playbackID, err)
 			w.WriteHeader(http.StatusBadGateway)

--- a/main.go
+++ b/main.go
@@ -285,6 +285,7 @@ func main() {
 		MistHost:                 cli.MistHost,
 		MistPort:                 cli.MistPort,
 		NodeName:                 cli.NodeName,
+		OwnRegion:                cli.OwnRegion,
 	})
 
 	bal := mistBalancer


### PR DESCRIPTION
This PR suppose to reduce [cross-region redirect number](https://livepeer.metabaseapp.com/dashboard/1849-redirects?date_filter=past10hours&ingest_or_playback=playback&user_email=daneli%40trovo.live). After first DNS routing we should mostly keep users in the same region.
[Discord](https://discord.com/channels/423160867534929930/1225093078050934864/1230302133295910912)