### PR TITLE
Increase timeout for write permission check

### DIFF
--- a/clients/object_store_client.go
+++ b/clients/object_store_client.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -89,7 +88,7 @@ func UploadToOSURLFields(osURL, filename string, data io.Reader, timeout time.Du
 
 	if err != nil {
 		metrics.Metrics.ObjectStoreClient.FailureCount.WithLabelValues(host, "write", bucket).Inc()
-		return fmt.Errorf("failed to write to OS URL %q: %s", log.RedactURL(filepath.Join(osURL, filename)), err)
+		return fmt.Errorf("failed to write to OS URL %q: %s", log.RedactURL(osURL+"/"+filename), err)
 	}
 
 	duration := time.Since(start)

--- a/handlers/upload.go
+++ b/handlers/upload.go
@@ -360,7 +360,7 @@ func checkWritePermission(reqID, externalID string, urls ...*url.URL) error {
 
 		urlString := u.String()
 		// check write permission by uploading a file
-		err := clients.UploadToOSURL(u.String(), "metadata.json", strings.NewReader(fmt.Sprintf(`{"external_id": "%s"}`, externalID)), time.Second)
+		err := clients.UploadToOSURL(u.String(), "metadata.json", strings.NewReader(fmt.Sprintf(`{"external_id": "%s"}`, externalID)), 30*time.Second)
 		if err != nil {
 			log.LogError(reqID, "failed write permission check", err, "url", log.RedactURL(urlString))
 			return fmt.Errorf("failed write permission check for %s", log.RedactURL(urlString))


### PR DESCRIPTION
I'm seeing this fail occasionally in prod since storage providers can be a bit slow even with a small json file.
Also fixed creds leaking in log line, the filepath join was stripping a `/` on `http://` which meant the log redact function couldn't parse it as a url.