### PR TITLE
Lock for the whole of GetState() to avoid parallel mist API calls

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -48,7 +48,7 @@ type MistClient struct {
 	TriggerCallback string
 	configMu        sync.Mutex
 	cache           *cache.Cache
-	// The cache uses a RWMutex which means multiple routines can end up with a cache miss at the same time and end up
+	// The go-cache library uses a RWMutex which means multiple routines can end up with a cache miss at the same time and end up
 	// calling through to the mist API. We want to avoid this and have the other routines wait so we lock for the
 	// whole of the GetState function.
 	stateCacheMu sync.Mutex


### PR DESCRIPTION
I was still observing hundreds of mist API calls being made on startup, much better than the thousands we had before but it still has the potential to blow up. This should fix that issue.

The cache uses a RWMutex which means multiple routines can end up with a cache miss at the same time and therefore calling through to the mist API. We want to avoid this and have the other routines wait so we lock for the whole of the GetState function.