### PR TITLE
Refactor to remove local catabalancer state

### DIFF
--- a/balancer/balancer.go
+++ b/balancer/balancer.go
@@ -5,7 +5,6 @@ package balancer
 import (
 	"context"
 
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/livepeer/catalyst-api/log"
 )
@@ -15,8 +14,6 @@ type Balancer interface {
 	UpdateMembers(ctx context.Context, members []cluster.Member) error
 	GetBestNode(ctx context.Context, redirectPrefixes []string, playbackID, lat, lon, fallbackPrefix string, isStudioReq bool) (string, string, error)
 	MistUtilLoadSource(ctx context.Context, streamID, lat, lon string) (string, error)
-	UpdateNodes(id string, nodeMetrics catabalancer.NodeMetrics)
-	UpdateStreams(id string, stream string, isIngest bool)
 }
 
 // CombinedBalancerEnabled checks if catabalancer is enabled in any way
@@ -105,16 +102,6 @@ func (c CombinedBalancer) MistUtilLoadSource(ctx context.Context, stream, lat, l
 		"stream", stream,
 	)
 	return dtscURL, err
-}
-
-func (c CombinedBalancer) UpdateNodes(id string, nodeMetrics catabalancer.NodeMetrics) {
-	c.Catabalancer.UpdateNodes(id, nodeMetrics)
-	c.MistBalancer.UpdateNodes(id, nodeMetrics)
-}
-
-func (c CombinedBalancer) UpdateStreams(id string, stream string, isIngest bool) {
-	c.Catabalancer.UpdateStreams(id, stream, isIngest)
-	c.MistBalancer.UpdateStreams(id, stream, isIngest)
 }
 
 type Config struct {

--- a/balancer/balancer_stub.go
+++ b/balancer/balancer_stub.go
@@ -5,8 +5,6 @@ package balancer
 import (
 	"context"
 	"fmt"
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
-
 	"github.com/livepeer/catalyst-api/cluster"
 )
 
@@ -48,10 +46,4 @@ func (b *BalancerStub) MistUtilLoadSource(ctx context.Context, stream, lat, lon 
 
 func (b *BalancerStub) MistUtilLoadStreamStats(ctx context.Context, stream string) error {
 	return fmt.Errorf("not implemented")
-}
-
-func (b *BalancerStub) UpdateNodes(id string, nodeMetrics catabalancer.NodeMetrics) {
-}
-
-func (b *BalancerStub) UpdateStreams(id string, stream string, isIngest bool) {
 }

--- a/balancer/catabalancer/catalyst_balancer.go
+++ b/balancer/catabalancer/catalyst_balancer.go
@@ -317,7 +317,6 @@ func (c *CataBalancer) RefreshNodes() (stats, error) {
 		NodeMetrics:   make(map[string]NodeMetrics),
 	}
 
-	log.LogNoRequestID("catabalancer refreshing nodes")
 	if c.NodeStatsDB == nil {
 		return s, fmt.Errorf("node stats DB was nil")
 	}

--- a/balancer/catabalancer/catalyst_balancer.go
+++ b/balancer/catabalancer/catalyst_balancer.go
@@ -17,15 +17,19 @@ import (
 )
 
 type CataBalancer struct {
-	NodeName            string // Node name of this instance
-	Nodes               map[string]*Node
-	nodesLock           sync.Mutex
-	Streams             map[string]Streams     // Node name -> Streams
-	IngestStreams       map[string]Streams     // Node name -> Streams
-	NodeMetrics         map[string]NodeMetrics // Node name -> NodeMetrics
+	NodeName  string // Node name of this instance
+	Nodes     map[string]*Node
+	nodesLock sync.Mutex
+
 	metricTimeout       time.Duration
 	ingestStreamTimeout time.Duration
 	NodeStatsDB         *sql.DB
+}
+
+type stats struct {
+	Streams       map[string]Streams     // Node name -> Streams
+	IngestStreams map[string]Streams     // Node name -> Streams
+	NodeMetrics   map[string]NodeMetrics // Node name -> NodeMetrics
 }
 
 type Streams map[string]Stream // Stream ID -> Stream
@@ -114,9 +118,6 @@ func NewBalancer(nodeName string, metricTimeout time.Duration, ingestStreamTimeo
 	return &CataBalancer{
 		NodeName:            nodeName,
 		Nodes:               make(map[string]*Node),
-		Streams:             make(map[string]Streams),
-		IngestStreams:       make(map[string]Streams),
-		NodeMetrics:         make(map[string]NodeMetrics),
 		metricTimeout:       metricTimeout,
 		ingestStreamTimeout: ingestStreamTimeout,
 		NodeStatsDB:         nodeStatsDB,
@@ -127,6 +128,7 @@ func (c *CataBalancer) Start(ctx context.Context) error {
 	return nil
 }
 
+// TODO not called anywhere but tests?
 func (c *CataBalancer) UpdateMembers(ctx context.Context, members []cluster.Member) error {
 	c.nodesLock.Lock()
 	defer c.nodesLock.Unlock()
@@ -142,35 +144,16 @@ func (c *CataBalancer) UpdateMembers(ctx context.Context, members []cluster.Memb
 		}
 	}
 
-	// remove stream data for nodes no longer present
-	for nodeName := range c.Streams {
-		if _, ok := latestNodes[nodeName]; !ok {
-			delete(c.Streams, nodeName)
-		}
-	}
-	for nodeName := range c.IngestStreams {
-		if _, ok := latestNodes[nodeName]; !ok {
-			delete(c.IngestStreams, nodeName)
-		}
-	}
-
-	// remove metric data for nodes no longer present
-	for nodeName := range c.NodeMetrics {
-		if _, ok := latestNodes[nodeName]; !ok {
-			delete(c.NodeMetrics, nodeName)
-		}
-	}
-
 	c.Nodes = latestNodes
 	return nil
 }
 
 func (c *CataBalancer) GetBestNode(ctx context.Context, redirectPrefixes []string, playbackID, lat, lon, fallbackPrefix string, isStudioReq bool) (string, string, error) {
-	if err := c.RefreshNodes(); err != nil {
+	s, err := c.RefreshNodes()
+	if err != nil {
 		return "", "", fmt.Errorf("error refreshing nodes: %w", err)
 	}
 
-	var err error
 	latf := 0.0
 	if lat != "" {
 		latf, err = strconv.ParseFloat(lat, 64)
@@ -189,7 +172,7 @@ func (c *CataBalancer) GetBestNode(ctx context.Context, redirectPrefixes []strin
 	// default to ourself if there are no other nodes
 	nodeName := c.NodeName
 
-	scoredNodes := c.createScoredNodes()
+	scoredNodes := c.createScoredNodes(s)
 	if len(scoredNodes) > 0 {
 		node, err := SelectNode(scoredNodes, playbackID, latf, lonf)
 		if err != nil {
@@ -207,12 +190,12 @@ func (c *CataBalancer) GetBestNode(ctx context.Context, redirectPrefixes []strin
 	return nodeName, fmt.Sprintf("%s+%s", prefix, playbackID), nil
 }
 
-func (c *CataBalancer) createScoredNodes() []ScoredNode {
+func (c *CataBalancer) createScoredNodes(s stats) []ScoredNode {
 	c.nodesLock.Lock()
 	defer c.nodesLock.Unlock()
 	var nodesList []ScoredNode
 	for nodeName, node := range c.Nodes {
-		metrics, ok := c.NodeMetrics[nodeName]
+		metrics, ok := s.NodeMetrics[nodeName]
 		if !ok {
 			continue
 		}
@@ -222,7 +205,7 @@ func (c *CataBalancer) createScoredNodes() []ScoredNode {
 		}
 		// make a copy of the streams map so that we can release the nodesLock (UpdateStreams will be making changes in the background)
 		streams := make(Streams)
-		for streamID, stream := range c.Streams[nodeName] {
+		for streamID, stream := range s.Streams[nodeName] {
 			if isStale(stream.Timestamp, c.metricTimeout) {
 				log.LogNoRequestID("catabalancer ignoring stale stream info", "nodeName", nodeName, "streamID", streamID, "timestamp", stream.Timestamp)
 				continue
@@ -232,7 +215,7 @@ func (c *CataBalancer) createScoredNodes() []ScoredNode {
 		nodesList = append(nodesList, ScoredNode{
 			Node:        *node,
 			Streams:     streams,
-			NodeMetrics: c.NodeMetrics[nodeName],
+			NodeMetrics: s.NodeMetrics[nodeName],
 		})
 	}
 	return nodesList
@@ -327,16 +310,22 @@ func truncateReturned(scoredNodes []ScoredNode, numNodes int) []ScoredNode {
 	return scoredNodes[:numNodes]
 }
 
-func (c *CataBalancer) RefreshNodes() error {
+func (c *CataBalancer) RefreshNodes() (stats, error) {
+	s := stats{
+		Streams:       make(map[string]Streams),
+		IngestStreams: make(map[string]Streams),
+		NodeMetrics:   make(map[string]NodeMetrics),
+	}
+
 	log.LogNoRequestID("catabalancer refreshing nodes")
 	if c.NodeStatsDB == nil {
-		return fmt.Errorf("node stats DB was nil")
+		return s, fmt.Errorf("node stats DB was nil")
 	}
 
 	query := "SELECT stats FROM node_stats"
 	rows, err := c.NodeStatsDB.Query(query)
 	if err != nil {
-		return fmt.Errorf("failed to query node stats: %w", err)
+		return s, fmt.Errorf("failed to query node stats: %w", err)
 	}
 	defer rows.Close()
 
@@ -344,46 +333,62 @@ func (c *CataBalancer) RefreshNodes() error {
 	for rows.Next() {
 		var statsBytes []byte
 		if err := rows.Scan(&statsBytes); err != nil {
-			return fmt.Errorf("failed to scan node stats row: %w", err)
+			return s, fmt.Errorf("failed to scan node stats row: %w", err)
 		}
 
 		var event NodeUpdateEvent
 		err = json.Unmarshal(statsBytes, &event)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal node update event: %w", err)
+			return s, fmt.Errorf("failed to unmarshal node update event: %w", err)
 		}
 
+		// TODO skip if node doesn't exist in c.Nodes too?
 		if isStale(event.NodeMetrics.Timestamp, c.metricTimeout) {
 			log.LogNoRequestID("catabalancer skipping stale data while refreshing", "nodeID", event.NodeID, "timestamp", event.NodeMetrics.Timestamp)
 			continue
 		}
 
-		c.UpdateNodes(event.NodeID, event.NodeMetrics)
+		s.NodeMetrics[event.NodeID] = event.NodeMetrics
+		s.Streams[event.NodeID] = make(Streams)
+		s.IngestStreams[event.NodeID] = make(Streams)
+
 		for _, stream := range event.GetStreams() {
-			c.UpdateStreams(event.NodeID, stream, false)
+			playbackID := getPlaybackID(stream)
+			s.Streams[event.NodeID][playbackID] = Stream{ID: stream, PlaybackID: playbackID, Timestamp: time.Now()}
 		}
 		for _, stream := range event.GetIngestStreams() {
-			c.UpdateStreams(event.NodeID, stream, true)
+			playbackID := getPlaybackID(stream)
+			s.IngestStreams[event.NodeID][stream] = Stream{ID: stream, PlaybackID: playbackID, Timestamp: time.Now()}
 		}
 	}
 
 	// Check for errors after iterating through rows
 	if err := rows.Err(); err != nil {
-		return err
+		return s, err
 	}
-	return nil
+	return s, nil
+}
+
+func getPlaybackID(streamID string) string {
+	playbackID := streamID
+	parts := strings.Split(streamID, "+")
+	if len(parts) == 2 {
+		playbackID = parts[1] // take the playbackID after the prefix e.g. 'video+'
+	}
+	return playbackID
 }
 
 func (c *CataBalancer) MistUtilLoadSource(ctx context.Context, streamID, lat, lon string) (string, error) {
-	if err := c.RefreshNodes(); err != nil {
+	s, err := c.RefreshNodes()
+	if err != nil {
 		return "", fmt.Errorf("error refreshing nodes: %w", err)
 	}
 
 	c.nodesLock.Lock()
 	defer c.nodesLock.Unlock()
 	for nodeName := range c.Nodes {
-		if s, ok := c.IngestStreams[nodeName][streamID]; ok {
-			if isStale(s.Timestamp, c.ingestStreamTimeout) {
+		if stream, ok := s.IngestStreams[nodeName][streamID]; ok {
+			if isStale(stream.Timestamp, c.ingestStreamTimeout) {
 				return "", fmt.Errorf("catabalancer no node found for ingest stream: %s stale: true", streamID)
 			}
 			dtsc := "dtsc://" + nodeName
@@ -394,58 +399,7 @@ func (c *CataBalancer) MistUtilLoadSource(ctx context.Context, streamID, lat, lo
 	return "", fmt.Errorf("catabalancer no node found for ingest stream: %s stale: false", streamID)
 }
 
-func (c *CataBalancer) checkAndCreateNode(nodeName string) {
-	if strings.HasPrefix(nodeName, "bgw") { // hack to ensure we ignore bgw nodes
-		return
-	}
-	if _, ok := c.Nodes[nodeName]; !ok {
-		c.Nodes[nodeName] = &Node{
-			Name: nodeName,
-		}
-	}
-}
-
-func (c *CataBalancer) UpdateNodes(nodeName string, nodeMetrics NodeMetrics) {
-	c.nodesLock.Lock()
-	defer c.nodesLock.Unlock()
-
-	c.checkAndCreateNode(nodeName)
-	nodeMetrics.Timestamp = time.Now()
-	c.NodeMetrics[nodeName] = nodeMetrics
-}
-
 var UpdateNodeStatsEvery = 5 * time.Second
-
-func (c *CataBalancer) UpdateStreams(nodeName string, streamID string, isIngest bool) {
-	c.nodesLock.Lock()
-	defer c.nodesLock.Unlock()
-
-	c.checkAndCreateNode(nodeName)
-	// remove old streams
-	removeOldStreams(c.Streams[nodeName], c.metricTimeout)
-	removeOldStreams(c.IngestStreams[nodeName], c.ingestStreamTimeout)
-
-	playbackID := streamID
-	parts := strings.Split(streamID, "+")
-	if len(parts) == 2 {
-		playbackID = parts[1] // take the playbackID after the prefix e.g. 'video+'
-	}
-
-	if isIngest {
-		if c.IngestStreams[nodeName] == nil {
-			c.IngestStreams[nodeName] = make(Streams)
-		}
-		// if a previous node had the stream, remove that entry
-		for name := range c.Nodes {
-			delete(c.IngestStreams[name], streamID)
-		}
-		c.IngestStreams[nodeName][streamID] = Stream{ID: streamID, PlaybackID: playbackID, Timestamp: time.Now()}
-	}
-	if c.Streams[nodeName] == nil {
-		c.Streams[nodeName] = make(Streams)
-	}
-	c.Streams[nodeName][playbackID] = Stream{ID: streamID, PlaybackID: playbackID, Timestamp: time.Now()}
-}
 
 func isStale(timestamp time.Time, stale time.Duration) bool {
 	return time.Since(timestamp) >= stale

--- a/balancer/catabalancer/catalyst_balancer_test.go
+++ b/balancer/catabalancer/catalyst_balancer_test.go
@@ -368,7 +368,7 @@ func TestMistUtilLoadSource(t *testing.T) {
 
 	err = c.UpdateMembers(context.Background(), []cluster.Member{})
 	require.NoError(t, err)
-	setNodeMetrics(t, mock, []NodeUpdateEvent{nodeStats})
+	setNodeMetrics(t, mock, []NodeUpdateEvent{})
 	source, err = c.MistUtilLoadSource(context.Background(), "ingest", "", "")
 	require.EqualError(t, err, "catabalancer no node found for ingest stream: ingest stale: false")
 	require.Empty(t, source)

--- a/balancer/mist/mist_balancer.go
+++ b/balancer/mist/mist_balancer.go
@@ -16,8 +16,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
-
 	"github.com/golang/glog"
 	"github.com/livepeer/catalyst-api/balancer"
 	"github.com/livepeer/catalyst-api/cluster"
@@ -495,12 +493,4 @@ func (b *MistBalancer) mistUtilLoadRequest(ctx context.Context, route, stream, l
 
 func (b *MistBalancer) mistAddr() string {
 	return fmt.Sprintf("http://%s:%d", b.config.MistHost, b.config.MistPort)
-}
-
-func (b *MistBalancer) UpdateNodes(id string, nodeMetrics catabalancer.NodeMetrics) {
-	//noop
-}
-
-func (b *MistBalancer) UpdateStreams(id string, stream string, isIngest bool) {
-	//noop
 }

--- a/handlers/events.go
+++ b/handlers/events.go
@@ -7,7 +7,6 @@ import (
 	"github.com/hashicorp/serf/serf"
 	"github.com/julienschmidt/httprouter"
 	"github.com/livepeer/catalyst-api/balancer"
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/livepeer/catalyst-api/errors"
 	"github.com/livepeer/catalyst-api/events"
@@ -15,7 +14,6 @@ import (
 	"github.com/xeipuuv/gojsonschema"
 	"io"
 	"net/http"
-	"strings"
 )
 
 type EventsHandlersCollection struct {
@@ -110,18 +108,6 @@ func (c *EventsHandlersCollection) ReceiveUserEvent() httprouter.Handle {
 			glog.V(5).Infof("received serf StopSessionsEvent: %v", event.PlaybackID)
 			c.mapic.StopSessions(event.PlaybackID)
 			return
-		case *catabalancer.NodeUpdateEvent:
-			if glog.V(5) {
-				glog.Infof("received serf NodeUpdateEvent. Node: %s. Length: %d bytes. Ingest Streams: %v. Non-Ingest Streams: %v", event.NodeID, len(userEventPayload), strings.Join(event.GetIngestStreams(), ","), strings.Join(event.GetStreams(), ","))
-			}
-
-			c.bal.UpdateNodes(event.NodeID, event.NodeMetrics)
-			for _, stream := range event.GetStreams() {
-				c.bal.UpdateStreams(event.NodeID, stream, false)
-			}
-			for _, stream := range event.GetIngestStreams() {
-				c.bal.UpdateStreams(event.NodeID, stream, true)
-			}
 		default:
 			glog.Errorf("unsupported serf event: %v", e)
 		}

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ func main() {
 	fs.IntVar(&config.MaxInFlightClipJobs, "max-inflight-clip-jobs", 20, "Maximum number of concurrent clipping jobs to support in catalyst-api")
 	fs.IntVar(&config.TranscodingParallelJobs, "parallel-transcode-jobs", 2, "Number of parallel transcode jobs")
 	fs.StringVar(&cli.CataBalancer, "catabalancer", "", "Enable catabalancer load balancer")
-	fs.DurationVar(&cli.CataBalancerMetricTimeout, "catabalancer-metric-timeout", 26*time.Second, "Catabalancer timeout for node metrics")
+	fs.DurationVar(&cli.CataBalancerMetricTimeout, "catabalancer-metric-timeout", 20*time.Second, "Catabalancer timeout for node metrics")
 	fs.DurationVar(&cli.CataBalancerIngestStreamTimeout, "catabalancer-ingest-stream-timeout", 20*time.Minute, "Catabalancer timeout for ingest stream metrics")
 	config.CommaSliceFlag(fs, &cli.BlockedJWTs, "gate-blocked-jwts", []string{}, "List of blocked JWTs for token gating")
 


### PR DESCRIPTION
Now that we're using a DB for the node stats we can remove the internal state for this data. The only state we still maintain in catabalancer is the list of nodes updated by serf.