### PR TITLE
Add 'catalyst=true' label to Mist-enriched metrics

### DIFF
--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -75,7 +75,7 @@ func (mc *mac) parsePlaybackID(line string) (string, bool) {
 
 func (mc *mac) enrichLabels(playbackID string) string {
 	res := mc.streamLabel(playbackID)
-	res += ",catalyst=true"
+	res += `,catalyst="true"`
 	si, err := mc.getStreamInfo(playbackID)
 	if err != nil {
 		glog.Warning("could not enrich Mist metrics for stream=%s err=%v", playbackID, err)

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -75,7 +75,7 @@ func (mc *mac) parsePlaybackID(line string) (string, bool) {
 
 func (mc *mac) enrichLabels(playbackID string) string {
 	res := mc.streamLabel(playbackID)
-	res += fmt.Sprintf(",catalyst=true")
+	res += ",catalyst=true"
 	si, err := mc.getStreamInfo(playbackID)
 	if err != nil {
 		glog.Warning("could not enrich Mist metrics for stream=%s err=%v", playbackID, err)

--- a/mapic/mistmetrics.go
+++ b/mapic/mistmetrics.go
@@ -75,6 +75,7 @@ func (mc *mac) parsePlaybackID(line string) (string, bool) {
 
 func (mc *mac) enrichLabels(playbackID string) string {
 	res := mc.streamLabel(playbackID)
+	res += fmt.Sprintf(",catalyst=true")
 	si, err := mc.getStreamInfo(playbackID)
 	if err != nil {
 		glog.Warning("could not enrich Mist metrics for stream=%s err=%v", playbackID, err)

--- a/mapic/mistmetrics_test.go
+++ b/mapic/mistmetrics_test.go
@@ -42,10 +42,10 @@ func TestEnrichMistMetrics(t *testing.T) {
 
 	expLines := []string{
 		`version{app="MistServer",version="729ddd4b42980d0124c72a46f13d8e0697293e94",release="Generic_x86_64"} 1`,
-		`mist_sessions{stream="video+077bh6xx5bx5tdua",catalyst=true,user_id="abcdefgh-123456789",sessType="viewers"}1`,
-		`mist_latency{stream="video+077bh6xx5bx5tdua",catalyst=true,user_id="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
-		`mist_sessions{stream="video+51b13mqy7sgw520w",catalyst=true,user_id="hgfedcba-987654321",sessType="viewers"}5`,
-		`mist_latency{stream="video+51b13mqy7sgw520w",catalyst=true,user_id="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
+		`mist_sessions{stream="video+077bh6xx5bx5tdua",catalyst="true",user_id="abcdefgh-123456789",sessType="viewers"}1`,
+		`mist_latency{stream="video+077bh6xx5bx5tdua",catalyst="true",user_id="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
+		`mist_sessions{stream="video+51b13mqy7sgw520w",catalyst="true",user_id="hgfedcba-987654321",sessType="viewers"}5`,
+		`mist_latency{stream="video+51b13mqy7sgw520w",catalyst="true",user_id="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
 	}
 	for _, exp := range expLines {
 		require.Contains(t, resLines, exp)

--- a/mapic/mistmetrics_test.go
+++ b/mapic/mistmetrics_test.go
@@ -42,10 +42,10 @@ func TestEnrichMistMetrics(t *testing.T) {
 
 	expLines := []string{
 		`version{app="MistServer",version="729ddd4b42980d0124c72a46f13d8e0697293e94",release="Generic_x86_64"} 1`,
-		`mist_sessions{stream="video+077bh6xx5bx5tdua",user_id="abcdefgh-123456789",sessType="viewers"}1`,
-		`mist_latency{stream="video+077bh6xx5bx5tdua",user_id="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
-		`mist_sessions{stream="video+51b13mqy7sgw520w",user_id="hgfedcba-987654321",sessType="viewers"}5`,
-		`mist_latency{stream="video+51b13mqy7sgw520w",user_id="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
+		`mist_sessions{stream="video+077bh6xx5bx5tdua",catalyst=true,user_id="abcdefgh-123456789",sessType="viewers"}1`,
+		`mist_latency{stream="video+077bh6xx5bx5tdua",catalyst=true,user_id="abcdefgh-123456789",source="sin-prod-catalyst-3.lp-playback.studio"}1795`,
+		`mist_sessions{stream="video+51b13mqy7sgw520w",catalyst=true,user_id="hgfedcba-987654321",sessType="viewers"}5`,
+		`mist_latency{stream="video+51b13mqy7sgw520w",catalyst=true,user_id="hgfedcba-987654321",source="prg-prod-catalyst-0.lp-playback.studio"}1156`,
 	}
 	for _, exp := range expLines {
 		require.Contains(t, resLines, exp)


### PR DESCRIPTION
When the catalyst-api was run inside catalyst, we used VM Agent to collect the metrics and then added the `catalyst=true` label in the [VM Agent config](https://github.com/livepeer/livepeer-infra/blob/89b7549035488359fee8761375ffba9e3b3c2856/values/catalyst.values.yaml#L176).

Now, for the standalone Catalyst API we use Kubernetes prometheus scrape which does not add this label. At the same time, we use this label in a really high number of charts, so the simple fix is to just add this label here.

An alternative would be to update all Grafana charts that use `catalyst=true` metric with a condition `app_kubernetes_io_name="catalyst-api"`. However I see there are really a lot of these charts, so I'm not sure there is a simple way to update  them all.