### PR TITLE
Implement percentage node replacement for load balancer

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -126,4 +126,8 @@ type Config struct {
 	MistHost                 string
 	OwnRegion                string
 	OwnRegionTagAdjust       int
+
+	ReplaceHostMatch   string
+	ReplaceHostList    []string
+	ReplaceHostPercent int
 }

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -371,6 +371,7 @@ func (b *MistBalancer) GetBestNode(ctx context.Context, redirectPrefixes []strin
 	// good path: we found the stream and a good node to play it back, yay!
 	if nodeAddr != "" {
 		if b.config.ReplaceHostMatch != "" && len(b.config.ReplaceHostList) > 0 && rand.Intn(100) < b.config.ReplaceHostPercent {
+			// replace the host for a percentage of requests based on the configured replacement list, choosing a random host from that list
 			if strings.Contains(nodeHostRegex.FindString(nodeAddr), b.config.ReplaceHostMatch) {
 				nodeAddr = nodeHostRegex.ReplaceAllString(nodeAddr, b.config.ReplaceHostList[rand.Intn(len(b.config.ReplaceHostList))]+".")
 			}

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -372,7 +372,7 @@ func (b *MistBalancer) GetBestNode(ctx context.Context, redirectPrefixes []strin
 	if nodeAddr != "" {
 		if b.config.ReplaceHostMatch != "" && len(b.config.ReplaceHostList) > 0 && rand.Intn(100) < b.config.ReplaceHostPercent {
 			if strings.Contains(nodeHostRegex.FindString(nodeAddr), b.config.ReplaceHostMatch) {
-				nodeAddr = nodeHostRegex.ReplaceAllString(nodeAddr, b.config.ReplaceHostList[rand.Intn(len(b.config.ReplaceHostList))])
+				nodeAddr = nodeHostRegex.ReplaceAllString(nodeAddr, b.config.ReplaceHostList[rand.Intn(len(b.config.ReplaceHostList))]+".")
 			}
 		}
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -91,6 +91,10 @@ type Cli struct {
 	SerfQueueSize                   int
 	SerfEventBuffer                 int
 	SerfMaxQueueDepth               int
+
+	LBReplaceHostMatch   string
+	LBReplaceHostPercent int
+	LBReplaceHostList    []string
 }
 
 // Return our own URL for callback trigger purposes

--- a/handlers/healthcheck.go
+++ b/handlers/healthcheck.go
@@ -2,7 +2,6 @@ package handlers
 
 import (
 	"encoding/json"
-	"io"
 	"net/http"
 
 	"github.com/julienschmidt/httprouter"
@@ -27,7 +26,7 @@ func (d *CatalystAPIHandlersCollection) Healthcheck() httprouter.Handle {
 			b = []byte(`{"status": "marshalling status failed"}`)
 		}
 
-		if _, err := io.WriteString(w, string(b)); err != nil {
+		if _, err := w.Write(b); err != nil {
 			log.LogNoRequestID("Failed to write HTTP response for " + req.URL.RawPath)
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -135,6 +135,9 @@ func main() {
 	fs.StringVar(&cli.SerfMembersEndpoint, "serf-members-endpoint", "", "Endpoint to get the current members in the cluster")
 	fs.StringVar(&cli.EventsEndpoint, "events-endpoint", "", "Endpoint to send proxied events from catalyst-api into catalyst")
 	fs.StringVar(&cli.CatalystApiURL, "catalyst-api-url", "", "Endpoint for externally deployed catalyst-api; if not set, use local catalyst-api")
+	fs.StringVar(&cli.LBReplaceHostMatch, "lb-replace-host-match", "", "What to match on the hostname for node replacement e.g. sto")
+	config.CommaSliceFlag(fs, &cli.LBReplaceHostList, "lb-replace-host-list", []string{}, "List of hostnames to replace with for node replacement")
+	fs.IntVar(&cli.LBReplaceHostPercent, "lb-replace-host-percent", 0, "Percentage of matching requests to replace host on")
 	pprofPort := fs.Int("pprof-port", 6061, "Pprof listen port")
 
 	fs.String("send-audio", "", "[DEPRECATED] ignored, will be removed")
@@ -205,6 +208,10 @@ func main() {
 		NodeName:                 cli.NodeName,
 		OwnRegion:                cli.OwnRegion,
 		OwnRegionTagAdjust:       cli.OwnRegionTagAdjust,
+
+		ReplaceHostMatch:   cli.LBReplaceHostMatch,
+		ReplaceHostPercent: cli.LBReplaceHostPercent,
+		ReplaceHostList:    cli.LBReplaceHostList,
 	}
 	broker = misttriggers.NewTriggerBroker()
 


### PR DESCRIPTION
This is a hack to allow us to re-route a portion of traffic from an overloaded region to alternative nodes. We have a region where we'd like to balance more traffic away from onto alternative regions instead.

For example to re-route 25% of `regionX` to a selection of other nodes:
```
lb-replace-host-match = regionX
lb-replace-host-percent = 25
lb-replace-host-list = otherNode1,otherNode2
```