### PR TITLE
Add logging about reason for not generating an MP4

### DIFF
--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -323,18 +323,19 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 		if p.C2PA {
 			si.C2PA = c.C2PA
 		}
-		si.SourceFile = osTransferURL.String()  // OS URL used by mist
-		si.SignedSourceURL = signedNewSourceURL // http(s) URL used by mediaconvert
-		si.InputFileInfo = inputVideoProbe
-		si.GenerateMP4 = ShouldGenerateMP4(sourceURL, p.Mp4TargetURL, p.FragMp4TargetURL, p.Mp4OnlyShort, si.InputFileInfo.Duration)
-		si.DownloadDone = time.Now()
-
+		si.SourceFile = osTransferURL.String() // OS URL used by mist
 		log.AddContext(p.RequestID, "new_source_url", si.SourceFile)
+
+		si.SignedSourceURL = signedNewSourceURL // http(s) URL used by mediaconvert
 		log.AddContext(p.RequestID, "signed_url", si.SignedSourceURL)
 
-		if si.GenerateMP4 {
-			log.Log(si.RequestID, "MP4s will be generated", "duration", si.InputFileInfo.Duration)
-		}
+		si.InputFileInfo = inputVideoProbe
+
+		shouldGenerateMP4, reason := ShouldGenerateMP4(sourceURL, p.Mp4TargetURL, p.FragMp4TargetURL, p.Mp4OnlyShort, si.InputFileInfo.Duration)
+		log.Log(si.RequestID, "Deciding whether to generate MP4s", "should_generate", shouldGenerateMP4, "duration", si.InputFileInfo.Duration, "reason", reason)
+		si.GenerateMP4 = shouldGenerateMP4
+
+		si.DownloadDone = time.Now()
 
 		c.startUploadJob(si)
 		return nil, nil
@@ -377,26 +378,26 @@ func checkClipResolution(p UploadJobPayload, inputVideoProbe *video.InputVideo, 
 	}
 }
 
-func ShouldGenerateMP4(sourceURL, mp4TargetUrl *url.URL, fragMp4TargetUrl *url.URL, mp4OnlyShort bool, durationSecs float64) bool {
+func ShouldGenerateMP4(sourceURL, mp4TargetUrl *url.URL, fragMp4TargetUrl *url.URL, mp4OnlyShort bool, durationSecs float64) (bool, string) {
 	// Skip mp4 generation if we weren't able to determine the duration of the input file for any reason
 	if durationSecs == 0.0 {
-		return false
+		return false, "duration is missing or zero"
 	}
 	// We're currently memory-bound for generating MP4s above a certain file size
 	// This has been hitting us for long recordings, so do a crude "is it longer than 12 hours?" check and skip the MP4 if it is
 	if clients.IsHLSInput(sourceURL) && durationSecs > maxRecordingMP4Duration.Seconds() {
-		return false
+		return false, "recording duration is too long"
 	}
 
 	if mp4TargetUrl != nil && (!mp4OnlyShort || durationSecs <= maxMP4OutDuration.Seconds()) {
-		return true
+		return true, "input asset duration is too long"
 	}
 
-	if fragMp4TargetUrl != nil {
-		return true
+	if fragMp4TargetUrl == nil {
+		return false, "missing MP4 target URL"
 	}
 
-	return false
+	return true, ""
 }
 
 func (c *Coordinator) startUploadJob(p *JobInfo) {

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -390,7 +390,7 @@ func ShouldGenerateMP4(sourceURL, mp4TargetUrl *url.URL, fragMp4TargetUrl *url.U
 	}
 
 	if mp4TargetUrl != nil && (!mp4OnlyShort || durationSecs <= maxMP4OutDuration.Seconds()) {
-		return true, "input asset duration is too long"
+		return true, ""
 	}
 
 	if fragMp4TargetUrl == nil {

--- a/pipeline/coordinator_test.go
+++ b/pipeline/coordinator_test.go
@@ -794,69 +794,36 @@ func TestMP4Generation(t *testing.T) {
 	fragMp4TargetURL, err := url.Parse("http://not-a-real-domain.lol/target/target.m3u8")
 	require.NoError(t, err)
 
-	require.False(
-		t,
-		ShouldGenerateMP4(mp4SourceURL, nil, nil, true, 60),
-		"Should NOT generate an MP4 if the MP4 target URL isn't present",
-	)
+	should, _ := ShouldGenerateMP4(mp4SourceURL, nil, nil, true, 60)
+	require.False(t, should, "Should NOT generate an MP4 if the MP4 target URL isn't present")
 
-	require.True(
-		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, fragMp4TargetURL, true, 60),
-		"SHOULD generate an MP4 for a short source MP4 input even if 'only short MP4s' mode is enabled",
-	)
+	should, _ = ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, fragMp4TargetURL, true, 60)
+	require.True(t, should, "SHOULD generate an MP4 for a short source MP4 input even if 'only short MP4s' mode is enabled")
 
-	require.True(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60),
-		"SHOULD generate an MP4 for a short source HLS input even if 'only short MP4s' mode is enabled",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60)
+	require.True(t, should, "SHOULD generate an MP4 for a short source HLS input even if 'only short MP4s' mode is enabled")
 
-	require.False(
-		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, true, 60*10),
-		"Should NOT generate an MP4 for a long source MP4 input if 'only short MP4s' mode is enabled",
-	)
+	should, _ = ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, true, 60*10)
+	require.False(t, should, "Should NOT generate an MP4 for a long source MP4 input if 'only short MP4s' mode is enabled")
 
-	require.False(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60*10),
-		"Should NOT generate an MP4 for a long source HLS input if 'only short MP4s' mode is enabled",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, true, 60*10)
+	require.False(t, should, "Should NOT generate an MP4 for a long source HLS input if 'only short MP4s' mode is enabled")
 
-	require.True(
-		t,
-		ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, false, 60*10),
-		"SHOULD generate an MP4 for a long source MP4 input if 'only short MP4s' mode is disabled",
-	)
+	should, _ = ShouldGenerateMP4(mp4SourceURL, mp4TargetURL, nil, false, 60*10)
+	require.True(t, should, "SHOULD generate an MP4 for a long source MP4 input if 'only short MP4s' mode is disabled")
 
-	require.True(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*10),
-		"SHOULD generate an MP4 for a long source HLS input if 'only short MP4s' mode is disabled",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*10)
+	require.True(t, should, "SHOULD generate an MP4 for a long source HLS input if 'only short MP4s' mode is disabled")
 
-	require.False(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*60*13),
-		"SHOULD NOT generate an MP4 for a VERY long source HLS input even if 'only short MP4s' mode is disabled",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, nil, false, 60*60*13)
+	require.False(t, should, "SHOULD NOT generate an MP4 for a VERY long source HLS input even if 'only short MP4s' mode is disabled")
 
-	require.True(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, nil, fragMp4TargetURL, false, 60*60*1),
-		"SHOULD generate an MP4 for a fragmented Mp4 regardless of 'only short MP4s' mode",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, nil, fragMp4TargetURL, false, 60*60*1)
+	require.True(t, should, "SHOULD generate an MP4 for a fragmented Mp4 regardless of 'only short MP4s' mode")
 
-	require.False(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, nil, nil, false, 60*60*13),
-		"SHOULD NOT generate an MP4 if no valid mp4 or fmp4 URL was provided",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, nil, nil, false, 60*60*13)
+	require.False(t, should, "SHOULD NOT generate an MP4 if no valid mp4 or fmp4 URL was provided")
 
-	require.False(
-		t,
-		ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, fragMp4TargetURL, false, 0),
-		"SHOULD NOT generate an MP4 if duration is 0 regardless of a valid mp4/fmp4 URL",
-	)
+	should, _ = ShouldGenerateMP4(hlsSourceURL, mp4TargetURL, fragMp4TargetURL, false, 0)
+	require.False(t, should, "SHOULD NOT generate an MP4 if duration is 0 regardless of a valid mp4/fmp4 URL")
 }


### PR DESCRIPTION
Currently there's no way of distinguishing between the different reasons when MP4 generation doesn't happen and so this extra logging means we will now always be able to differentiate.