### PR TITLE
Mist getState caching

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/metrics"
 	"github.com/patrickmn/go-cache"
 )
@@ -428,6 +429,7 @@ func (mc *MistClient) GetStreamInfo(streamName string) (MistStreamInfo, error) {
 func (mc *MistClient) GetState() (MistState, error) {
 	cachedState, found := mc.cache.Get(stateCacheKey)
 	if found {
+		glog.V(6).Info("returning mist GetState from cache")
 		return *cachedState.(*MistState), nil
 	}
 

--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -12,11 +12,19 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/livepeer/catalyst-api/metrics"
+	"github.com/patrickmn/go-cache"
 )
 
 //go:generate mockgen -source=./mist_client.go -destination=../mocks/clients/mist_client.go
+
+const (
+	stateCacheKey          = "stateCacheKey"
+	defaultCacheExpiration = time.Second
+	cacheCleanupInterval   = 10 * time.Minute
+)
 
 type MistAPIClient interface {
 	AddStream(streamName, sourceUrl string) error
@@ -38,12 +46,14 @@ type MistClient struct {
 	HttpReqUrl      string
 	TriggerCallback string
 	configMu        sync.Mutex
+	cache           *cache.Cache
 }
 
 func NewMistAPIClient(user, password, host string, port int, ownURL string) MistAPIClient {
 	mist := &MistClient{
 		ApiUrl:          fmt.Sprintf("http://%s:%d", host, port),
 		TriggerCallback: ownURL,
+		cache:           cache.New(defaultCacheExpiration, cacheCleanupInterval),
 	}
 	return mist
 }
@@ -416,6 +426,11 @@ func (mc *MistClient) GetStreamInfo(streamName string) (MistStreamInfo, error) {
 }
 
 func (mc *MistClient) GetState() (MistState, error) {
+	cachedState, found := mc.cache.Get(stateCacheKey)
+	if found {
+		return *cachedState.(*MistState), nil
+	}
+
 	c := commandState()
 	resp, err := mc.sendCommand(c)
 	if err := validateAuth(resp, err); err != nil {
@@ -426,6 +441,8 @@ func (mc *MistClient) GetState() (MistState, error) {
 	if err := json.Unmarshal([]byte(resp), &stats); err != nil {
 		return MistState{}, err
 	}
+
+	mc.cache.SetDefault(stateCacheKey, &stats)
 
 	return stats, nil
 }

--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -27,7 +27,6 @@ const streamPlaybackPrefix = "playback_"
 const waitForPushError = 7 * time.Second
 const waitForPushErrorIncreased = 2 * time.Minute
 const keepStreamAfterEnd = 15 * time.Second
-const minReconcileInterval = time.Second
 
 const ownExchangeName = "lp_mist_api_connector"
 const webhooksExchangeName = "webhook_default_exchange"
@@ -539,7 +538,6 @@ func (mc *mac) wildcardPlaybackID(stream *api.Stream) string {
 // reconcileLoop calls reconcileStream, reconcileMultistream and processStats
 // periodically or when streamUpdated is triggered on demand (from serf event).
 func (mc *mac) reconcileLoop(ctx context.Context) {
-	var lastStreamUpdated time.Time
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
 	for {
@@ -548,11 +546,6 @@ func (mc *mac) reconcileLoop(ctx context.Context) {
 			return
 		case <-ticker.C:
 		case <-mc.streamUpdated:
-			if time.Since(lastStreamUpdated) < minReconcileInterval {
-				glog.V(7).Info("rate limiting reconcileLoop")
-				continue
-			}
-			lastStreamUpdated = time.Now()
 		}
 		mistState, err := mc.mist.GetState()
 		if err != nil {

--- a/mapic/mistapiconnector_app_test.go
+++ b/mapic/mistapiconnector_app_test.go
@@ -1,7 +1,6 @@
 package mistapiconnector
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -259,27 +258,4 @@ func TestReconcileStreams(t *testing.T) {
 		"video+abcdefghi",
 	}
 	require.ElementsMatch(t, expectedNuked, recodedNuked)
-}
-
-func Test_reconcileLoopRateLimit(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mm := mockmistclient.NewMockMistAPIClient(ctrl)
-
-	streamUpdated := make(chan struct{}, 1)
-	mc := mac{
-		mist:          mm,
-		streamUpdated: streamUpdated,
-	}
-	go func() {
-		mc.reconcileLoop(context.Background())
-	}()
-
-	// expect rate limiting to only allow one call
-	mm.EXPECT().GetState().DoAndReturn(func() (clients.MistState, error) {
-		return clients.MistState{}, nil
-	}).Times(1)
-
-	for i := 0; i < 10; i++ {
-		mc.streamUpdated <- struct{}{}
-	}
 }


### PR DESCRIPTION
Revert my previous rate limiting commit and just add caching to the getState calls. This will then account for both the `StreamEvent` and `StopSessionsEvent` serf events (these subsequently cause a call to `GetState`): 
https://github.com/livepeer/catalyst-api/blob/cad2ccf1b684798b69311b76374fcceaf9f303ad/main.go#L381