### PR TITLE
pod-mon.sh and mist-cleanup.sh to run forever even sometimes crashing

### DIFF
--- a/middleware/shell.go
+++ b/middleware/shell.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"sync"
 	"time"
+
+	"github.com/golang/glog"
 )
 
 type Shell struct {
@@ -39,8 +41,8 @@ func (s *Shell) RunBg() *time.Ticker {
 		for range ticker.C {
 			err := s.Run()
 			if err != nil {
-				log.Println("cmd: failed to start", s.Cmd)
-				break
+				glog.Errorf("cmd: failed to start %s", err)
+				continue
 			}
 		}
 	}()
@@ -61,6 +63,5 @@ func (s *Shell) Run() error {
 		return fmt.Errorf("cmd: failed to Run(): %s\n", err)
 	}
 	log.Printf("cmd: output: %s\n", out)
-
-	return err
+	return nil
 }


### PR DESCRIPTION
High CPU/memory are easier to investigate during the alert as we don't have per process CPU/memory usage metrics on grafana. There are just per-pod metrics and mist works as hundreds of processes, separate for ingest, playback, load-balancing, etc.

There are logs from [pod-mon.sh](https://github.com/livepeer/catalyst-api/blob/main/scripts/pod-mon.sh) that we start from [catalyst-api](https://github.com/livepeer/catalyst-api/blob/main/main.go#L343-L346) but I they started missing on [sto-1 and sto-3](https://eu-metrics-monitoring.livepeer.live/grafana/goto/i2-xLZGNR?orgId=1) for some reason. On sto-1 the catalyst-api has been running for 11 days and logs stopped appearing on 2024-11-02 17:48:43 with a log line cmd: failed to start [pod-mon.sh](http://pod-mon.sh/). It also lines up with the [high CPU spike on this node](https://eu-metrics-monitoring.livepeer.live/grafana/d/000000016/mist-global-overview?orgId=1&from=1730567946110&to=1730571641379&var-region=All&var-catalyst_node=All&viewPanel=2). Same story with sto-1 catalyst pod.

I guess we fail to run `pod-mon.sh` or mist cleanup script on high CPU/memory or it times out what results in never running these two scripts again.