### PR TITLE
Refactor cluster abstraction: remove Member() and ResolveNodeURL()

### DIFF
--- a/handlers/geolocation/geolocation_test.go
+++ b/handlers/geolocation/geolocation_test.go
@@ -36,6 +36,7 @@ var fakeSerfMember = cluster.Member{
 		"https": fmt.Sprintf("https://%s", closestNodeAddr),
 		"dtsc":  fmt.Sprintf("dtsc://%s", closestNodeAddr),
 	},
+	Status: "alive",
 }
 
 var prefixes = [...]string{"video", "videorec", "stream", "playback", "vod"}
@@ -158,15 +159,10 @@ func mockHandlers(t *testing.T) *GeolocationHandlersCollection {
 		Return("", "", errors.New(""))
 
 	mc.EXPECT().
-		Member(map[string]string{}, "alive", closestNodeAddr).
+		MembersFiltered(map[string]string{}, gomock.Any(), closestNodeAddr).
 		AnyTimes().
-		Return(fakeSerfMember, nil)
+		Return([]cluster.Member{fakeSerfMember}, nil)
 
-	mc.EXPECT().
-		ResolveNodeURL(gomock.Any()).DoAndReturn(func(streamURL string) (string, error) {
-		return cluster.ResolveNodeURL(mc, streamURL)
-	}).
-		AnyTimes()
 	coll := GeolocationHandlersCollection{
 		Balancer: mb,
 		Cluster:  mc,


### PR DESCRIPTION
This change is refactoring-only, it does not introduce any functional changes.

It improves the Cluster interface abstraction, two of its functions were used only inside geolocation, so it's better to move it there and keep it package-private.

This change is related to the Zero Impact Catalyst API Deployments, because I plan to make a split between stateful and stateless catalyst-api at the cluster level. 

Design Doc: https://www.notion.so/livepeer/Zero-Impact-Catalyst-API-Deployments-c2b15232f3a2450ba3e4803130ecd2be?pvs=4#5ce68dfca1c341bfb6b21361d36d19df