### PR TITLE
Relax the condition for parsing AddrFlag

### DIFF
--- a/config/cli.go
+++ b/config/cli.go
@@ -155,13 +155,9 @@ func (cli *Cli) ParseLegacyEnv() {
 func AddrFlag(fs *flag.FlagSet, dest *string, name, value, usage string) {
 	*dest = value
 	fs.Func(name, usage, func(s string) error {
-		host, _, err := net.SplitHostPort(s)
+		_, _, err := net.SplitHostPort(s)
 		if err != nil {
 			return err
-		}
-		ip := net.ParseIP(host)
-		if ip == nil {
-			return fmt.Errorf("invalid address: %s", s)
 		}
 		*dest = s
 		return nil


### PR DESCRIPTION
With the existing check it's impossible to pass anything that is not resolved to an IP Address. In particular, it fails to run locally inside Docker container and parse 'host.docker.internal'.