### PR TITLE
Rate limit stream reconcile loop

### DIFF
--- a/mapic/mistapiconnector_app_test.go
+++ b/mapic/mistapiconnector_app_test.go
@@ -1,6 +1,7 @@
 package mistapiconnector
 
 import (
+	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -258,4 +259,27 @@ func TestReconcileStreams(t *testing.T) {
 		"video+abcdefghi",
 	}
 	require.ElementsMatch(t, expectedNuked, recodedNuked)
+}
+
+func Test_reconcileLoopRateLimit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mm := mockmistclient.NewMockMistAPIClient(ctrl)
+
+	streamUpdated := make(chan struct{}, 1)
+	mc := mac{
+		mist:          mm,
+		streamUpdated: streamUpdated,
+	}
+	go func() {
+		mc.reconcileLoop(context.Background())
+	}()
+
+	// expect rate limiting to only allow one call
+	mm.EXPECT().GetState().DoAndReturn(func() (clients.MistState, error) {
+		return clients.MistState{}, nil
+	}).Times(1)
+
+	for i := 0; i < 10; i++ {
+		mc.streamUpdated <- struct{}{}
+	}
 }


### PR DESCRIPTION
Currently we are flooding mist with "getState" calls on startup because we receive a huge backlog of `StreamEvent` messages via serf, to stop this from happening I am introducing rate limiting in the reconcile loop where these messages are received.