### PR TITLE
Revert "clients: Handle not found errors gracefully (#1302)"

### DIFF
--- a/clients/arweave_ipfs_s3.go
+++ b/clients/arweave_ipfs_s3.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/livepeer/catalyst-api/config"
-	catErrs "github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 )
 
@@ -65,41 +64,35 @@ func (d *DStorageDownload) DownloadDStorageFromGatewayList(u, requestID string) 
 	defer func() { d.gatewaysListPosition++ }()
 	length := len(gateways)
 	until := d.gatewaysListPosition + length
-	var lastErr error
 	for i := d.gatewaysListPosition; i < until; i++ {
 		d.gatewaysListPosition = i % length
 		gateway := gateways[d.gatewaysListPosition]
-		opContent, err := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
-		if err == nil {
+		opContent := downloadDStorageResourceFromSingleGateway(gateway, resourceID, requestID)
+		if opContent != nil {
 			return opContent, nil
 		}
-		lastErr = err
 	}
 
-	return nil, fmt.Errorf("failed to fetch %s from any of the gateways: %w", u, lastErr)
+	return nil, fmt.Errorf("failed to fetch %s from any of the gateways", u)
 }
 
-func downloadDStorageResourceFromSingleGateway(gateway *url.URL, resourceId, requestID string) (io.ReadCloser, error) {
+func downloadDStorageResourceFromSingleGateway(gateway *url.URL, resourceId, requestID string) io.ReadCloser {
 	fullURL := gateway.JoinPath(resourceId).String()
 	log.Log(requestID, "downloading from gateway", "resourceID", resourceId, "url", fullURL)
 	resp, err := http.DefaultClient.Get(fullURL)
 
 	if err != nil {
 		log.LogError(requestID, "failed to fetch content from gateway", err, "url", fullURL)
-		return nil, err
+		return nil
 	}
 
-	if resp.StatusCode == 404 {
-		resp.Body.Close()
-		log.Log(requestID, "dstorage gateway not found", "status_code", resp.StatusCode, "url", fullURL)
-		return nil, catErrs.NewObjectNotFoundError("not found in dstorage", nil)
-	} else if resp.StatusCode >= 300 {
+	if resp.StatusCode >= 300 {
 		resp.Body.Close()
 		log.Log(requestID, "unexpected response from gateway", "status_code", resp.StatusCode, "url", fullURL)
-		return nil, fmt.Errorf("unexpected response from gateway: %d", resp.StatusCode)
+		return nil
 	}
 
-	return resp.Body, nil
+	return resp.Body
 }
 
 func IsDStorageResource(dStorage string) bool {

--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -2,7 +2,6 @@ package clients
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"net/url"
@@ -10,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	catErrs "github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/log"
 
 	"github.com/cenkalti/backoff/v4"
@@ -31,7 +29,7 @@ func DownloadOSURL(osURL string) (io.ReadCloser, error) {
 func GetOSURL(osURL, byteRange string) (*drivers.FileInfoReader, error) {
 	storageDriver, err := drivers.ParseOSURL(osURL, true)
 	if err != nil {
-		return nil, catErrs.Unretriable(fmt.Errorf("failed to parse OS URL %q: %w", log.RedactURL(osURL), err))
+		return nil, fmt.Errorf("failed to parse OS URL %q: %s", log.RedactURL(osURL), err)
 	}
 
 	start := time.Now()
@@ -52,10 +50,6 @@ func GetOSURL(osURL, byteRange string) (*drivers.FileInfoReader, error) {
 
 	if err != nil {
 		metrics.Metrics.ObjectStoreClient.FailureCount.WithLabelValues(host, "read", bucket).Inc()
-
-		if errors.Is(err, drivers.ErrNotExist) {
-			return nil, catErrs.NewObjectNotFoundError("not found in OS", err)
-		}
 		return nil, fmt.Errorf("failed to read from OS URL %q: %w", log.RedactURL(osURL), err)
 	}
 

--- a/clients/object_store_client_test.go
+++ b/clients/object_store_client_test.go
@@ -1,14 +1,12 @@
 package clients
 
 import (
+	"github.com/stretchr/testify/require"
 	"io"
 	"path"
 	"strings"
 	"testing"
 	"time"
-
-	catErrs "github.com/livepeer/catalyst-api/errors"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -41,8 +39,8 @@ func TestItFailsWithInvalidURLs(t *testing.T) {
 func TestItFailsWithMissingFile(t *testing.T) {
 	_, err := DownloadOSURL("/tmp/this/should/not/exist.m3u8")
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "ObjectNotFoundError")
-	require.True(t, catErrs.IsObjectNotFound(err))
+	require.Contains(t, err.Error(), "failed to read from OS URL")
+	require.Contains(t, err.Error(), "no such file or directory")
 }
 
 func TestPublish(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/julienschmidt/httprouter v1.3.0
 	github.com/lib/pq v1.10.9
 	github.com/livepeer/go-api-client v0.4.23
-	github.com/livepeer/go-tools v0.3.8
+	github.com/livepeer/go-tools v0.3.7
 	github.com/livepeer/joy4 v0.1.1
 	github.com/livepeer/livepeer-data v0.8.1
 	github.com/livepeer/m3u8 v0.11.1

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/libp2p/go-openssl v0.1.0 h1:LBkKEcUv6vtZIQLVTegAil8jbNpJErQ9AnT+bWV+O
 github.com/libp2p/go-openssl v0.1.0/go.mod h1:OiOxwPpL3n4xlenjx2h7AwSGaFSC/KZvf6gNdOBQMtc=
 github.com/livepeer/go-api-client v0.4.23 h1:buvWJGxLzwsmvkXaxdI2bOUOAiYZJtcTMfFWMqnOrco=
 github.com/livepeer/go-api-client v0.4.23/go.mod h1:Jdb+RI7JyzEZOHd1GUuKofwFDKMO/btTa80SdpUpYQw=
-github.com/livepeer/go-tools v0.3.8 h1:/SRoFeuWW3/p5aTZ9xieGWO3o04S70ME2yH0SVEEK4w=
-github.com/livepeer/go-tools v0.3.8/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
+github.com/livepeer/go-tools v0.3.7 h1:CaiwL7r85EkBd0GUxFyNAp/xMmrjTr/GgIlqoiMtoog=
+github.com/livepeer/go-tools v0.3.7/go.mod h1:qs31y68b3PQPmSr8nR8l5WQiIWI623z6pqOccqebjos=
 github.com/livepeer/joy4 v0.1.1 h1:Tz7gVcmvpG/nfUKHU+XJn6Qke/k32mTWMiH9qB0bhnM=
 github.com/livepeer/joy4 v0.1.1/go.mod h1:xkDdm+akniYxVT9KW1Y2Y7Hso6aW+rZObz3nrA9yTHw=
 github.com/livepeer/livepeer-data v0.8.1 h1:FOlCGbV0ws9hY+F88MZmQhLuvPn5nyl1vuKNWaxCW3c=

--- a/handlers/playback.go
+++ b/handlers/playback.go
@@ -82,7 +82,7 @@ func (p *PlaybackHandler) Handle(w http.ResponseWriter, req *http.Request, param
 func handleError(err error, req *http.Request, requestID string, w http.ResponseWriter) {
 	log.LogError(requestID, "error in playback handler", err, "url", req.URL)
 	switch {
-	case catErrs.IsObjectNotFound(err):
+	case errors.Is(err, catErrs.ObjectNotFoundError):
 		catErrs.WriteHTTPNotFound(w, "not found", nil)
 	case errors.Is(err, catErrs.UnauthorisedError):
 		catErrs.WriteHTTPUnauthorized(w, "denied", nil)

--- a/playback/playback.go
+++ b/playback/playback.go
@@ -7,8 +7,11 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/grafov/m3u8"
 	"github.com/livepeer/catalyst-api/clients"
+	caterrs "github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/go-tools/drivers"
 )
 
@@ -117,7 +120,13 @@ func osFetch(buckets []*url.URL, playbackID, file, byteRange string) (*drivers.F
 			return f, nil
 		}
 		// if this is the final bucket in the list then the error set here will be used in the final return
-		err = fmt.Errorf("failed to get file for playback: %w", err)
+		var awsErr awserr.Error
+		if errors.As(err, &awsErr) && awsErr.Code() == s3.ErrCodeNoSuchKey ||
+			strings.Contains(err.Error(), "no such file") {
+			err = fmt.Errorf("invalid request: %w %v", caterrs.ObjectNotFoundError, err)
+		} else {
+			err = fmt.Errorf("failed to get file for playback: %w", err)
+		}
 	}
 	return nil, err
 }

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -538,7 +538,7 @@ func transcodeSegment(
 		defer cancel()
 		rc, err := clients.GetFile(ctx, transcodeRequest.RequestID, segment.Input.URL.String(), nil)
 		if err != nil {
-			return fmt.Errorf("failed to download source segment %q: %w", segment.Input, err)
+			return fmt.Errorf("failed to download source segment %q: %s", segment.Input, err)
 		}
 		defer rc.Close()
 


### PR DESCRIPTION
Need to figure out the retry logic before re-rolling this. Sometimes we need to retry 404s due to eventual consistency of storage.

This reverts commit 7a3e994b944d3dbf6ca4e67d21e8bc7fe99ad3f3.