### PR TITLE
Log internal errors rather than returning them to requester

### DIFF
--- a/clients/broadcaster_local.go
+++ b/clients/broadcaster_local.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+
+	"github.com/livepeer/catalyst-api/log"
 )
 
 // Currently only implemented by LocalBroadcasterClient
@@ -20,7 +22,7 @@ type LocalBroadcasterClient struct {
 func NewLocalBroadcasterClient(broadcasterURL string) (BroadcasterClient, error) {
 	u, err := url.Parse(broadcasterURL)
 	if err != nil {
-		return &LocalBroadcasterClient{}, fmt.Errorf("error parsing local broadcaster URL %q: %s", broadcasterURL, err)
+		return &LocalBroadcasterClient{}, fmt.Errorf("error parsing local broadcaster URL %q: %s", log.RedactURL(broadcasterURL), err)
 	}
 	return &LocalBroadcasterClient{
 		broadcasterURL: *u,

--- a/clients/callback_client.go
+++ b/clients/callback_client.go
@@ -176,12 +176,12 @@ func (pcc *PeriodicCallbackClient) doWithRetries(r *http.Request) error {
 
 	resp, err := metrics.MonitorRequest(metrics.Metrics.TranscodingStatusUpdate, pcc.httpClient, r)
 	if err != nil {
-		return fmt.Errorf("failed to send callback to %q. Error: %s", r.URL.String(), err)
+		return fmt.Errorf("failed to send callback to %q. Error: %s", r.URL.Redacted(), err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode >= 400 {
-		return fmt.Errorf("failed to send callback to %q. HTTP Code: %d", r.URL.String(), resp.StatusCode)
+		return fmt.Errorf("failed to send callback to %q. HTTP Code: %d", r.URL.Redacted(), resp.StatusCode)
 	}
 
 	return nil

--- a/pipeline/coordinator.go
+++ b/pipeline/coordinator.go
@@ -303,7 +303,7 @@ func (c *Coordinator) StartUploadJob(p UploadJobPayload) {
 					// Use new clipped manifest as the source URL
 					clipSourceURL, err := clients.ClipInputManifest(p.RequestID, sourceURL.String(), p.ClipTargetURL.String(), p.ClipStrategy.StartTime, p.ClipStrategy.EndTime)
 					if err != nil {
-						return fmt.Errorf("clipping failed: %s %w", sourceURL, err)
+						return fmt.Errorf("clipping failed: %s %w", sourceURL.Redacted(), err)
 					}
 					sourceURL = clipSourceURL
 					return nil

--- a/pipeline/ffmpeg.go
+++ b/pipeline/ffmpeg.go
@@ -311,7 +311,7 @@ func (f *ffmpeg) probeSourceSegment(requestID string, seg *m3u8.MediaSegment, so
 	}
 	probeURL, err := clients.SignURL(u)
 	if err != nil {
-		return fmt.Errorf("failed to create signed url for %s: %w", u, err)
+		return fmt.Errorf("failed to create signed url for %s: %w", u.Redacted(), err)
 	}
 	if err := backoff.Retry(func() error {
 		_, err = f.probe.ProbeFile(requestID, probeURL)
@@ -350,7 +350,7 @@ func copyFileToLocalTmpAndSegment(job *JobInfo) (string, error) {
 		defer cancel()
 		_, err = clients.CopyFile(timeout, job.SignedSourceURL, localSourceFile.Name(), "", job.RequestID)
 		if err != nil {
-			return fmt.Errorf("failed to copy file (%s) locally for segmenting: %s", job.SignedSourceURL, err)
+			return fmt.Errorf("failed to copy file (%s) locally for segmenting: %s", log.RedactURL(job.SignedSourceURL), err)
 		}
 		return nil
 	}, retries(6)); err != nil {

--- a/transcode/transcode.go
+++ b/transcode/transcode.go
@@ -113,7 +113,7 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 	lastSegment := sourceSegmentURLs[len(sourceSegmentURLs)-1]
 	lastSegmentURL, err := clients.SignURL(lastSegment.URL)
 	if err != nil {
-		return outputs, segmentsCount, fmt.Errorf("failed to create signed url for last segment %s: %w", lastSegment.URL, err)
+		return outputs, segmentsCount, fmt.Errorf("failed to create signed url for last segment %s: %w", lastSegment.URL.Redacted(), err)
 	}
 	// ignore the following probe errors when checking the last segment
 	var ignoreProbeErrs = []string{
@@ -397,13 +397,13 @@ func RunTranscodeProcess(transcodeRequest TranscodeSegmentRequest, streamName st
 				var err error
 				probeURL, err = clients.SignURL(mp4TargetUrl)
 				if err != nil {
-					return outputs, segmentsCount, fmt.Errorf("failed to create signed url for %s: %w", mp4TargetUrl, err)
+					return outputs, segmentsCount, fmt.Errorf("failed to create signed url for %s: %w", mp4TargetUrl.Redacted(), err)
 				}
 			}
 			// Populate OutputVideo structs with results from probing step to send back in final response to Studio
 			mp4Out, err = video.PopulateOutput(transcodeRequest.RequestID, video.Probe{}, probeURL, mp4Out)
 			if err != nil {
-				return outputs, segmentsCount, fmt.Errorf("failed to populate output for %s: %w", probeURL, err)
+				return outputs, segmentsCount, fmt.Errorf("failed to populate output for %s: %w", log.RedactURL(probeURL), err)
 			}
 			mp4Outputs = append(mp4Outputs, mp4Out)
 		}
@@ -657,7 +657,7 @@ func processTranscodeResult(
 
 		targetRenditionURL, err := url.JoinPath(targetOSURL.String(), profile.Name)
 		if err != nil {
-			return fmt.Errorf("error building rendition segment URL %q: %s", targetRenditionURL, err)
+			return fmt.Errorf("error building rendition segment URL %q: %s", log.RedactURL(targetRenditionURL), err)
 		}
 
 		if transcodeRequest.GenerateMP4 {


### PR DESCRIPTION
If we return internal error messages to the requester there is the possibility to reveal internal secrets etc so we should just log them instead. This will also be more useful for debugging since we can query logs for this info.