### PR TITLE
mapic: Fix multistream target URL `?` handling

### DIFF
--- a/mapic/mistapiconnector_app.go
+++ b/mapic/mistapiconnector_app.go
@@ -748,16 +748,13 @@ func (mc *mac) getPushUrl(stream *api.Stream, targetRef *api.MultistreamTargetRe
 		}
 		videoSelector = fmt.Sprintf("~%dx%d", prof.Width, prof.Height)
 	}
-	join := "?"
-	if strings.Contains(target.URL, "?") {
-		join = "&"
-	}
 	audioSelector := "maxbps"
 	if targetRef.VideoOnly {
 		audioSelector = "silent"
 	}
-	// Inject ?video=~widthxheight to send the correct rendition
-	return target, fmt.Sprintf("%s%svideo=%s&audio=%s", target.URL, join, videoSelector, audioSelector), nil
+	// Inject ?video=~widthxheight to send the correct rendition. Notice that we don't care if there is already a
+	// query-string in the URL since Mist will always strip from the last `?` in the push URL for its configs.
+	return target, fmt.Sprintf("%s?video=%s&audio=%s", target.URL, videoSelector, audioSelector), nil
 }
 
 func (mc *mac) getStreamInfoLogged(playbackID string) (*streamInfo, bool) {


### PR DESCRIPTION
It turns out that Mist has a special parsing of these push URLs which is not a regular URL parsing. It removes anything after the last `?` in the URL and uses that as its config. If there are multiple `?` in the URL (e.g. query-string already existed in target URL), it will strip only (from) the last one and keep the previous.

So instead of merging Mist's qs with the existing ones, we actually need to create a separate `?` section for Mist. This guarantees both that Mist gets its config properly, as well as that it preserves the URL to call the target service.