### PR TITLE
Use constant port for MistUtilLoad and reconcile periodically to make sure it's running

### DIFF
--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -19,7 +19,6 @@ import (
 	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/balancer"
 	"github.com/livepeer/catalyst-api/cluster"
-	"golang.org/x/sync/errgroup"
 )
 
 var mistUtilLoadSingleRequestTimeout = 15 * time.Second
@@ -50,14 +49,12 @@ func NewBalancer(config *balancer.Config) balancer.Balancer {
 
 // start this load balancer instance, execing MistUtilLoad if necessary
 func (b *MistBalancer) Start(ctx context.Context) error {
-	group, ctx := errgroup.WithContext(ctx)
-	group.Go(func() error {
-		return b.execBalancer(ctx, b.config.Args)
-	})
-	group.Go(func() error {
-		return b.waitForStartup(ctx)
-	})
-	return group.Wait()
+	b.killPreviousBalancer(ctx)
+
+	go func() {
+		b.reconcileBalancerLoop(ctx, b.config.Args)
+	}()
+	return b.waitForStartup(ctx)
 }
 
 // wait for the mist LB to be available. can be called multiple times.
@@ -243,6 +240,45 @@ func (b *MistBalancer) getMistLoadBalancerServers(ctx context.Context) (map[stri
 // commonly this means catalyst-0.example.com --> https://catalyst-0.example.com:443
 func (b *MistBalancer) formatNodeAddress(server string) string {
 	return fmt.Sprintf(b.config.MistLoadBalancerTemplate, server)
+}
+
+// killPreviousBalancer cleans up the previous MistUtilLoad process if it exists.
+// It uses pkill to kill the process.
+func (b *MistBalancer) killPreviousBalancer(ctx context.Context) {
+	cmd := exec.CommandContext(ctx, "pkill", "-f", "MistUtilLoad")
+	cmd.Run()
+}
+
+// reconcileBalancerLoop makes sure that MistUtilLoad is up and running all the time.
+func (b *MistBalancer) reconcileBalancerLoop(ctx context.Context, balancerArgs []string) {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		b.reconcileBalancer(ctx, balancerArgs)
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// reconcileBalancer makes sure that MistUtilLoad is up and running.
+func (b *MistBalancer) reconcileBalancer(ctx context.Context, balancerArgs []string) {
+	if !b.isBalancerRunning(ctx) {
+		err := b.execBalancer(ctx, balancerArgs)
+		if err != nil {
+			glog.Warningf("Error starting MistUtilLoad: %v", err)
+		}
+	}
+}
+
+// isBalancerRunning checks if MistUtilLoad is running.
+func (b *MistBalancer) isBalancerRunning(ctx context.Context) bool {
+	cmd := exec.CommandContext(ctx, "pgrep", "-f", "MistUtilLoad")
+	err := cmd.Run()
+	return err == nil
 }
 
 func (b *MistBalancer) execBalancer(ctx context.Context, balancerArgs []string) error {

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -267,6 +267,7 @@ func (b *MistBalancer) reconcileBalancerLoop(ctx context.Context, balancerArgs [
 // reconcileBalancer makes sure that MistUtilLoad is up and running.
 func (b *MistBalancer) reconcileBalancer(ctx context.Context, balancerArgs []string) {
 	if !b.isBalancerRunning(ctx) {
+		glog.Info("Starting MistUtilLoad")
 		err := b.execBalancer(ctx, balancerArgs)
 		if err != nil {
 			glog.Warningf("Error starting MistUtilLoad: %v", err)

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -246,7 +246,10 @@ func (b *MistBalancer) formatNodeAddress(server string) string {
 // It uses pkill to kill the process.
 func (b *MistBalancer) killPreviousBalancer(ctx context.Context) {
 	cmd := exec.CommandContext(ctx, "pkill", "-f", "MistUtilLoad")
-	cmd.Run()
+	err := cmd.Run()
+	if err != nil {
+		glog.V(6).Infof("Killing MistUtilLoad failed, most probably it was not running, err=%v", err)
+	}
 }
 
 // reconcileBalancerLoop makes sure that MistUtilLoad is up and running all the time.

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -51,7 +51,7 @@ type Member struct {
 	Status string            `json:"status"`
 }
 
-var mediaFilter = map[string]string{"node": "media"}
+var MediaFilter = map[string]string{"node": "media"}
 
 // Create a connection to a new Cluster that will immediately connect
 func NewCluster(config *config.Cli) Cluster {
@@ -328,7 +328,7 @@ func (c *ClusterImpl) handleEvents(ctx context.Context) error {
 			return nil
 		}
 
-		members, err := c.MembersFiltered(mediaFilter, "alive", "")
+		members, err := c.MembersFiltered(MediaFilter, "alive", "")
 
 		if err != nil {
 			glog.Errorf("Error getting serf, crashing: %v\n", err)

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math/rand"
 	"os"
 	"os/signal"
 	"strings"
@@ -111,7 +110,7 @@ func main() {
 	fs.Float64Var(&cli.NodeLongitude, "node-longitude", 0, "Longitude of this Catalyst node. Used for load balancing.")
 	config.CommaSliceFlag(fs, &cli.RedirectPrefixes, "redirect-prefixes", []string{}, "Set of valid prefixes of playback id which are handled by mistserver")
 	config.CommaMapFlag(fs, &cli.Tags, "tags", map[string]string{"node": "media"}, "Serf tags for Catalyst nodes")
-	fs.IntVar(&cli.MistLoadBalancerPort, "mist-load-balancer-port", rand.Intn(10000)+40000, "MistUtilLoad port (default random)")
+	fs.IntVar(&cli.MistLoadBalancerPort, "mist-load-balancer-port", 40010, "MistUtilLoad port (default random)")
 	fs.StringVar(&cli.MistLoadBalancerTemplate, "mist-load-balancer-template", "http://%s:4242", "template for specifying the host that should be queried for Prometheus stat output for this node")
 	config.CommaSliceFlag(fs, &cli.RetryJoin, "retry-join", []string{}, "An agent to join with. This flag be specified multiple times. Does not exit on failure like -join, used to retry until success.")
 	fs.StringVar(&cli.EncryptKey, "encrypt", "", "Key for encrypting network traffic within Serf. Must be a base64-encoded 32-byte key.")


### PR DESCRIPTION
The context for this change is that we sometimes see multiple MistUtilLoad instances running, sometimes zero instances running. Therefore we should always make sure that only 1 instance is running all the time.

This change will also make simpler to implement Zero Impact Catalyst API Deployments, because we'll statically configure MistUtilPort. Additionally, this change includes periodic members refresh (in case the serf member event is missed).

Design Doc: https://www.notion.so/livepeer/Zero-Impact-Catalyst-API-Deployments-c2b15232f3a2450ba3e4803130ecd2be?pvs=4#5ce68dfca1c341bfb6b21361d36d19df

Tagging @iameli , because you may remember the context of why we're running MistUtilLoad using a random port.