### PR TITLE
analytics: Don't log on missing X-Region-Name header

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -116,7 +116,7 @@ func (c *AnalyticsHandlersCollection) Log() httprouter.Handle {
 		}
 		geo, err := parseAnalyticsGeo(r)
 		if err != nil {
-			glog.Warningf("cannot parse geo info from analytics log request header, err=%v", err)
+			glog.Warningf("cannot parse geo info from analytics log request header, %v", err)
 		}
 		extData, err := c.extFetcher.Fetch(log.PlaybackID)
 		if err != nil {

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -171,7 +171,8 @@ func parseAnalyticsGeo(r *http.Request) (AnalyticsGeo, error) {
 	res.Country, missingHeader = getOrAddMissing("X-City-Country-Name", r.Header, missingHeader)
 	res.CountryCode, missingHeader = getOrAddMissing("X-City-Country-Code", r.Header, missingHeader)
 	res.Continent = analytics.GetContinent(res.CountryCode)
-	res.Subdivision, missingHeader = getOrAddMissing("X-Region-Name", r.Header, missingHeader)
+	// X-Region-Name is optional, so we don't add it into missingHeader map if missing
+	res.Subdivision = r.Header.Get("X-Region-Name")
 	res.Timezone, missingHeader = getOrAddMissing("X-Time-Zone", r.Header, missingHeader)
 
 	lat, missingHeader := getOrAddMissing("X-Latitude", r.Header, missingHeader)

--- a/handlers/analytics_test.go
+++ b/handlers/analytics_test.go
@@ -394,7 +394,6 @@ func TestParseAnalyticsGeo(t *testing.T) {
 			},
 			wantErrorContains: []string{
 				"missing geo headers",
-				"X-Region-Name",
 				"X-Time-Zone",
 			},
 		},


### PR DESCRIPTION
Geo header X-Region-Name is not available in all regions, therefore we should treat it as optional.