### PR TITLE
Save $ by not doing multi-pass encoding in fallback situation

### DIFF
--- a/clients/fixtures/mediaconvert_payloads/accelerated.txt
+++ b/clients/fixtures/mediaconvert_payloads/accelerated.txt
@@ -52,7 +52,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 1000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -81,7 +81,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 4000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -125,7 +125,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 1000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -154,7 +154,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 4000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }

--- a/clients/fixtures/mediaconvert_payloads/happy.txt
+++ b/clients/fixtures/mediaconvert_payloads/happy.txt
@@ -49,7 +49,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 1000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -78,7 +78,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 4000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -122,7 +122,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 1000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -151,7 +151,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 4000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }

--- a/clients/fixtures/mediaconvert_payloads/no-mp4.txt
+++ b/clients/fixtures/mediaconvert_payloads/no-mp4.txt
@@ -49,7 +49,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 1000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }
@@ -78,7 +78,7 @@
                   FramerateControl: "INITIALIZE_FROM_SOURCE",
                   GopSizeUnits: "AUTO",
                   MaxBitrate: 4000000,
-                  QualityTuningLevel: "MULTI_PASS_HQ",
+                  QualityTuningLevel: "SINGLE_PASS",
                   RateControlMode: "QVBR",
                   SceneChangeDetect: "TRANSITION_DETECTION"
                 }

--- a/clients/mediaconvert.go
+++ b/clients/mediaconvert.go
@@ -433,7 +433,7 @@ func output(container, name string, height, maxBitrate int64) *mediaconvert.Outp
 					MaxBitrate:         aws.Int64(maxBitrate),
 					RateControlMode:    aws.String("QVBR"),
 					SceneChangeDetect:  aws.String("TRANSITION_DETECTION"),
-					QualityTuningLevel: aws.String("MULTI_PASS_HQ"),
+					QualityTuningLevel: aws.String("SINGLE_PASS"),
 					FramerateControl:   aws.String("INITIALIZE_FROM_SOURCE"),
 				}}},
 		AudioDescriptions: []*mediaconvert.AudioDescription{


### PR DESCRIPTION
Tested on Staging by pushing an FLV and an HEVC file through