### PR TITLE
Revert removal of dynamic Mist trigger setup

### DIFF
--- a/handlers/misttriggers/trigger_broker.go
+++ b/handlers/misttriggers/trigger_broker.go
@@ -2,6 +2,8 @@ package misttriggers
 
 import (
 	"context"
+	"fmt"
+	"github.com/livepeer/catalyst-api/clients"
 	"sync"
 
 	"github.com/golang/glog"
@@ -27,6 +29,8 @@ import (
 //    handler for these sorts of triggers.
 
 type TriggerBroker interface {
+	SetupMistTriggers(clients.MistAPIClient, string) error
+
 	OnStreamBuffer(func(context.Context, *StreamBufferPayload) error)
 	TriggerStreamBuffer(context.Context, *StreamBufferPayload)
 
@@ -70,6 +74,27 @@ type triggerBroker struct {
 	userNewFuncs       funcGroup[UserNewPayload]
 	userEndFuncs       funcGroup[UserEndPayload]
 	streamSourceFuncs  funcGroup[StreamSourcePayload]
+}
+
+var triggers = map[string]bool{
+	TRIGGER_PUSH_END:        false,
+	TRIGGER_PUSH_OUT_START:  true,
+	TRIGGER_PUSH_REWRITE:    true,
+	TRIGGER_STREAM_BUFFER:   false,
+	TRIGGER_LIVE_TRACK_LIST: false,
+	TRIGGER_USER_NEW:        true,
+	TRIGGER_USER_END:        false,
+	TRIGGER_STREAM_SOURCE:   true,
+}
+
+func (b *triggerBroker) SetupMistTriggers(mist clients.MistAPIClient, triggerCallback string) error {
+	for name, sync := range triggers {
+		err := mist.AddTrigger([]string{}, name, triggerCallback, sync)
+		if err != nil {
+			return fmt.Errorf("error setting up mist trigger trigger=%s error=%w", name, err)
+		}
+	}
+	return nil
 }
 
 func (b *triggerBroker) OnStreamBuffer(cb func(context.Context, *StreamBufferPayload) error) {

--- a/handlers/misttriggers/trigger_broker.go
+++ b/handlers/misttriggers/trigger_broker.go
@@ -3,10 +3,10 @@ package misttriggers
 import (
 	"context"
 	"fmt"
-	"github.com/livepeer/catalyst-api/clients"
 	"sync"
 
 	"github.com/golang/glog"
+	"github.com/livepeer/catalyst-api/clients"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/main.go
+++ b/main.go
@@ -319,7 +319,7 @@ func main() {
 	if cli.IsClusterMode() {
 		// Configure Mist Triggers
 		if cli.MistEnabled && cli.MistTriggerSetup {
-			mistTriggerHandlerEndpoint := fmt.Sprintf("%s/api/mist/trigger", catalystApiURL)
+			mistTriggerHandlerEndpoint := fmt.Sprintf("%s/api/mist/trigger", cli.OwnInternalURL())
 			err := broker.SetupMistTriggers(mist, mistTriggerHandlerEndpoint)
 			if err != nil {
 				glog.Error("catalyst-api was unable to communicate with MistServer to set up its triggers.")

--- a/main.go
+++ b/main.go
@@ -317,6 +317,17 @@ func main() {
 	}
 
 	if cli.IsClusterMode() {
+		// Configure Mist Triggers
+		if cli.MistEnabled && cli.MistTriggerSetup {
+			mistTriggerHandlerEndpoint := fmt.Sprintf("%s/api/mist/trigger", catalystApiURL)
+			err := broker.SetupMistTriggers(mist, mistTriggerHandlerEndpoint)
+			if err != nil {
+				glog.Error("catalyst-api was unable to communicate with MistServer to set up its triggers.")
+				glog.Error("hint: are you trying to boot catalyst-api without Mist for development purposes? use the flag -no-mist")
+				glog.Fatalf("error setting up Mist triggers err=%s", err)
+			}
+		}
+
 		// Start cron style apps to run periodically
 		if cli.ShouldMistCleanup() {
 			app := "mist-cleanup.sh"


### PR DESCRIPTION
This broke catalyst E2E Tests. I plan to fix it later, but for now let's revert this removal