### PR TITLE
Add Docker build

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,76 @@
+name: Build and publish catalyst-api docker images
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - dev
+    tags:
+      - "v*"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    name: Build and publish docker image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.CI_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.CI_DOCKERHUB_TOKEN }}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            livepeer/${{ github.event.repository.name }}
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=pr
+            type=ref,event=tag
+            type=sha,format=long
+            type=ref,event=branch
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ github.event.pull_request.head.ref }}
+            type=raw,value=stable,enable=${{ startsWith(github.event.ref, 'refs/tags/v') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          platforms: linux/amd64, linux/arm64
+          push: true
+          build-args: |
+            version=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Notify new build upload
+        run: curl -X POST https://holy-bread-207a.livepeer.workers.dev

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            livepeer/${{ github.event.repository.name }}
+            livepeerci/${{ github.event.repository.name }}
             ghcr.io/${{ github.repository }}
           tags: |
             type=sha
@@ -66,7 +66,7 @@ jobs:
           platforms: linux/amd64, linux/arm64
           push: true
           build-args: |
-            version=${{ github.ref_type == 'tag' && github.ref_name || github.sha }}
+            GIT_VERSION=${{ github.ref_type == 'tag' && github.ref_name || github.event.pull_request.head.sha || github.sha }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,6 @@ FROM	golang:1-bullseye	as	gobuild
 
 ARG TARGETARCH
 
-# Download c2patool needed to sign our C2PA manifest
-# We download it from any of our previous builds, because building c2patool from source is very slow with QEMU
-RUN	apt update && apt install -yqq \
-	curl \
-	ca-certificates \
-	&& curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz \
-	&& tar xzf /c2patool.tar.gz
-
 WORKDIR	/src
 
 ADD	go.mod go.sum	./
@@ -39,6 +31,5 @@ RUN	apt update && apt install -yqq \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=gobuild		/src/build/catalyst-api /bin/catalyst-api
-COPY --from=gobuild		/go/c2patool /bin/
 
 CMD ["/bin/catalyst-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,18 +29,13 @@ LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
 
 ARG	BUILD_TARGET
 
-RUN	apt update && apt install -yqq wget software-properties-common \
-	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
+RUN	apt update && apt install -yqq wget software-properties-common
 
 RUN	apt update && apt install -yqq \
 	curl \
 	ca-certificates \
-	musl \
-	python3 \
 	procps \
 	vnstat \
-	ffmpeg \
-	gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base gstreamer1.0-plugins-bad \
 	&& rm -rf /var/lib/apt/lists/*
 
 COPY --from=gobuild		/src/build/catalyst-api /bin/catalyst-api

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+ARG	GIT_VERSION=unknown
+ARG	BUILD_TARGET
+ARG	FROM_LOCAL_PARENT
+
+FROM	golang:1-bullseye	as	gobuild
+
+ARG TARGETARCH
+
+# Download c2patool needed to sign our C2PA manifest
+# We download it from any of our previous builds, because building c2patool from source is very slow with QEMU
+RUN	apt update && apt install -yqq \
+	curl \
+	ca-certificates \
+	&& curl https://build.livepeer.live/c2patool/0.6.2/c2patool-linux-${TARGETARCH}.tar.gz -o /c2patool.tar.gz \
+	&& tar xzf /c2patool.tar.gz
+
+WORKDIR	/src
+
+ADD	go.mod go.sum	./
+RUN	go mod download
+
+ADD	.	.
+RUN make build
+
+ARG	GIT_VERSION
+ENV	GIT_VERSION="${GIT_VERSION}"
+
+FROM	ubuntu:22.04	AS	catalyst
+
+ENV	DEBIAN_FRONTEND=noninteractive
+
+LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
+
+ARG	BUILD_TARGET
+
+RUN	apt update && apt install -yqq wget software-properties-common \
+	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
+
+RUN	apt update && apt install -yqq \
+	curl \
+	ca-certificates \
+	musl \
+	python3 \
+	procps \
+	vnstat \
+	ffmpeg \
+	gstreamer1.0-tools gstreamer1.0-plugins-good gstreamer1.0-plugins-base gstreamer1.0-plugins-bad \
+	&& rm -rf /var/lib/apt/lists/*
+
+COPY --from=gobuild		/src/build/catalyst-api /bin/catalyst-api
+COPY --from=gobuild		/go/c2patool /bin/
+
+CMD ["/bin/catalyst-api"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,3 @@
-ARG	GIT_VERSION=unknown
-ARG	BUILD_TARGET
-ARG	FROM_LOCAL_PARENT
-
 FROM	golang:1-bullseye	as	gobuild
 
 ARG TARGETARCH
@@ -34,7 +30,7 @@ LABEL	maintainer="Amritanshu Varshney <amritanshu+github@livepeer.org>"
 ARG	BUILD_TARGET
 
 RUN	apt update && apt install -yqq wget software-properties-common \
-	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg6
+	&& add-apt-repository -y ppa:ubuntuhandbook1/ffmpeg7
 
 RUN	apt update && apt install -yqq \
 	curl \


### PR DESCRIPTION
We plan to enable running catalyst-api separately to catalyst, therefore it needs its own Docker image. 

Note that it I didn't include `w3` tool, because Web3 Storage has shut down, so we should remove the support for Web3 Storage.

Design Doc: https://www.notion.so/livepeer/Zero-Impact-Catalyst-API-Deployments-c2b15232f3a2450ba3e4803130ecd2be?pvs=4#5ce68dfca1c341bfb6b21361d36d19df

