### PR TITLE
Fix VTT format

### DIFF
--- a/middleware/gating.go
+++ b/middleware/gating.go
@@ -62,7 +62,7 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 
 		playbackAccessControlAllowed, err := h.AccessControl.IsAuthorized(req.Context(), playbackID, &payload)
 		if err != nil {
-			log.LogError(requestID, "unable to get playback access control info", err, "playbackID", playbackID, "accessKey", accessKey, "jwt", jwt)
+			log.LogError(requestID, "unable to get playback access control info", err, "playbackID", playbackID, "accessKey", accessKey, "jwt", jwt, "url", req.URL.Redacted())
 			if errors.Is(err, catErrs.InvalidJWT) {
 				deny(params.ByName("file"), w)
 			} else {
@@ -72,7 +72,7 @@ func (h *GatingHandler) GatingCheck(next httprouter.Handle) httprouter.Handle {
 		}
 
 		if !playbackAccessControlAllowed {
-			log.Log(requestID, "playback access control denied", "playbackID", playbackID, "accessKey", accessKey, "jwt", jwt)
+			log.Log(requestID, "playback access control denied", "playbackID", playbackID, "accessKey", accessKey, "jwt", jwt, "url", req.URL.Redacted())
 			deny(params.ByName("file"), w)
 			return
 		}

--- a/thumbnails/thumbnails.go
+++ b/thumbnails/thumbnails.go
@@ -61,7 +61,7 @@ func GenerateThumbsVTT(requestID string, input string, output *url.URL) error {
 	const layout = "15:04:05.000"
 	outputLocation := output.JoinPath(outputDir)
 	builder := &bytes.Buffer{}
-	_, err = builder.WriteString("WEBVTT\n")
+	_, err = builder.WriteString("WEBVTT\n\n")
 	if err != nil {
 		return err
 	}

--- a/thumbnails/thumbnails_test.go
+++ b/thumbnails/thumbnails_test.go
@@ -103,6 +103,7 @@ func testGenerateThumbsRun(t *testing.T, outDir, input string) {
 	require.NoError(t, err)
 
 	expectedVtt := `WEBVTT
+
 00:00:00.000 --> 00:00:10.000
 keyframes_0.png
 


### PR DESCRIPTION
The VTT file should have had a blank line after the first line, it parses successfully in https://w3c.github.io/webvtt.js/parser.html now