### PR TITLE
Give up on remaining analytics messages when we fail to push to the buffer

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -123,13 +123,15 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 			cerrors.WriteHTTPBadRequest(w, "Invalid playback_id", nil)
 		}
 
-		for _, ad := range c.toAnalyticsData(log, geo, extData) {
+		data := c.toAnalyticsData(log, geo, extData)
+		for i, ad := range data {
 			select {
 			case dataCh <- ad:
 				// process data async
 			default:
-				glog.Warningf("error processing analytics log, too many requests")
+				glog.Warningf("error processing analytics log, too many requests. Failed to write %d lines", len(data)-i)
 				cerrors.WriteHTTPInternalServerError(w, "error processing analytics log, too many requests", nil)
+				return
 			}
 		}
 	}

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -129,7 +129,12 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 			case dataCh <- ad:
 				// process data async
 			default:
-				glog.Warningf("error processing analytics log, too many requests. Failed to write %d lines", len(data)-i)
+				// Do some counting up of the different message types to give us a better picture of what's going on here
+				msgTypes := map[string]int{}
+				for _, msg := range data {
+					msgTypes[msg.EventType] += 1
+				}
+				glog.Warningf("error processing analytics log, too many requests. Failed to write %d lines. Message types: %v", len(data)-i, msgTypes)
 				cerrors.WriteHTTPInternalServerError(w, "error processing analytics log, too many requests", nil)
 				return
 			}


### PR DESCRIPTION
This is to avoid spamming log lines and to ease pressure in situations where we're getting thousands of messages spammed simultaneously.

Also adds more info to the log line to try and understand the root cause of what we're getting spammed with.