### PR TITLE
Better method for detecting clipping requests

### DIFF
--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -109,9 +109,7 @@ func (r UploadVODRequest) IsProfileValid() bool {
 }
 
 func (r UploadVODRequest) IsClippingRequest() bool {
-	return r.hasTargetOutput(func(o UploadVODRequestOutputLocationOutputs) string {
-		return o.Clip
-	})
+	return r.ClipStrategy.PlaybackID != ""
 }
 
 func (r UploadVODRequest) ValidateClippingRequest() error {
@@ -164,15 +162,6 @@ func (r UploadVODRequest) getSourceCopyEnabled() bool {
 }
 
 type getOutput func(UploadVODRequestOutputLocationOutputs) string
-
-func (r UploadVODRequest) hasTargetOutput(getOutput getOutput) bool {
-	for _, o := range r.OutputLocations {
-		if getOutput(o.Outputs) == "enabled" {
-			return true
-		}
-	}
-	return false
-}
 
 func (r UploadVODRequest) getTargetOutput(getOutput getOutput) UploadVODRequestOutputLocation {
 	for _, o := range r.OutputLocations {

--- a/handlers/upload_test.go
+++ b/handlers/upload_test.go
@@ -200,31 +200,13 @@ func TestIsProfileValid(t *testing.T) {
 
 func TestWeCanDetermineIfItsAClippingRequest(t *testing.T) {
 	u := UploadVODRequest{
-		OutputLocations: []UploadVODRequestOutputLocation{
-			{
-				URL:  "some-url",
-				Type: "clip",
-				Outputs: UploadVODRequestOutputLocationOutputs{
-					Clip: "enabled",
-				},
-			},
+		ClipStrategy: video.ClipStrategy{
+			PlaybackID: "12345",
 		},
 	}
 	require.True(t, u.IsClippingRequest())
 
-	u = UploadVODRequest{
-		OutputLocations: []UploadVODRequestOutputLocation{
-			{
-				URL:  "some-url",
-				Type: "vod",
-				Outputs: UploadVODRequestOutputLocationOutputs{
-					HLS:        "enabled",
-					MP4:        "enabled",
-					Thumbnails: "enabled",
-				},
-			},
-		},
-	}
+	u = UploadVODRequest{}
 	require.False(t, u.IsClippingRequest())
 }
 


### PR DESCRIPTION
It turns out that Studio doesn't pass in a "clip" output in the request, but it does always have a Playback ID in the clipping strategy, so use that instead.