### PR TITLE
geo redirect: Redirect self-node in case of "127.0.0.1" (not MistHost)

### DIFF
--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -421,7 +421,7 @@ func (b *MistBalancer) MistUtilLoadBalance(ctx context.Context, stream, lat, lon
 		return "", err
 	}
 	// Special case: rewrite our local node to our public node url
-	if str == b.config.MistHost {
+	if str == "127.0.0.1" {
 		str = b.config.NodeName
 	}
 	return str, nil

--- a/balancer/mist/mist_balancer_test.go
+++ b/balancer/mist/mist_balancer_test.go
@@ -26,7 +26,7 @@ func start(t *testing.T) (*MistBalancer, *mockMistUtilLoad) {
 
 	b := &MistBalancer{
 		config: &balancer.Config{
-			MistHost:           u.Hostname(),
+			MistHost:           "127.0.0.1",
 			MistPort:           port,
 			OwnRegion:          "fra",
 			OwnRegionTagAdjust: 1000,


### PR DESCRIPTION
When catalyst-api is deployed standalone, then MistHost is not "127.0.0.1" and this redirect does not work