### PR TITLE
Refactor SetupMistTrigger()

### DIFF
--- a/handlers/misttriggers/trigger_broker.go
+++ b/handlers/misttriggers/trigger_broker.go
@@ -29,7 +29,7 @@ import (
 //    handler for these sorts of triggers.
 
 type TriggerBroker interface {
-	SetupMistTriggers(clients.MistAPIClient) error
+	SetupMistTriggers(clients.MistAPIClient, string) error
 
 	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 	TriggerStreamBuffer(context.Context, *StreamBufferPayload)
@@ -87,9 +87,9 @@ var triggers = map[string]bool{
 	TRIGGER_STREAM_SOURCE:   true,
 }
 
-func (b *triggerBroker) SetupMistTriggers(mist clients.MistAPIClient) error {
+func (b *triggerBroker) SetupMistTriggers(mist clients.MistAPIClient, triggerCallback string) error {
 	for name, sync := range triggers {
-		err := mist.AddTrigger([]string{}, name, sync)
+		err := mist.AddTrigger([]string{}, name, triggerCallback, sync)
 		if err != nil {
 			return fmt.Errorf("error setting up mist trigger trigger=%s error=%w", name, err)
 		}

--- a/main.go
+++ b/main.go
@@ -253,10 +253,10 @@ func main() {
 
 	var mist clients.MistAPIClient
 	if cli.MistEnabled {
-		ownURL := fmt.Sprintf("%s/api/mist/trigger", cli.OwnInternalURL())
-		mist = clients.NewMistAPIClient(cli.MistUser, cli.MistPassword, cli.MistHost, cli.MistPort, ownURL)
+		mist = clients.NewMistAPIClient(cli.MistUser, cli.MistPassword, cli.MistHost, cli.MistPort)
 		if cli.MistTriggerSetup {
-			err := broker.SetupMistTriggers(mist)
+			ownURL := fmt.Sprintf("%s/api/mist/trigger", cli.OwnInternalURL())
+			err := broker.SetupMistTriggers(mist, ownURL)
 			if err != nil {
 				glog.Error("catalyst-api was unable to communicate with MistServer to set up its triggers.")
 				glog.Error("hint: are you trying to boot catalyst-api without Mist for development purposes? use the flag -no-mist")


### PR DESCRIPTION
This change is refactoring-only, no functional changes included.

The rationale is that MistClient can execute commands on any remote Mist server and setting up triggers (or having a field TriggerCallback) breaks this abstraction.