### PR TITLE
Thumbs for mediaconvert

### DIFF
--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -257,10 +258,13 @@ func processSegment(input string, thumbOut string) error {
 	return nil
 }
 
-var segmentPrefix = []string{"index360p0_", "index", "clip_"}
+var segmentPrefix = []string{"index", "clip_"}
+var reg = regexp.MustCompile(`index.*?_(.*?\.ts)`) // to match something like index360p0_1.ts
 
 func segmentIndex(segmentURI string) (int64, error) {
-	// segmentURI will be indexX.ts or clip_X.ts or index360p0_00001.ts
+	segmentURI = reg.ReplaceAllString(segmentURI, "${1}")
+
+	// segmentURI will be indexX.ts or clip_X.ts
 	for _, prefix := range segmentPrefix {
 		segmentURI = strings.TrimPrefix(segmentURI, prefix)
 	}

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -172,6 +172,18 @@ func GenerateThumb(segmentURI string, input []byte, output *url.URL, segmentOffs
 	return nil
 }
 
+func GenerateThumbsAndVTT(requestID, input string, output *url.URL) error {
+	err := GenerateThumbsFromManifest(requestID, input, output)
+	if err != nil {
+		return err
+	}
+	err = GenerateThumbsVTT(requestID, input, output)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func GenerateThumbsFromManifest(requestID, input string, output *url.URL) error {
 	// parse manifest and generate one thumbnail per segment
 	mediaPlaylist, err := getMediaManifest(requestID, input)
@@ -245,10 +257,10 @@ func processSegment(input string, thumbOut string) error {
 	return nil
 }
 
-var segmentPrefix = []string{"index", "clip_"}
+var segmentPrefix = []string{"index360p0_", "index", "clip_"}
 
 func segmentIndex(segmentURI string) (int64, error) {
-	// segmentURI will be indexX.ts or clip_X.ts
+	// segmentURI will be indexX.ts or clip_X.ts or index360p0_00001.ts
 	for _, prefix := range segmentPrefix {
 		segmentURI = strings.TrimPrefix(segmentURI, prefix)
 	}

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -166,3 +166,36 @@ func Test_thumbFilename(t *testing.T) {
 		})
 	}
 }
+
+func Test_segmentIndex(t *testing.T) {
+	tests := []struct {
+		name       string
+		segmentURI string
+		want       int64
+	}{
+		{
+			name:       "normal index",
+			segmentURI: "index0.ts",
+			want:       0,
+		},
+		{
+			name:       "clip",
+			segmentURI: "clip_0.ts",
+			want:       0,
+		},
+		{
+			name:       "mediaconvert",
+			segmentURI: "index360p0_001.ts",
+			want:       1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := segmentIndex(tt.segmentURI)
+			require.NoError(t, err)
+			if got != tt.want {
+				t.Errorf("segmentIndex() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We need thumbs from mediaconvert to have feature parity across the two pipelines.