### PR TITLE
Rename analytics field error_message => message

### DIFF
--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -284,7 +284,7 @@ func (c *AnalyticsHandlersCollection) toAnalyticsData(log *AnalyticsLog, geo Ana
 }
 
 func isSupportedEvent(eventType string) bool {
-	if eventType == "heartbeat" || eventType == "error" {
+	if eventType == "heartbeat" || eventType == "error" || eventType == "warning" {
 		return true
 	}
 	return false

--- a/handlers/analytics.go
+++ b/handlers/analytics.go
@@ -73,8 +73,8 @@ type AnalyticsLogEvent struct {
 	WindowWidthPX       *int    `json:"window_width_px"`
 
 	// Error event
-	ErrorMessage *string `json:"error_message"`
-	Category     *string `json:"category"`
+	Message  *string `json:"message"`
+	Category *string `json:"category"`
 }
 
 type AnalyticsGeo struct {
@@ -275,8 +275,8 @@ func (c *AnalyticsHandlersCollection) toAnalyticsData(log *AnalyticsLog, geo Ana
 				WindowHeightPX:      e.WindowHeightPX,
 				WindowWidthPX:       e.WindowWidthPX,
 
-				ErrorMessage: e.ErrorMessage,
-				Category:     e.Category,
+				Message:  e.Message,
+				Category: e.Category,
 			},
 		})
 	}
@@ -284,7 +284,7 @@ func (c *AnalyticsHandlersCollection) toAnalyticsData(log *AnalyticsLog, geo Ana
 }
 
 func isSupportedEvent(eventType string) bool {
-	if eventType == "heartbeat" || eventType == "error" || eventType == "warning" {
+	if eventType == "heartbeat" || eventType == "error" {
 		return true
 	}
 	return false

--- a/handlers/analytics/log_processor.go
+++ b/handlers/analytics/log_processor.go
@@ -52,8 +52,8 @@ type LogDataEvent struct {
 	WindowWidthPX       *int    `json:"window_width_px,omitempty"`
 
 	// Error event
-	ErrorMessage *string `json:"error_message,omitempty"`
-	Category     *string `json:"category,omitempty"`
+	Message  *string `json:"message,omitempty"`
+	Category *string `json:"category,omitempty"`
 }
 
 type LogData struct {

--- a/handlers/analytics_test.go
+++ b/handlers/analytics_test.go
@@ -88,7 +88,7 @@ func TestHandleLog(t *testing.T) {
 						"id": "abcde12345",
 						"type": "error",
 						"timestamp": 1234567895,
-						"error_message": "error message",
+						"message": "error message",
 						"category": "offline"
 					}
 				]
@@ -161,9 +161,9 @@ func TestHandleLog(t *testing.T) {
 					EventType:      "error",
 					EventTimestamp: 1234567895,
 					EventData: analytics.LogDataEvent{
-						ID:           strPtr("abcde12345"),
-						ErrorMessage: strPtr("error message"),
-						Category:     strPtr("offline"),
+						ID:       strPtr("abcde12345"),
+						Message:  strPtr("error message"),
+						Category: strPtr("offline"),
 					},
 				},
 			},

--- a/handlers/schemas/AnalyticsLog.yaml
+++ b/handlers/schemas/AnalyticsLog.yaml
@@ -45,7 +45,7 @@ properties:
             type: "integer"
           autoplay_status:
             type: "string"
-          error_message:
+          message:
             type: "string"
         required:
           - type


### PR DESCRIPTION
Player sends the field `message` (not `error_message`), so we need to update it so that it's correctly propagated to Kafka.