### PR TITLE
We always want thumbs index to start from zero as users are expecting this

### DIFF
--- a/handlers/ffmpeg/ffmpeg.go
+++ b/handlers/ffmpeg/ffmpeg.go
@@ -89,7 +89,7 @@ func (h *HandlersCollection) NewFile() httprouter.Handle {
 				if job.ThumbnailsTargetURL == nil {
 					return
 				}
-				if err := thumbnails.GenerateThumb(filename, content, job.ThumbnailsTargetURL); err != nil {
+				if err := thumbnails.GenerateThumb(filename, content, job.ThumbnailsTargetURL, 0); err != nil {
 					log.LogError(job.RequestID, "generate thumb failed", err, "in", path.Join(targetURLBase, filename), "out", job.ThumbnailsTargetURL)
 				}
 			}()

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -72,11 +72,11 @@ func TestGenerateThumbsOffset(t *testing.T) {
 #EXT-X-MEDIA-SEQUENCE:0
 #EXT-X-TARGETDURATION:10
 #EXTINF:10.000000,
-seg-100.ts
+clip_100.ts
 #EXTINF:10.000000,
-seg-101.ts
+clip_101.ts
 #EXTINF:10.000000,
-seg-102.ts
+clip_102.ts
 #EXT-X-ENDLIST
 `
 	err = os.WriteFile(inputFile, []byte(manifest), 0644)
@@ -85,7 +85,7 @@ seg-102.ts
 	for i := 0; i < 3; i++ {
 		b, err := os.ReadFile(path.Join(wd, "..", fmt.Sprintf("test/fixtures/seg-%d.ts", i)))
 		require.NoError(t, err)
-		err = os.WriteFile(path.Join(outDir, "in", fmt.Sprintf("seg-%d.ts", i+100)), b, 0644)
+		err = os.WriteFile(path.Join(outDir, "in", fmt.Sprintf("clip_%d.ts", i+100)), b, 0644)
 		require.NoError(t, err)
 	}
 

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -2,6 +2,7 @@ package thumbnails
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"os"
 	"path"
@@ -15,7 +16,7 @@ import (
 func generateThumb(t *testing.T, filename string, out *url.URL) {
 	bs, err := os.ReadFile(filename)
 	require.NoError(t, err)
-	err = GenerateThumb(path.Base(filename), bs, out)
+	err = GenerateThumb(path.Base(filename), bs, out, 0)
 	require.NoError(t, err)
 }
 
@@ -35,7 +36,7 @@ func TestGenerateThumbs(t *testing.T) {
 	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-1.ts"), out)
 	generateThumb(t, path.Join(wd, "..", "test/fixtures/seg-2.ts"), out)
 
-	testGenerateThumbsRun(t, outDir)
+	testGenerateThumbsRun(t, outDir, path.Join(wd, "..", "test/fixtures/tiny.m3u8"))
 
 	// Test the recording flow
 	outDir, err = os.MkdirTemp(os.TempDir(), "thumbs*")
@@ -47,17 +48,58 @@ func TestGenerateThumbs(t *testing.T) {
 	err = GenerateThumbsFromManifest("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
 	require.NoError(t, err)
 
-	testGenerateThumbsRun(t, outDir)
+	testGenerateThumbsRun(t, outDir, path.Join(wd, "..", "test/fixtures/tiny.m3u8"))
 }
 
-func testGenerateThumbsRun(t *testing.T, outDir string) {
-	out, err := url.Parse(outDir)
-	require.NoError(t, err)
+func TestGenerateThumbsOffset(t *testing.T) {
+	// Test manifest with an segment offset i.e. the first segment has index >0
 
 	wd, err := os.Getwd()
 	require.NoError(t, err)
+	outDir, err := os.MkdirTemp(os.TempDir(), "thumbs*")
+	require.NoError(t, err)
+	defer os.RemoveAll(outDir)
+	out, err := url.Parse(outDir)
+	require.NoError(t, err)
+	err = os.Mkdir(path.Join(outDir, "in"), 0755)
+	require.NoError(t, err)
 
-	err = GenerateThumbsVTT("req ID", path.Join(wd, "..", "test/fixtures/tiny.m3u8"), out)
+	// Generate a manifest with an offset
+	inputFile := path.Join(outDir, "in", "index.m3u8")
+	manifest := `
+#EXTM3U
+#EXT-X-VERSION:3
+#EXT-X-MEDIA-SEQUENCE:0
+#EXT-X-TARGETDURATION:10
+#EXTINF:10.000000,
+seg-100.ts
+#EXTINF:10.000000,
+seg-101.ts
+#EXTINF:10.000000,
+seg-102.ts
+#EXT-X-ENDLIST
+`
+	err = os.WriteFile(inputFile, []byte(manifest), 0644)
+	require.NoError(t, err)
+	// copy segments
+	for i := 0; i < 3; i++ {
+		b, err := os.ReadFile(path.Join(wd, "..", fmt.Sprintf("test/fixtures/seg-%d.ts", i)))
+		require.NoError(t, err)
+		err = os.WriteFile(path.Join(outDir, "in", fmt.Sprintf("seg-%d.ts", i+100)), b, 0644)
+		require.NoError(t, err)
+	}
+
+	err = GenerateThumbsFromManifest("req ID", inputFile, out)
+	require.NoError(t, err)
+
+	testGenerateThumbsRun(t, outDir, inputFile)
+}
+
+func testGenerateThumbsRun(t *testing.T, outDir, input string) {
+	out, err := url.Parse(outDir)
+	require.NoError(t, err)
+
+	err = GenerateThumbsVTT("req ID", input, out)
 	require.NoError(t, err)
 
 	expectedVtt := `WEBVTT
@@ -92,24 +134,33 @@ keyframes_2.jpg
 
 func Test_thumbFilename(t *testing.T) {
 	tests := []struct {
-		name       string
-		segmentURI string
-		want       string
+		name          string
+		segmentURI    string
+		segmentOffset int64
+		want          string
 	}{
 		{
-			name:       "index",
-			segmentURI: "index0.ts",
-			want:       "keyframes_0.jpg",
+			name:          "index",
+			segmentURI:    "index0.ts",
+			segmentOffset: 0,
+			want:          "keyframes_0.jpg",
 		},
 		{
-			name:       "clip",
-			segmentURI: "clip_1.ts",
-			want:       "keyframes_1.jpg",
+			name:          "clip",
+			segmentURI:    "clip_1.ts",
+			segmentOffset: 0,
+			want:          "keyframes_1.jpg",
+		},
+		{
+			name:          "clip",
+			segmentURI:    "clip_101.ts",
+			segmentOffset: 100,
+			want:          "keyframes_1.jpg",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := thumbFilename(tt.segmentURI)
+			got, err := thumbFilename(tt.segmentURI, tt.segmentOffset)
 			require.NoError(t, err)
 			require.Equal(t, tt.want, got)
 		})


### PR DESCRIPTION
Clip manifests generally have their segment index starting at a non-zero value since they're taken from the middle of a live stream. This was causing the thumb filenames to start with this same index rather than zero. This wasn't great from a user perspective because often they want to just use the filename `keyframe_0.jpg` to get the first frame.

E.g. clip manifest:
```
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-MEDIA-SEQUENCE:0
#EXT-X-TARGETDURATION:8
#EXTINF:2.875,
clip_16.ts
#EXT-X-DISCONTINUITY
#EXTINF:7.125,
clip_17.ts
#EXT-X-ENDLIST
```

Current thumbs output:
```
keyframes_16.jpg
keyframes_17.jpg
```

Fixed thumbs output:
```
keyframes_0.jpg
keyframes_1.jpg
```