### PR TITLE
Improvements for Zero Impact Catalyst API Deployments

### DIFF
--- a/api/http_internal.go
+++ b/api/http_internal.go
@@ -29,8 +29,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
-func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker, metricsDB *sql.DB, serfMembersEndpoint string) error {
-	router := NewCatalystAPIRouterInternal(cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint)
+func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker, metricsDB *sql.DB, serfMembersEndpoint, eventsEndpoint string) error {
+	router := NewCatalystAPIRouterInternal(cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint, eventsEndpoint)
 	server := http.Server{Addr: cli.HTTPInternalAddress, Handler: router}
 	ctx, cancel := context.WithCancel(ctx)
 
@@ -56,7 +56,7 @@ func ListenAndServeInternal(ctx context.Context, cli config.Cli, vodEngine *pipe
 	return server.Shutdown(ctx)
 }
 
-func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker, metricsDB *sql.DB, serfMembersEndpoint string) *httprouter.Router {
+func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinator, mapic mistapiconnector.IMac, bal balancer.Balancer, c cluster.Cluster, broker misttriggers.TriggerBroker, metricsDB *sql.DB, serfMembersEndpoint, eventsEndpoint string) *httprouter.Router {
 	router := httprouter.New()
 	withLogging := middleware.LogRequest()
 	withAuth := middleware.IsAuthorized
@@ -73,7 +73,7 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 	spkiPublicKey, _ := crypto.ConvertToSpki(cli.VodDecryptPublicKey)
 
 	catalystApiHandlers := &handlers.CatalystAPIHandlersCollection{VODEngine: vodEngine}
-	eventsHandler := handlers.NewEventsHandlersCollection(c, mapic, bal)
+	eventsHandler := handlers.NewEventsHandlersCollection(c, mapic, bal, eventsEndpoint)
 	ffmpegSegmentingHandlers := &ffmpeg.HandlersCollection{VODEngine: vodEngine}
 	accessControlHandlers := accesscontrol.NewAccessControlHandlersCollection(cli, mapic)
 	analyticsHandlers := analytics.NewAnalyticsHandler(metricsDB)
@@ -139,6 +139,8 @@ func NewCatalystAPIRouterInternal(cli config.Cli, vodEngine *pipeline.Coordinato
 		router.GET("/api/serf/members", withLogging(adminHandlers.MembersHandler()))
 		// Public handler to propagate an event to all Catalyst nodes, execute from Studio API => Catalyst
 		router.POST("/api/events", withLogging(eventsHandler.Events()))
+	} else {
+		router.POST("/api/events", withLogging(eventsHandler.ProxyEvents()))
 	}
 
 	return router

--- a/config/cli.go
+++ b/config/cli.go
@@ -74,6 +74,7 @@ type Cli struct {
 	KafkaPassword             string
 	AnalyticsKafkaTopic       string
 	SerfMembersEndpoint       string
+	EventsEndpoint            string
 	CatalystApiURL            string
 
 	// mapping playbackId to value between 0.0 to 100.0

--- a/handlers/events.go
+++ b/handlers/events.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"github.com/golang/glog"
@@ -85,16 +84,8 @@ func (d *EventsHandlersCollection) Events() httprouter.Handle {
 func (d *EventsHandlersCollection) ProxyEvents() httprouter.Handle {
 	// Proxy the request to d.eventsEndpoint
 	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-		// Read the request body
-		body, err := io.ReadAll(req.Body)
-		if err != nil {
-			glog.Errorf("Cannot read request body: %s", err)
-			errors.WriteHTTPBadRequest(w, "Cannot read request body", err)
-			return
-		}
-
 		// Create a new request to the target endpoint
-		proxyReq, err := http.NewRequest(req.Method, d.eventsEndpoint, bytes.NewReader(body))
+		proxyReq, err := http.NewRequest(req.Method, d.eventsEndpoint, req.Body)
 		if err != nil {
 			glog.Errorf("Cannot create proxy request: %s", err)
 			errors.WriteHTTPInternalServerError(w, "Cannot create proxy request", err)

--- a/handlers/events_test.go
+++ b/handlers/events_test.go
@@ -63,7 +63,7 @@ func TestEventHandler(t *testing.T) {
 		return nil
 	}).AnyTimes()
 
-	catalystApiHandlers := NewEventsHandlersCollection(mc, nil, nil)
+	catalystApiHandlers := NewEventsHandlersCollection(mc, nil, nil, "")
 	router := httprouter.New()
 	router.POST("/events", catalystApiHandlers.Events())
 
@@ -114,7 +114,7 @@ func TestReceiveUserEventHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mac := mock_mistapiconnector.NewMockIMac(ctrl)
 
-	catalystApiHandlers := NewEventsHandlersCollection(nil, mac, nil)
+	catalystApiHandlers := NewEventsHandlersCollection(nil, mac, nil, "")
 	router := httprouter.New()
 	router.POST("/receiveUserEvent", catalystApiHandlers.ReceiveUserEvent())
 

--- a/main.go
+++ b/main.go
@@ -374,7 +374,7 @@ func resolveCatalystApiURL(cli config.Cli) interface{} {
 		// the whole catalyst node
 		hostname := os.Getenv("HOSTNAME")            // e.g. "staging-catalyst-0"
 		ecosystem := strings.Split(hostname, "-")[0] // e.g. "staging"
-		return fmt.Sprintf("%s-catalyst-api-%s", ecosystem, hostname)
+		return fmt.Sprintf("http://%s-catalyst-api-%s:7979", ecosystem, hostname)
 	}
 	// not used for other modes
 	return ""

--- a/main.go
+++ b/main.go
@@ -209,6 +209,8 @@ func main() {
 	broker = misttriggers.NewTriggerBroker()
 
 	catalystApiURL := resolveCatalystApiURL(cli)
+	glog.Infof("Using Catalyst API URL: %s", catalystApiURL)
+
 	serfMembersEndpoint := cli.SerfMembersEndpoint
 	if serfMembersEndpoint == "" {
 		serfMembersEndpoint = cli.OwnInternalURL() + "/api/serf/members"

--- a/main.go
+++ b/main.go
@@ -133,6 +133,7 @@ func main() {
 	fs.StringVar(&cli.KafkaPassword, "kafka-password", "", "Kafka Password")
 	fs.StringVar(&cli.AnalyticsKafkaTopic, "analytics-kafka-topic", "", "Kafka Topic used to send analytics logs")
 	fs.StringVar(&cli.SerfMembersEndpoint, "serf-members-endpoint", "", "Endpoint to get the current members in the cluster")
+	fs.StringVar(&cli.EventsEndpoint, "events-endpoint", "", "Endpoint to send proxied events from catalyst-api into catalyst")
 	fs.StringVar(&cli.CatalystApiURL, "catalyst-api-url", "", "Endpoint for externally deployed catalyst-api; if not set, use local catalyst-api")
 	pprofPort := fs.Int("pprof-port", 6061, "Pprof listen port")
 
@@ -350,7 +351,7 @@ func main() {
 	})
 
 	group.Go(func() error {
-		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint)
+		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint, cli.EventsEndpoint)
 	})
 
 	err = group.Wait()


### PR DESCRIPTION
This PR includes 2 ugly changes that are needed to deploy catalyst-api separately from catalyst:

### Change 1: Proxy `/api/events` requests

The events are used, e.g.,  to notify multistream target change and to nuke a stream. They are received in catalyst, then propagated to all nodes using Serf, and then forwarded to each catalyst-api instance. The change included here is to expose `/api/events` not only in catalyst, but also in catalyst-api (which then proxies the request to catalyst). It's needed because Studio API communicates events with catalyst-api (not directly with catalyst).

Alternatively, we could have two catalyst params in Studio API (but I think it would be "even more" ugly.

### Change 2: Hack to resolve Catalyst API URL if not specified

Catalyst needs to communicate with each corresponding Statelss Catalyst API. E.g. `staging-catalyst-0` needs to communicate with `staging-catalyst-api-0`. At first I thought it will be just an env variable, but then I realized that to introduce a new env variable we need to restart each catalyst node 🤦 . So to avoid restarting, I added a dirty hack to resolve dynamically the corresponding catalyst-api instance in the code (if not specified).