### PR TITLE
analytics: Add 'time_warning_ms' field

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -53,6 +53,7 @@ type AnalyticsLogEvent struct {
 	AutoplayStatus      *string `json:"autoplay_status"`
 	StalledCount        *int    `json:"stalled_count"`
 	WaitingCount        *int    `json:"waiting_count"`
+	TimeWarningMS       *int    `json:"time_warning_ms"`
 	TimeErroredMS       *int    `json:"time_errored_ms"`
 	TimeStalledMS       *int    `json:"time_stalled_ms"`
 	TimePlayingMS       *int    `json:"time_playing_ms"`
@@ -244,6 +245,7 @@ func (c *AnalyticsHandlersCollection) toAnalyticsData(log *AnalyticsLog, geo Ana
 				AutoplayStatus:      e.AutoplayStatus,
 				StalledCount:        e.StalledCount,
 				WaitingCount:        e.WaitingCount,
+				TimeWarningMS:       e.TimeWarningMS,
 				TimeErroredMS:       e.TimeErroredMS,
 				TimeStalledMS:       e.TimeStalledMS,
 				TimePlayingMS:       e.TimePlayingMS,

--- a/handlers/analytics/log_processor.go
+++ b/handlers/analytics/log_processor.go
@@ -32,6 +32,7 @@ type LogDataEvent struct {
 	AutoplayStatus      *string `json:"autoplay_status,omitempty"`
 	StalledCount        *int    `json:"stalled_count,omitempty"`
 	WaitingCount        *int    `json:"waiting_count,omitempty"`
+	TimeWarningMS       *int    `json:"time_warning_ms,omitempty"`
 	TimeErroredMS       *int    `json:"time_errored_ms,omitempty"`
 	TimeStalledMS       *int    `json:"time_stalled_ms,omitempty"`
 	TimePlayingMS       *int    `json:"time_playing_ms,omitempty"`


### PR DESCRIPTION
Fix https://linear.app/livepeer/issue/ENG-2135/add-time-warning-ms-to-catalyst-api