### PR TITLE
Add request count to client metrics

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -9,6 +9,7 @@ import (
 type ClientMetrics struct {
 	RetryCount      *prometheus.GaugeVec
 	FailureCount    *prometheus.CounterVec
+	RequestCount    *prometheus.CounterVec
 	RequestDuration *prometheus.HistogramVec
 }
 
@@ -131,7 +132,7 @@ func NewMetrics() *CatalystAPIMetrics {
 		TranscodingStatusUpdate: ClientMetrics{
 			RetryCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "transcoding_status_update_retry_count",
-				Help: "The number of retries of a successful request to Studio",
+				Help: "The number of retried transcoding status updates",
 			}, []string{"host"}),
 			FailureCount: promauto.NewCounterVec(prometheus.CounterOpts{
 				Name: "transcoding_status_update_failure_count",
@@ -142,54 +143,70 @@ func NewMetrics() *CatalystAPIMetrics {
 				Help:    "Time taken to send transcoding status updates",
 				Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 			}, []string{"host"}),
+			RequestCount: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "transcoding_status_update_request_count",
+				Help: "The total number of transcoding status updates",
+			}, []string{"host"}),
 		},
 
 		BroadcasterClient: ClientMetrics{
 			RetryCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "broadcaster_client_retry_count",
-				Help: "The number of retries of a successful request to Studio",
+				Help: "The number of retried broadcaster requests",
 			}, []string{"host"}),
 			FailureCount: promauto.NewCounterVec(prometheus.CounterOpts{
 				Name: "broadcaster_client_failure_count",
-				Help: "The total number of failed transcoding status updates",
+				Help: "The total number of failed broadcaster requests",
 			}, []string{"host", "status_code"}),
 			RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name:    "broadcaster_client_request_duration",
-				Help:    "Time taken to send transcoding status updates",
+				Help:    "Time taken to send broadcaster requests",
 				Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			}, []string{"host"}),
+			RequestCount: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "broadcaster_client_request_count",
+				Help: "The total number of broadcaster requests",
 			}, []string{"host"}),
 		},
 
 		MistClient: ClientMetrics{
 			RetryCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "mist_client_retry_count",
-				Help: "The number of retries of a successful request to Studio",
+				Help: "The number of retried mist requests",
 			}, []string{"host"}),
 			FailureCount: promauto.NewCounterVec(prometheus.CounterOpts{
 				Name: "mist_client_failure_count",
-				Help: "The total number of failed transcoding status updates",
+				Help: "The total number of failed mist requests",
 			}, []string{"host", "status_code"}),
 			RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name:    "mist_client_request_duration",
-				Help:    "Time taken to send transcoding status updates",
+				Help:    "Time taken to send mist requests",
 				Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+			}, []string{"host"}),
+			RequestCount: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "mist_client_request_count",
+				Help: "The total number of mist requests",
 			}, []string{"host"}),
 		},
 
 		ObjectStoreClient: ClientMetrics{
 			RetryCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
 				Name: "object_store_retry_count",
-				Help: "The number of retries of a successful request to Studio",
+				Help: "The number of retried object store requests",
 			}, []string{"host", "operation", "bucket"}),
 			FailureCount: promauto.NewCounterVec(prometheus.CounterOpts{
 				Name: "object_store_failure_count",
-				Help: "The total number of failed transcoding status updates",
+				Help: "The total number of failed object store requests",
 			}, []string{"host", "operation", "bucket"}),
 			RequestDuration: promauto.NewHistogramVec(prometheus.HistogramOpts{
 				Name:    "object_store_request_duration",
-				Help:    "Time taken to send transcoding status updates",
+				Help:    "Time taken to send object store requests",
 				Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
 			}, []string{"host", "operation", "bucket"}),
+			RequestCount: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "object_store_request_count",
+				Help: "The total number of object store requests",
+			}, []string{"host"}),
 		},
 
 		VODPipelineMetrics: VODPipelineMetrics{

--- a/metrics/monitor_request.go
+++ b/metrics/monitor_request.go
@@ -31,6 +31,9 @@ func MonitorRequest(clientMetrics ClientMetrics, client *http.Client, r *http.Re
 
 	clientMetrics.RequestDuration.WithLabelValues(req.URL.Host).Observe(duration.Seconds())
 	clientMetrics.RetryCount.WithLabelValues(req.URL.Host).Set(float64(retries.count))
+	if clientMetrics.RequestCount != nil {
+		clientMetrics.RequestCount.WithLabelValues(req.URL.Host).Inc()
+	}
 
 	return res, err
 }


### PR DESCRIPTION
We recently started caching mist API requests so I want to be able to monitor the request count especially during deploys where we had the problems before