### PR TITLE
backoff: Fix usage of backoff library

### DIFF
--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -184,8 +184,8 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 	backOff := backoff.NewExponentialBackOff()
 	backOff.InitialInterval = 200 * time.Millisecond
 	backOff.MaxInterval = maxRetryInterval
-	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
-
+	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries=
+	backOff.Reset()
 	return backOff
 }
 

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -184,7 +184,7 @@ func newExponentialBackOffExecutor() *backoff.ExponentialBackOff {
 	backOff := backoff.NewExponentialBackOff()
 	backOff.InitialInterval = 200 * time.Millisecond
 	backOff.MaxInterval = maxRetryInterval
-	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries=
+	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
 	backOff.Reset()
 	return backOff
 }

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -407,5 +407,6 @@ func retries(retries uint64) backoff.BackOff {
 	backOff.InitialInterval = 1 * time.Second
 	backOff.MaxInterval = 30 * time.Second
 	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
+	backOff.Reset()
 	return backoff.WithMaxRetries(backOff, retries)
 }

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -25,8 +25,10 @@ const resolution = "854:480"
 const vttFilename = "thumbnails.vtt"
 const outputDir = "thumbnails"
 
-// Wait a maximum of 5 mins for thumbnails to finish
-var thumbWaitBackoff = backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
+func thumbWaitBackoff() backoff.BackOff {
+	// Wait a maximum of 5 mins for thumbnails to finish
+	return backoff.WithMaxRetries(backoff.NewConstantBackOff(30*time.Second), 10)
+}
 
 func getMediaManifest(requestID string, input string) (*m3u8.MediaPlaylist, error) {
 	var (
@@ -102,7 +104,7 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 				rc.Close()
 			}
 			return err
-		}, thumbWaitBackoff)
+		}, thumbWaitBackoff())
 		if err != nil {
 			return fmt.Errorf("failed to find thumb %s: %w", filename, err)
 		}

--- a/video/probe.go
+++ b/video/probe.go
@@ -59,6 +59,7 @@ func (p Probe) runProbe(url string, ffProbeOptions ...string) (iv InputVideo, er
 	backOff.InitialInterval = 500 * time.Millisecond
 	backOff.MaxInterval = 2 * time.Second
 	backOff.MaxElapsedTime = 0 // don't impose a timeout as part of the retries
+	backOff.Reset()
 	err = backoff.Retry(operation, backoff.WithMaxRetries(backOff, 3))
 	if err != nil {
 		return InputVideo{}, fmt.Errorf("error probing: %w", err)


### PR DESCRIPTION
This fixes 2 misuses of the backoff lib found in `catalyst-api` code:
- Re-using singleton instances of a backoff. They are not meant to be shared so we should create one on every call
- Not calling `Reset` on the exponential backoff after configuring it. This (confusing) requirement is necessary if we change the `IniitalDelay`. By not calling it we were basically ignoring any changes and going with the default 500ms.