### PR TITLE
Add nil check for serf

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -184,6 +184,9 @@ func (c *ClusterImpl) retryJoin(ctx context.Context) {
 }
 
 func (c *ClusterImpl) MembersFiltered(filter map[string]string, status, name string) ([]Member, error) {
+	if c.serf == nil {
+		return nil, fmt.Errorf("serf not initialized")
+	}
 	return FilterMembers(toClusterMembers(c.serf.Members()), filter, status, name)
 }
 


### PR DESCRIPTION
Both the [reconcile loop](https://github.com/livepeer/catalyst-api/blob/eaa3c06f3dc0ca35eb8c6c2c0e42d3312164a333/main.go#L391) and the [code](https://github.com/livepeer/catalyst-api/blob/fd526881be1bf1a0c52073f426657a27fe14a7b3/cluster/cluster.go#L125) that initialises the `c.serf` variable start in parallel so there's a chance for `serf` to be nil when `MembersFiltered` is called.