### PR TITLE
Add viewer limit

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -59,6 +59,7 @@ type Cli struct {
 	VodDecryptPublicKey       string
 	VodDecryptPrivateKey      string
 	GateURL                   string
+	DataURL                   string
 	StreamHealthHookURL       string
 	BroadcasterURL            string
 	SourcePlaybackHosts       map[string]string

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -178,6 +178,10 @@ func NewAccessControlHandlersCollection(cli config.Cli, mapic mistapiconnector.I
 				gateURL: cli.GateURL,
 				Client:  &http.Client{},
 			},
+			dataClient: &DataClient{
+				Endpoint:    cli.DataURL,
+				AccessToken: cli.APIToken,
+			},
 			blockedJWTs: cli.BlockedJWTs,
 		}
 		accessControlHandlersCollection.periodicCleanUpRecordCache()

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -111,7 +111,7 @@ type GateConfig struct {
 	StaleWhileRevalidate int32  `json:"stale_while_revalidate"`
 	RateLimit            int32  `json:"rate_limit"`
 	RefreshInterval      int32  `json:"refresh_interval"`
-	ViewerLimitPerUser   int32  `json:"viewer_limit_per_user"`
+	UserViewerLimit      int32  `json:"user_viewer_limit"`
 	UserID               string `json:"user_id"`
 }
 
@@ -500,11 +500,11 @@ func (ac *AccessControlHandlersCollection) cachePlaybackAccessControlInfo(playba
 
 	// cache viewer limit per user data
 	viewerLimitCache.mux.Lock()
-	if gateConfig.ViewerLimitPerUser != 0 && gateConfig.UserID != "" {
+	if gateConfig.UserViewerLimit != 0 && gateConfig.UserID != "" {
 		if _, ok := viewerLimitCache.data[playbackID]; !ok {
 			viewerLimitCache.data[playbackID] = &ViewerLimitCacheEntry{}
 		}
-		viewerLimitCache.data[playbackID].ViewerLimitPerUser = gateConfig.ViewerLimitPerUser
+		viewerLimitCache.data[playbackID].ViewerLimitPerUser = gateConfig.UserViewerLimit
 		viewerLimitCache.data[playbackID].UserID = gateConfig.UserID
 	} else {
 		delete(viewerLimitCache.data, playbackID)
@@ -584,12 +584,12 @@ func (g *GateClient) QueryGate(body []byte) (bool, GateConfig, error) {
 			}
 			refreshInterval = int32(refreshIntervalFloat64)
 		}
-		if ri, ok := result["viewer_limit_per_user"]; ok {
+		if ri, ok := result["user_viewer_limit"]; ok {
 			viewerLimitPerUser, ok := ri.(float64)
 			if !ok {
-				return false, gateConfig, fmt.Errorf("viewer_limit_per_user is not a number")
+				return false, gateConfig, fmt.Errorf("user_viewer_limit is not a number")
 			}
-			gateConfig.ViewerLimitPerUser = int32(viewerLimitPerUser)
+			gateConfig.UserViewerLimit = int32(viewerLimitPerUser)
 		}
 		if ri, ok := result["user_id"]; ok {
 			userID, ok := ri.(string)

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -74,23 +74,23 @@ type HitRecords struct {
 	mux  sync.Mutex
 }
 
+// ViewerLimitCache comes from Gate API
 type ViewerLimitCache struct {
 	data map[string]*ViewerLimitCacheEntry
 	mux  sync.RWMutex
 }
 
-// ViewerLimitCacheEntry is cached from Gate API
 type ViewerLimitCacheEntry struct {
 	ViewerLimitPerUser int32
 	UserID             string
 }
 
+// ConcurrentViewersCache comes from the server-side realtime viewership (livepeer-data)
 type ConcurrentViewersCache struct {
 	data map[string]*ConcurrentViewersCacheEntry
 	mux  sync.RWMutex
 }
 
-// ConcurrentViewersCacheEntry is cached from the server-side realtime viewership
 type ConcurrentViewersCacheEntry struct {
 	ViewCount   int32
 	LastRefresh time.Time

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -59,10 +59,6 @@ type GateAPICaller interface {
 	QueryGate(body []byte) (bool, GateConfig, error)
 }
 
-type DataAPICaller interface {
-	QueryServerViewCount(userID string) (int32, error)
-}
-
 type GateClient struct {
 	Client  *http.Client
 	gateURL string

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -348,7 +348,7 @@ func (ac *AccessControlHandlersCollection) checkViewerLimit(playbackID string) b
 
 	if viewerLimit, ok := viewerLimitCache.data[playbackID]; ok {
 		// We don't want to make any blocking calls, so refreshing the cache async
-		// The worse that can happen is that we allow a few users above the limit for a few seconds
+		// The worse that can happen is that we allow a few viewers above the limit for a few seconds
 		defer func() { go ac.refreshConcurrentViewerCache(playbackID) }()
 		if concurrentViewers, ok2 := concurrentViewersCache.data[playbackID]; ok2 {
 			if viewerLimit.ViewerLimitPerUser != 0 && concurrentViewers.ViewCount > viewerLimit.ViewerLimitPerUser {

--- a/handlers/accesscontrol/access-control_test.go
+++ b/handlers/accesscontrol/access-control_test.go
@@ -262,7 +262,7 @@ func TestViewerLimit(t *testing.T) {
 			MaxAge:               120,
 			StaleWhileRevalidate: 300,
 			RefreshInterval:      0,
-			ViewerLimitPerUser:   1,
+			UserViewerLimit:      1,
 			UserID:               userID,
 		}
 		return true, gateConfig, nil

--- a/handlers/accesscontrol/access-control_test.go
+++ b/handlers/accesscontrol/access-control_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 const (
+	userID         = "some-user"
 	playbackID     = "1bbbqz6753hcli1t"
 	plusPlaybackID = "video+1bbbqz6753hcli1t"
 	publicKey      = `LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFNzRoTHBSUkx0TzBQS01Vb08yV3ptY2xOemFBaQp6RTd2UnUrdmtHQXFEVzBEVzB5eW9LV3ZKakZNcWdOb0dCakpiZDM2c3ZiTzhVRnN6aXlSZzJYdXlnPT0KLS0tLS1FTkQgUFVCTElDIEtFWS0tLS0tCg==`
@@ -32,6 +33,12 @@ type stubGateClient struct{}
 
 func (g *stubGateClient) QueryGate(body []byte) (bool, GateConfig, error) {
 	return queryGate(body)
+}
+
+type stubDataClient struct{}
+
+func (d *stubDataClient) QueryServerViewCount(userID string) (int32, error) {
+	return 2, nil
 }
 
 var queryGate = func(body []byte) (bool, GateConfig, error) {
@@ -65,10 +72,16 @@ var denyAccess = func(body []byte) (bool, GateConfig, error) {
 }
 
 func testTriggerHandler() func(context.Context, *misttriggers.UserNewPayload) (bool, error) {
-	return (&AccessControlHandlersCollection{
+	c := &AccessControlHandlersCollection{
 		cache:      make(map[string]map[string]*PlaybackAccessControlEntry),
 		gateClient: &stubGateClient{},
-	}).HandleUserNew
+		dataClient: &stubDataClient{},
+	}
+	// Make sure the concurrent viewer data is available
+	// In the code it's done async, so to make sure this test is not flaky,
+	// we need to execute it here synchronously
+	c.refreshConcurrentViewerCache(playbackID)
+	return c.HandleUserNew
 }
 
 func TestAllowedAccessValidToken(t *testing.T) {
@@ -237,6 +250,34 @@ func TestInvalidCache(t *testing.T) {
 	executeFlow(payload, handler, countableAllowAccess)
 
 	require.Equal(t, 2, callCount)
+}
+
+func TestViewerLimit(t *testing.T) {
+	token, _ := craftToken(privateKey, publicKey, playbackID, expiration)
+	payload := []byte(fmt.Sprint(playbackID, "\n1\n2\n3\nhttp://localhost:8080/hls/", playbackID, "/index.m3u8?stream=", playbackID, "&jwt=", token, "\n5"))
+
+	access := func(body []byte) (bool, GateConfig, error) {
+		gateConfig := GateConfig{
+			RateLimit:            0,
+			MaxAge:               120,
+			StaleWhileRevalidate: 300,
+			RefreshInterval:      0,
+			ViewerLimitPerUser:   1,
+			UserID:               userID,
+		}
+		return true, gateConfig, nil
+	}
+
+	// The first called is allowed, because the viewer limit is not cached yet
+	// This is ok, because we don't need to be so strict about limiting viewers
+	// It's better to return fast and let the user watch the stream
+	result1 := executeFlow(payload, testTriggerHandler(), access)
+	require.Equal(t, "true", result1)
+
+	// The second call should be blocked, because we already cached the viewer limit
+	// and it's exceeded
+	result2 := executeFlow(payload, testTriggerHandler(), access)
+	require.Equal(t, "false", result2)
 }
 
 func executeFlow(body []byte, handler func(context.Context, *misttriggers.UserNewPayload) (bool, error), request func(body []byte) (bool, GateConfig, error)) string {

--- a/handlers/accesscontrol/data_client.go
+++ b/handlers/accesscontrol/data_client.go
@@ -10,6 +10,7 @@ type DataAPICaller interface {
 	QueryServerViewCount(userID string) (int32, error)
 }
 
+// DataClient is a client for the Livepeer Data API
 type DataClient struct {
 	Endpoint    string
 	AccessToken string

--- a/handlers/accesscontrol/data_client.go
+++ b/handlers/accesscontrol/data_client.go
@@ -1,0 +1,62 @@
+package accesscontrol
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+type DataAPICaller interface {
+	QueryServerViewCount(userID string) (int32, error)
+}
+
+type DataClient struct {
+	Endpoint    string
+	AccessToken string
+}
+
+type ViewCountResponse struct {
+	ViewCount int32 `json:"viewCount"`
+}
+
+func NewDataClient(endpoint, accessToken string) *DataClient {
+	return &DataClient{
+		Endpoint:    endpoint,
+		AccessToken: accessToken,
+	}
+}
+
+func (d *DataClient) QueryServerViewCount(userID string) (int32, error) {
+	if userID == "" {
+		return 0, fmt.Errorf("userID is empty")
+	}
+
+	url := fmt.Sprintf("%s/views/internal/server/now?userId=%s", d.Endpoint, userID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create request, err=%v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", d.AccessToken))
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("failed to perform request, err=%v", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return 0, fmt.Errorf("unexpected status code %d", res.StatusCode)
+	}
+
+	var viewCountRes []ViewCountResponse
+	if err := json.NewDecoder(res.Body).Decode(&viewCountRes); err != nil {
+		return 0, fmt.Errorf("failed to decode response body, err=%v", err)
+	}
+
+	if len(viewCountRes) != 1 {
+		return 0, fmt.Errorf("view count does not contain exactly one element, viewCountRes=%v", viewCountRes)
+	}
+
+	return viewCountRes[0].ViewCount, nil
+}

--- a/main.go
+++ b/main.go
@@ -118,6 +118,7 @@ func main() {
 	fs.StringVar(&cli.VodDecryptPublicKey, "catalyst-public-key", "", "Public key of the catalyst node for encryption")
 	fs.StringVar(&cli.VodDecryptPrivateKey, "catalyst-private-key", "", "Private key of the catalyst node for encryption")
 	fs.StringVar(&cli.GateURL, "gate-url", "http://localhost:3004/api/access-control/gate", "Address to contact playback gating API for access control verification")
+	fs.StringVar(&cli.GateURL, "data-url", "http://localhost:3004/api/data", "Address of the Livepeer Data Endpoint")
 	config.InvertedBoolFlag(fs, &cli.MistTriggerSetup, "mist-trigger-setup", true, "Overwrite Mist triggers with the ones built into catalyst-api")
 	fs.IntVar(&cli.SerfQueueSize, "serf-queue-size", 100000, "Size of internal serf queue before messages are dropped")
 	fs.IntVar(&cli.SerfEventBuffer, "serf-event-buffer", 100000, "Size of serf 'recent event' buffer, outside of which things are dropped")

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func main() {
 	fs.StringVar(&cli.VodDecryptPublicKey, "catalyst-public-key", "", "Public key of the catalyst node for encryption")
 	fs.StringVar(&cli.VodDecryptPrivateKey, "catalyst-private-key", "", "Private key of the catalyst node for encryption")
 	fs.StringVar(&cli.GateURL, "gate-url", "http://localhost:3004/api/access-control/gate", "Address to contact playback gating API for access control verification")
-	fs.StringVar(&cli.GateURL, "data-url", "http://localhost:3004/api/data", "Address of the Livepeer Data Endpoint")
+	fs.StringVar(&cli.DataURL, "data-url", "http://localhost:3004/api/data", "Address of the Livepeer Data Endpoint")
 	config.InvertedBoolFlag(fs, &cli.MistTriggerSetup, "mist-trigger-setup", true, "Overwrite Mist triggers with the ones built into catalyst-api")
 	fs.IntVar(&cli.SerfQueueSize, "serf-queue-size", 100000, "Size of internal serf queue before messages are dropped")
 	fs.IntVar(&cli.SerfEventBuffer, "serf-event-buffer", 100000, "Size of serf 'recent event' buffer, outside of which things are dropped")


### PR DESCRIPTION
Related to: https://www.notion.so/livepeer/Cap-50k-Fishtank-viewers-a828ef8d037a4f27b9a6769d91c50b23

**Related PRs:**
- https://github.com/livepeer/livepeer-data/pull/194
- https://github.com/livepeer/studio/pull/2223

**Comments:**
- The solution is not 100% bullet-proof (we may encounter viewers exceeding the limit); that's done on purpose, because we prefer to allow a few viewers above the limit rather than increasing the TTFF. The reasons why viewers may be allowed above the limit:
  - data about the concurrent view count is note refresh (livepeer data takes data from Victoria Metrics nad it has some delay)
  - we cache the concurrent view count for 30s
  - we refresh the concurrent view count **after** allowing the user (because we don't want to make a sync call)
  - viewer limit may not be refreshed (10 min cache)
- We should do some refactoring and changes (but I prefer to do it in a separate PRs), in particular:
  - rate limit can be removed and replaced with the viewer limit mechanism
  - parsing Gate API response should use the standard json umarshall mechanism