### PR TITLE
Improve handling Kafka write errors

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -114,7 +114,7 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 		}
 		geo, err := parseAnalyticsGeo(r)
 		if err != nil {
-			glog.Warning("error parsing geo info from analytics log request header, err=%v", err)
+			glog.Warning("cannot parse geo info from analytics log request header, err=%v", err)
 		}
 		extData, err := c.extFetcher.Fetch(log.PlaybackID)
 		if err != nil {

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	GeoHashPrecision     = 3
-	LogChannelBufferSize = 5000
+	LogChannelBufferSize = 25000
 )
 
 type AnalyticsLog struct {

--- a/handlers/analytics/log_processor.go
+++ b/handlers/analytics/log_processor.go
@@ -184,7 +184,7 @@ func (p *LogProcessor) sendEvents() {
 
 	// We retry sending messages to Kafka in case of a failure
 	// We don't use any backoff, because the number of events are filling up very quickly, so in case of a failure
-	// it's better to lose analytics logs than fill up the memory and crashing the whole catalyst-api
+	// it's better to lose analytics logs than fill up the memory and crash the whole catalyst-api
 	kafkaWriteRetries := 3
 	var err error
 	for i := 0; i < kafkaWriteRetries; i++ {


### PR DESCRIPTION
**Improvements:**
1. Increase the internal buffer size from 5000 analytics logs to 25000 analytics logs (this will delay the 5xx to more Kafka write errors before we start to see them)
2. Update warning message to not include a word `error`
3. Add retries to writing messages to Kafka

Fix https://linear.app/livepeer/issue/PS-721/5xx-alerts-sto-prod-catalyst-4lp-playbackstudio-prod-catalyst-4