### PR TITLE
Proxy Mist triggers from catalyst to catalyst-api and remove dynamic Mist Trigger Setup

### DIFF
--- a/handlers/events.go
+++ b/handlers/events.go
@@ -79,31 +79,6 @@ func (d *EventsHandlersCollection) Events() httprouter.Handle {
 	}
 }
 
-// ProxyEvents is a handler of Catalyst API called by Studio API.
-// It proxies the requests to Catalyst.
-func (d *EventsHandlersCollection) ProxyEvents() httprouter.Handle {
-	// Proxy the request to d.eventsEndpoint
-	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-		// Create a new request to the target endpoint
-		proxyReq, err := http.NewRequest(req.Method, d.eventsEndpoint, req.Body)
-		if err != nil {
-			glog.Errorf("Cannot create proxy request: %s", err)
-			errors.WriteHTTPInternalServerError(w, "Cannot create proxy request", err)
-			return
-		}
-
-		// Send the request to the target endpoint
-		client := &http.Client{}
-		resp, err := client.Do(proxyReq)
-		if err != nil {
-			glog.Errorf("Cannot send proxy request: %s", err)
-			errors.WriteHTTPInternalServerError(w, "Cannot send proxy request", err)
-			return
-		}
-		defer resp.Body.Close()
-	}
-}
-
 // ReceiveUserEvent is a handler to receive Serf events from Catalyst.
 // The idea is that:
 // 1. Studio API sends an event to Catalyst (received by Events() handler)

--- a/handlers/misttriggers/trigger_broker.go
+++ b/handlers/misttriggers/trigger_broker.go
@@ -72,17 +72,6 @@ type triggerBroker struct {
 	streamSourceFuncs  funcGroup[StreamSourcePayload]
 }
 
-var triggers = map[string]bool{
-	TRIGGER_PUSH_END:        false,
-	TRIGGER_PUSH_OUT_START:  true,
-	TRIGGER_PUSH_REWRITE:    true,
-	TRIGGER_STREAM_BUFFER:   false,
-	TRIGGER_LIVE_TRACK_LIST: false,
-	TRIGGER_USER_NEW:        true,
-	TRIGGER_USER_END:        false,
-	TRIGGER_STREAM_SOURCE:   true,
-}
-
 func (b *triggerBroker) OnStreamBuffer(cb func(context.Context, *StreamBufferPayload) error) {
 	b.streamBufferFuncs.RegisterNoResponse(cb)
 }

--- a/handlers/misttriggers/trigger_broker.go
+++ b/handlers/misttriggers/trigger_broker.go
@@ -2,11 +2,9 @@ package misttriggers
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
 	"github.com/golang/glog"
-	"github.com/livepeer/catalyst-api/clients"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -29,8 +27,6 @@ import (
 //    handler for these sorts of triggers.
 
 type TriggerBroker interface {
-	SetupMistTriggers(clients.MistAPIClient, string) error
-
 	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 	TriggerStreamBuffer(context.Context, *StreamBufferPayload)
 
@@ -85,16 +81,6 @@ var triggers = map[string]bool{
 	TRIGGER_USER_NEW:        true,
 	TRIGGER_USER_END:        false,
 	TRIGGER_STREAM_SOURCE:   true,
-}
-
-func (b *triggerBroker) SetupMistTriggers(mist clients.MistAPIClient, triggerCallback string) error {
-	for name, sync := range triggers {
-		err := mist.AddTrigger([]string{}, name, triggerCallback, sync)
-		if err != nil {
-			return fmt.Errorf("error setting up mist trigger trigger=%s error=%w", name, err)
-		}
-	}
-	return nil
 }
 
 func (b *triggerBroker) OnStreamBuffer(cb func(context.Context, *StreamBufferPayload) error) {

--- a/handlers/proxy.go
+++ b/handlers/proxy.go
@@ -1,0 +1,48 @@
+package handlers
+
+import (
+	"io"
+	"net/http"
+
+	"github.com/golang/glog"
+	"github.com/julienschmidt/httprouter"
+	"github.com/livepeer/catalyst-api/errors"
+)
+
+// ProxyRequest proxies a request to a target endpoint
+func ProxyRequest(targetEndpoint string) httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+		// Create a new request to the target endpoint
+		proxyReq, err := http.NewRequest(req.Method, targetEndpoint, req.Body)
+		if err != nil {
+			glog.Errorf("Cannot create proxy request: %s", err)
+			errors.WriteHTTPInternalServerError(w, "Cannot create proxy request", err)
+			return
+		}
+		for k, v := range req.Header {
+			proxyReq.Header.Set(k, v[0])
+		}
+
+		// Send the request to the target endpoint
+		client := &http.Client{}
+		resp, err := client.Do(proxyReq)
+		if err != nil {
+			glog.Errorf("Cannot send proxy request: %s", err)
+			errors.WriteHTTPInternalServerError(w, "Cannot send proxy request", err)
+			return
+		}
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			glog.Errorf("Cannot read response body: %s", err)
+			errors.WriteHTTPInternalServerError(w, "Cannot read response body", err)
+			return
+		}
+		for k, v := range resp.Header {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(resp.StatusCode)
+		w.Write(body) // nolint:errcheck
+	}
+}

--- a/main.go
+++ b/main.go
@@ -317,17 +317,6 @@ func main() {
 	}
 
 	if cli.IsClusterMode() {
-		// Configure Mist Triggers
-		if cli.MistEnabled && cli.MistTriggerSetup {
-			mistTriggerHandlerEndpoint := fmt.Sprintf("%s/api/mist/trigger", catalystApiURL)
-			err := broker.SetupMistTriggers(mist, mistTriggerHandlerEndpoint)
-			if err != nil {
-				glog.Error("catalyst-api was unable to communicate with MistServer to set up its triggers.")
-				glog.Error("hint: are you trying to boot catalyst-api without Mist for development purposes? use the flag -no-mist")
-				glog.Fatalf("error setting up Mist triggers err=%s", err)
-			}
-		}
-
 		// Start cron style apps to run periodically
 		if cli.ShouldMistCleanup() {
 			app := "mist-cleanup.sh"
@@ -360,14 +349,14 @@ func main() {
 	})
 
 	group.Go(func() error {
-		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint, cli.EventsEndpoint)
+		return api.ListenAndServeInternal(ctx, cli, vodEngine, mapic, bal, c, broker, metricsDB, serfMembersEndpoint, cli.EventsEndpoint, catalystApiURL)
 	})
 
 	err = group.Wait()
 	glog.Infof("Shutdown complete. Reason for shutdown: %s", err)
 }
 
-func resolveCatalystApiURL(cli config.Cli) interface{} {
+func resolveCatalystApiURL(cli config.Cli) string {
 	if cli.CatalystApiURL != "" {
 		return cli.CatalystApiURL
 	}


### PR DESCRIPTION
I always thought that catalyst-api dynamically sets Mist triggers. This is true, but this config gets overwritten with the default config present [here](https://github.com/livepeer/livepeer-infra/blob/a82a30fcd185fc6b9fc3fa52412c8608725b47c4/values/catalyst.values.yaml#L191) every time MistController restarts of the config file is changed. The only reason it worked in prod is that our dynamic Mist Trigger configuration is exactly the same as the config map configuration.

I think it's super misleading and it led to the issues when I tried to use the standalone catalyst-api, because my config got overwritten and all stopped working at some point.

-----

First of all, I suggest removing this whole dynamic mist triggers setup (to avoid further confusion). Secondly, we need to think how to solve it if catalyst-api is deployed separately.

1. Option 1: What I implemented in this PR => Proxy each Mist trigger request from catalyst to catalyst-api
2. Option 2: Monitor Mist triggers and dynamically override them each time the config changes
3. Option 3: Investigate it further, maybe if we remove the Mist triggers configuration from [here](https://github.com/livepeer/livepeer-infra/blob/a82a30fcd185fc6b9fc3fa52412c8608725b47c4/values/catalyst.values.yaml#L191) it will not override the dynamically set configuration; the reason I didn't start from this option is that I'm afraid we'll come to some corner cases like Mist crashing or something and then we'll end up with Mist with no triggers set up at all
4. Option 4: Have a separate config map for each catalyst pod (then we can differentiate between triggers in the infra config)