### PR TITLE
Remove prores support

### DIFF
--- a/video/probe.go
+++ b/video/probe.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	unsupportedVideoCodecList = []string{"mjpeg", "jpeg", "png"}
+	unsupportedVideoCodecList = []string{"mjpeg", "jpeg", "png", "prores"}
 	supportedFormats          = []string{"mp4", "mov", "hls"}
 )
 

--- a/video/probe_test.go
+++ b/video/probe_test.go
@@ -35,6 +35,21 @@ func TestItRejectsWhenMJPEGVideoTrackPresent(t *testing.T) {
 	require.ErrorContains(t, err, "jpeg is not supported")
 }
 
+func TestItRejectsProresVideos(t *testing.T) {
+	_, err := parseProbeOutput(&ffprobe.ProbeData{
+		Format: &ffprobe.Format{
+			Size: "1",
+		},
+		Streams: []*ffprobe.Stream{
+			{
+				CodecType: "video",
+				CodecName: "prores",
+			},
+		},
+	})
+	require.ErrorContains(t, err, "prores is not supported")
+}
+
 func TestItRejectsWhenFormatMissing(t *testing.T) {
 	_, err := parseProbeOutput(&ffprobe.ProbeData{
 		Streams: []*ffprobe.Stream{


### PR DESCRIPTION
We no longer want to support this format for VOD, so will start explicitly rejecting it at the point of ingest.