### PR TITLE
analytics.go: Fix typo in error message formatting

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -114,12 +114,12 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 		}
 		geo, err := parseAnalyticsGeo(r)
 		if err != nil {
-			glog.Warning("cannot parse geo info from analytics log request header, err=%v", err)
+			glog.Warningf("cannot parse geo info from analytics log request header, err=%v", err)
 		}
 		extData, err := c.extFetcher.Fetch(log.PlaybackID)
 		if err != nil {
 			metrics.Metrics.AnalyticsMetrics.AnalyticsLogsErrors.Inc()
-			glog.Warning("error enriching analytics log with external data, err=%v", err)
+			glog.Warningf("error enriching analytics log with external data, err=%v", err)
 			cerrors.WriteHTTPBadRequest(w, "Invalid playback_id", nil)
 		}
 


### PR DESCRIPTION
i was getting tired of seeing `%v` appear in logs:
```
W0731 05:15:49.119430 2566432 analytics.go:117] cannot parse geo info from analytics log request header, err=%vmissing geo headers: [X-Region-Name]
```