### PR TITLE
config: reduce max concurreent VOD jobs to 5

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ const MaxSegmentSizeSecs = 20
 // Separate limits are set for the the maximum number of regular VOD jobs and clipping
 // VOD jobs. The limits are somewhat arbitrary and will need to be tweaked based on
 // requirements.
-var MaxInFlightJobs int = 8
+var MaxInFlightJobs int = 5
 var MaxInFlightClipJobs int = 20
 
 // How long to try writing a single segment to storage for before giving up


### PR DESCRIPTION
This is to reduce the resource utilization on each node until VOD and live playback is separated.