### PR TITLE
Add Mist authentication

### DIFF
--- a/main.go
+++ b/main.go
@@ -175,10 +175,6 @@ func main() {
 		return
 	}
 
-	if cli.MistUser != "" || cli.MistPassword != "" {
-		glog.Warning("DEPRECATION NOTICE: mist-user and mist-password are no longer used and will be removed in a later version")
-	}
-
 	// TODO: I don't love the global variables for these
 	config.ImportIPFSGatewayURLs = cli.ImportIPFSGatewayURLs
 	config.ImportArweaveGatewayURLs = cli.ImportArweaveGatewayURLs


### PR DESCRIPTION
We need to enable running catalyst-api on a separate machine to where Mist is running. If Mist is run on a non-localhost machine, it requires a single authentication request. This PR adds an authentication if the command send to Mist failed.

Related to Zero Impact Catalyst API Deployments, we want to run catalyst-api separately to Mist.

Design Doc: https://www.notion.so/livepeer/Zero-Impact-Catalyst-API-Deployments-c2b15232f3a2450ba3e4803130ecd2be?pvs=4#5ce68dfca1c341bfb6b21361d36d19df