### PR TITLE
Fix thumbs for recording fallback

### DIFF
--- a/clients/input_copy.go
+++ b/clients/input_copy.go
@@ -64,14 +64,14 @@ func (s *InputCopy) CopyInputToS3(requestID string, inputFile, osTransferURL *ur
 		}
 	}
 
-	log.Log(requestID, "starting probe", "source", inputFile.String(), "dest", osTransferURL.String())
+	log.Log(requestID, "starting probe", "source", inputFile.Redacted(), "dest", osTransferURL.Redacted())
 	inputFileProbe, err := s.Probe.ProbeFile(requestID, signedURL, "-analyzeduration", "15000000")
 	if err != nil {
-		log.Log(requestID, "probe failed", "err", err, "source", inputFile.String(), "dest", osTransferURL.String())
+		log.Log(requestID, "probe failed", "err", err, "source", inputFile.Redacted(), "dest", osTransferURL.Redacted())
 		return video.InputVideo{}, "", fmt.Errorf("error probing MP4 input file from S3: %w", err)
 	}
 
-	log.Log(requestID, "probe succeeded", "source", inputFile.String(), "dest", osTransferURL.String())
+	log.Log(requestID, "probe succeeded", "source", inputFile.Redacted(), "dest", osTransferURL.Redacted())
 	videoTrack, err := inputFileProbe.GetTrack(video.TrackTypeVideo)
 	hasVideoTrack := err == nil
 	// verify the duration of the video track and don't process if we can't determine duration
@@ -229,7 +229,7 @@ func CopyAllInputFiles(requestID string, srcInputUrl, dstOutputUrl *url.URL, dec
 		}
 		byteCount += size
 	}
-	log.Log(requestID, "Copied", "bytes", byteCount, "source", srcInputUrl.String(), "dest", dstOutputUrl.String())
+	log.Log(requestID, "Copied", "bytes", byteCount, "source", srcInputUrl.Redacted(), "dest", dstOutputUrl.Redacted())
 	return nil
 }
 


### PR DESCRIPTION
Thumbnails were broken for recording fallback because it wasn't expecting absolute URLs in the manifest.

Also tweaked the fallback logic to just return the original manifest URL if everything was found on the primary, I kinda prefer to keep the happy path using the same manifest we're used to rather than writing a new playlist for every recording job. There may be weird edge cases like this thumbnails issue, and would rather keep the normal happy path unchanged in that way.