### PR TITLE
add own-region-tag-adjust cli parameter with 1000 as default

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -124,4 +124,5 @@ type Config struct {
 	MistPort                 int
 	MistHost                 string
 	OwnRegion                string
+	OwnRegionTagAdjust       int
 }

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -344,7 +344,7 @@ func (b *MistBalancer) MistUtilLoadBalance(ctx context.Context, stream, lat, lon
 	// add `tag_adjust={"region_name":1000}` to bump current region weight so it's more important that other params like
 	// cpu, memory, bandwidth or distance. It's meant to minimise redirects to other regions after current region is "selected"
 	// by the DNS rules.
-	str, err := b.mistUtilLoadRequest(ctx, "/", stream, lat, lon, fmt.Sprintf("?tag_adjust={\"%s\":1000}", b.config.OwnRegion))
+	str, err := b.mistUtilLoadRequest(ctx, "/", stream, lat, lon, fmt.Sprintf("?tag_adjust={\"%s\":%d}", b.config.OwnRegion, b.config.OwnRegionTagAdjust))
 	if err != nil {
 		return "", err
 	}

--- a/balancer/mist/mist_balancer_test.go
+++ b/balancer/mist/mist_balancer_test.go
@@ -26,8 +26,10 @@ func start(t *testing.T) (*MistBalancer, *mockMistUtilLoad) {
 
 	b := &MistBalancer{
 		config: &balancer.Config{
-			MistHost: u.Hostname(),
-			MistPort: port,
+			MistHost:           u.Hostname(),
+			MistPort:           port,
+			OwnRegion:          "fra",
+			OwnRegionTagAdjust: 1000,
 		},
 		cmd:      nil,
 		endpoint: mul.Server.URL,
@@ -180,8 +182,6 @@ func TestGetBestNode(t *testing.T) {
 	bal, mul := start(t)
 	defer mul.Close()
 
-	bal.config.OwnRegion = "fra"
-
 	mul.BalancedHosts = map[string]string{
 		"http://one.example.com:4242": "Online",
 		"http://two.example.com:4242": "Online",
@@ -254,6 +254,7 @@ func (mul *mockMistUtilLoad) Handle(t *testing.T) http.HandlerFunc {
 
 		// Default balancer implementation
 		if len(queryVals) == 0 || (len(queryVals) == 1 && queryVals.Has("tag_adjust")) {
+			require.Equal(t, queryVals.Get("tag_adjust"), `{"fra":1000}`)
 			for node := range mul.BalancedHosts {
 				u, err := url.Parse(node)
 				require.NoError(t, err)

--- a/config/cli.go
+++ b/config/cli.go
@@ -37,6 +37,7 @@ type Cli struct {
 	LogSysUsage               bool
 	AMQPURL                   string
 	OwnRegion                 string
+	OwnRegionTagAdjust        int
 	APIToken                  string
 	APIServer                 string
 	SourceOutput              string

--- a/main.go
+++ b/main.go
@@ -96,6 +96,7 @@ func main() {
 	fs.StringVar(&cli.APIServer, "api-server", "", "Livepeer API server to use")
 	fs.StringVar(&cli.AMQPURL, "amqp-url", "", "RabbitMQ url")
 	fs.StringVar(&cli.OwnRegion, "own-region", "", "Identifier of the region where the service is running, used for mapping external data back to current region")
+	fs.IntVar(&cli.OwnRegionTagAdjust, "own-region-tag-adjust", 1000, "Bonus weight for 'own-region' to minimise cross-region redirects done by mist load balancer (MistUtilLoad)")
 	fs.StringVar(&cli.StreamHealthHookURL, "stream-health-hook-url", "http://localhost:3004/api/stream/hook/health", "Address to POST stream health payloads to (response is ignored)")
 
 	// catalyst-node parameters
@@ -286,6 +287,7 @@ func main() {
 		MistPort:                 cli.MistPort,
 		NodeName:                 cli.NodeName,
 		OwnRegion:                cli.OwnRegion,
+		OwnRegionTagAdjust:       cli.OwnRegionTagAdjust,
 	})
 
 	bal := mistBalancer


### PR DESCRIPTION
https://linear.app/livepeer/issue/PS-515/use-tags-to-add-weight-to-chosen-node-based-on-dns-latency-routing


https://github.com/livepeer/catalyst-api/pull/1231