### PR TITLE
pod-mon: re-enable to collect usage metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func main() {
 	config.URLSliceVarFlag(fs, &cli.ImportIPFSGatewayURLs, "import-ipfs-gateway-urls", "https://vod-import-gtw.mypinata.cloud/ipfs/?pinataGatewayToken={{secrets.LP_PINATA_GATEWAY_TOKEN}},https://w3s.link/ipfs/,https://ipfs.io/ipfs/,https://cloudflare-ipfs.com/ipfs/", "Comma delimited ordered list of IPFS gateways (includes /ipfs/ suffix) to import assets from")
 	config.URLSliceVarFlag(fs, &cli.ImportArweaveGatewayURLs, "import-arweave-gateway-urls", "https://arweave.net/", "Comma delimited ordered list of arweave gateways")
 	fs.BoolVar(&cli.MistCleanup, "run-mist-cleanup", true, "Run mist-cleanup.sh to cleanup shm")
-	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", false, "Run pod-mon script to monitor sys usage")
+	fs.BoolVar(&cli.LogSysUsage, "run-pod-mon", true, "Run pod-mon script to monitor sys usage")
 	fs.StringVar(&cli.BroadcasterURL, "broadcaster-url", config.DefaultBroadcasterURL, "URL of local broadcaster")
 	config.InvertedBoolFlag(fs, &cli.MistEnabled, "mist", true, "Disable all Mist integrations. Should only be used for development and CI")
 	config.CommaMapFlag(fs, &cli.SourcePlaybackHosts, "source-playback-hosts", map[string]string{}, "Hostname to prefix mappings for source playback URLs")
@@ -244,8 +244,8 @@ func main() {
 	}
 	if cli.ShouldLogSysUsage() {
 		app := "pod-mon.sh"
-		// schedule pod-mon every 60s with timeout of 15s
-		podMon, err := middleware.NewShell(60*time.Second, 15*time.Second, app)
+		// schedule pod-mon every 5min with timeout of 5s
+		podMon, err := middleware.NewShell(300*time.Second, 5*time.Second, app)
 		if err != nil {
 			glog.Info("Failed to shell out:", app, err)
 		}

--- a/scripts/pod-mon.sh
+++ b/scripts/pod-mon.sh
@@ -22,18 +22,57 @@ log () {
   fi
 }
 
-# get cpu/mem usage
-top=$(top -b -n 1 -H -o %CPU | head -n 15)
-free=$(free -h)
-# get disk usage
-df=$(df -h)
-tmpusage=$(du -ch --max-depth=1 /tmp | sort -hr)
+# List of process names to monitor
+processes=("MistController" "MistProcLivepeer" "MistUtilLoad" "MistOutWebRTC" "MistInDTSC" "MistOutDTSC" "MistOutFLV" "MistInFLV" "MistInBuffer" "MistOutHTTPTS" "catalyst-api" "catalyst-uploader")
 
-log "System usage --------"
-log "$top"
-log "Mem usage --------"
-log "$free"
-log "Disk usage --------"
-log "$df"
-log "/tmp usage --------"
-log "$tmpusage"
+# Function to calculate CPU and MEM usage for a specific process
+calculate_usage() {
+  local process_name=$1
+
+  # Get the output of ps aux filtered by the process name, skipping the header row and capturing only the CPU and MEM columns
+  ps aux | grep "$process_name" | grep -v grep | awk '{
+    cpu+=$3; mem+=$4; count+=1; if ($3 > max_cpu) max_cpu=$3
+  } END {
+    print cpu, mem, count, max_cpu
+  }'
+}
+
+# Get the number of CPU cores
+num_cores=$(grep -c ^processor /proc/cpuinfo)
+
+# Initialize the output as an empty string
+output="["
+
+# Loop through each process and calculate the usage
+for process in "${processes[@]}"; do
+  output_data=$(calculate_usage "$process")
+
+  cpu=$(echo "$output_data" | awk '{print $1}')
+  mem=$(echo "$output_data" | awk '{print $2}')
+  count=$(echo "$output_data" | awk '{print $3}')
+  max_cpu=$(echo "$output_data" | awk '{print $4}')
+
+  # Set defaults if count is not a number
+  if ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    count=0
+  fi
+
+  if [ "$count" -gt 0 ]; then
+    avg_cpu_per_core=$(awk "BEGIN {print $cpu / $num_cores}")
+    avg_mem=$(awk "BEGIN {print $mem / $count}")
+  else
+    avg_cpu_per_core=0
+    avg_mem=0
+    max_cpu=0
+  fi
+
+  # Append the JSON-like string to the output string
+  output+="{\"process\": \"$process\", \"avg_cpu_per_core\": $avg_cpu_per_core, \"max_cpu_per_core\": $max_cpu, \"avg_mem_per_process\": $avg_mem}, "
+done
+
+# Remove the trailing comma and space, then close the JSON array
+output=${output%, }
+output+="]"
+
+# Print the final JSON string
+log "$output"


### PR DESCRIPTION
To help narrow down usage of Mist and other catalyst processes. 

This script will print a single line json-ish output like this that would make it easier to parse using metabase or loki (?): 
```
{"process": "MistController", "avg_cpu_per_core": 0.214062, "max_cpu_per_core": 13.7, "avg_mem_per_process": 0.05}, {"process": "MistProcLivepeer", "avg_cpu_per_core": 1.04062, "max_cpu_per_core": 12.6, "avg_mem_per_process": 0}, {"process": "MistUtilLoad", "avg_cpu_per_core": 0.15625, "max_cpu_per_core": 5.1, "avg_mem_per_process": 0}, {"process": "MistOutWebRTC", "average_cpu_per_core": 0.0890625, "max_cpu_per_core": 2.9, "avg_mem_per_process": 0}, {"process": "MistInDTSC", "avg_cpu_per_core": 2.07187, "max_cpu_per_core": 15.0, "avg_mem_per_process": 0}, {"process": "MistOutDTSC", "avg_cpu_per_core": 4.88594, "max_cpu_per_core": 6.8, "avg_mem_per_process": 0}, {"process": "MistOutFLV", "avg_cpu_per_core": 0.4875, "max_cpu_per_core": 1.6, "avg_mem_per_process": 0}, {"process": "MistInFLV", "avg_cpu_per_core": 0.882812, "max_cpu_per_core": 10.9, "avg_mem_per_process": 0}, {"process": "MistInBuffer", "avg_cpu_per_core": 0.410938, "max_cpu_per_core": 1.5, "avg_mem_per_process": 0}, {"process": "MistOutHTTPTS", "avg_cpu_per_core": 0.745313, "max_cpu_per_core": 7.7, "avg_mem_per_process": 0}, {"process": "catalyst-api", "avg_cpu_per_core": 0.125, "max_cpu_per_core": 8.0, "avg_mem_per_process": 0.2}, {"process": "catalyst-uploader", "avg_cpu_per_core": 1.59844, "max_cpu_per_core": 18.0, "avg_mem_per_process": 0.08}]
```