### PR TITLE
Cache also errors when caching lapi.GetStreamByPlaybackID()

### DIFF
--- a/mapic/utils.go
+++ b/mapic/utils.go
@@ -32,7 +32,7 @@ type entry struct {
 func (a *ApiClientCached) GetStreamByPlaybackID(playbackId string) (*api.Stream, error) {
 	a.mu.RLock()
 	e, ok := a.streamCache[playbackId]
-	if ok && e.stream != nil && e.updateAt.Add(a.ttl).After(time.Now()) {
+	if ok && e.updateAt.Add(a.ttl).After(time.Now()) {
 		// Use cached value
 		a.mu.RUnlock()
 		return e.stream, e.err
@@ -44,7 +44,7 @@ func (a *ApiClientCached) GetStreamByPlaybackID(playbackId string) (*api.Stream,
 	defer a.mu.Unlock()
 	// Check again in case another goroutine has updated the cache in the meantime
 	e, ok = a.streamCache[playbackId]
-	if ok && e.stream != nil && e.updateAt.Add(a.ttl).After(time.Now()) {
+	if ok && e.updateAt.Add(a.ttl).After(time.Now()) {
 		return e.stream, e.err
 	}
 	// No value in the cache, fetch from Livepeer API and store the result in a cache


### PR DESCRIPTION
@victorges  made a good comment after I already merged https://github.com/livepeer/catalyst-api/pull/1342

> don't we need to remove the e.stream != nil check from L35 and L47 if we want to cache errors?
https://github.com/livepeer/catalyst-api/pull/1339/files#diff-3ab4c68e5efa7f23725f338aae519ee0613c23dd471ecc3a45ac4f0488bd985cR35
i mean. we are caching errors. we're just not using that cache haha