### PR TITLE
Fix locking during session invalidation

### DIFF
--- a/clients/mist_client.go
+++ b/clients/mist_client.go
@@ -238,7 +238,9 @@ type MistPushStats struct {
 	Tracks        []int `json:"tracks"`
 }
 
-var mistRetryableClient = newRetryableClient(nil)
+const MIST_CLIENT_TIMEOUT = 1 * time.Minute
+
+var mistRetryableClient = newRetryableClient(&http.Client{Timeout: MIST_CLIENT_TIMEOUT})
 
 func (mc *MistClient) AddStream(streamName, sourceUrl string) error {
 	c := commandAddStream(streamName, sourceUrl)

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -139,6 +139,7 @@ func (ac *AccessControlHandlersCollection) periodicRefreshIntervalCache(mapic mi
 			ac.mutex.Unlock()
 
 			go func() {
+				glog.Infof("Invalidating sessions, count=%d", len(keysToInvalidate))
 				for _, key := range keysToInvalidate {
 					mapic.InvalidateAllSessions(key)
 				}

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -124,18 +124,23 @@ func (ac *AccessControlHandlersCollection) periodicRefreshIntervalCache(mapic mi
 			time.Sleep(5 * time.Second)
 			ac.mutex.Lock()
 			refreshIntervalCache.mux.Lock()
+			var keysToInvalidate []string
 			for key := range refreshIntervalCache.data {
 				if time.Since(refreshIntervalCache.data[key].LastRefresh) > time.Duration(refreshIntervalCache.data[key].RefreshInterval)*time.Second {
 					refreshIntervalCache.data[key].LastRefresh = time.Now()
-					mapic.InvalidateAllSessions(key)
+					keysToInvalidate = append(keysToInvalidate, key)
 					for cachedAccessKey := range ac.cache[key] {
 						delete(ac.cache[key], cachedAccessKey)
 					}
 					break
 				}
 			}
-			ac.mutex.Unlock()
 			refreshIntervalCache.mux.Unlock()
+			ac.mutex.Unlock()
+
+			for _, key := range keysToInvalidate {
+				mapic.InvalidateAllSessions(key)
+			}
 		}
 	}()
 }

--- a/handlers/accesscontrol/access-control.go
+++ b/handlers/accesscontrol/access-control.go
@@ -138,9 +138,11 @@ func (ac *AccessControlHandlersCollection) periodicRefreshIntervalCache(mapic mi
 			refreshIntervalCache.mux.Unlock()
 			ac.mutex.Unlock()
 
-			for _, key := range keysToInvalidate {
-				mapic.InvalidateAllSessions(key)
-			}
+			go func() {
+				for _, key := range keysToInvalidate {
+					mapic.InvalidateAllSessions(key)
+				}
+			}()
 		}
 	}()
 }


### PR DESCRIPTION
It addresses the problem we discovered during catalyst deployment.

### Solution
Execute session invalidate HTTP requests to Mist:
1. Outside locks
2. In a separate goroutine
3. With timeout

In theory any of these points would solve the issue, but it's better and safer to implement all of them.

### Problem Description

When we deployed catalyst, then in most cases `USER_NEW` trigger was blocked and we saw the following error:
```
MistOutFLV:video+9cfc2xmk4pvz6jo7 (958765) FAIL: STREAM_SOURCE trigger: http://127.0.0.1:7979/api/mist/trigger (blocking) failed to execute (Timed out), using default response: true
```

### Analysis what happened

1. In the [`periodicRefreshIntervalCache()` func](https://github.com/livepeer/catalyst-api/blob/fdad3c74a7bb39cc293523f505444994b7dfd976/handlers/accesscontrol/access-control.go#L121) we acquired a lock and made an HTTP call to Mist
2. The HTTP req does not have any timeout, so if Mist hasn't ever replied or closed the connection, then this hangs forever; that caused the lock to be acquired forever
3. The same lock is used in [handling `USER_NEW` trigger](https://github.com/livepeer/catalyst-api/blob/fdad3c74a7bb39cc293523f505444994b7dfd976/handlers/accesscontrol/access-control.go#L376), so in effect handling `USER_NEW` trigger timed out

I still don't understand why it hadn't happened when catalyst-api was embedded inside catalyst, but some possible explanations:
- We had always restarted the catalyst-api process during the Mist deployment
- Mist handles local HTTP requests differently than remote HTTP request; this is for sure true in terms of the authentication (local requests are not authenticated), but not sure why it could be different when it comes to keeping the connection open