### PR TITLE
Allow using a remote MistUtilLoad for load balancing

### DIFF
--- a/balancer/mist/mist_balancer_test.go
+++ b/balancer/mist/mist_balancer_test.go
@@ -31,7 +31,6 @@ func start(t *testing.T) (*MistBalancer, *mockMistUtilLoad) {
 			OwnRegion:          "fra",
 			OwnRegionTagAdjust: 1000,
 		},
-		cmd:      nil,
 		endpoint: mul.Server.URL,
 	}
 	// Mock startup loop

--- a/main.go
+++ b/main.go
@@ -275,7 +275,7 @@ func main() {
 	c := cluster.NewCluster(&cli)
 
 	// Start balancer
-	mistBalancer := mist_balancer.NewBalancer(&balancer.Config{
+	mistBalancerConfig := &balancer.Config{
 		Args:                     cli.BalancerArgs,
 		MistUtilLoadPort:         uint32(cli.MistLoadBalancerPort),
 		MistLoadBalancerTemplate: cli.MistLoadBalancerTemplate,
@@ -284,7 +284,8 @@ func main() {
 		NodeName:                 cli.NodeName,
 		OwnRegion:                cli.OwnRegion,
 		OwnRegionTagAdjust:       cli.OwnRegionTagAdjust,
-	})
+	}
+	mistBalancer := mist_balancer.NewLocalBalancer(mistBalancerConfig)
 
 	bal := mistBalancer
 	if balancer.CombinedBalancerEnabled(cli.CataBalancer) {


### PR DESCRIPTION
We want to allow running catalyst-api separately to catalyst, so MistUtilLoad needs to be accessed remotely.

Design Doc: https://www.notion.so/livepeer/Zero-Impact-Catalyst-API-Deployments-c2b15232f3a2450ba3e4803130ecd2be