### PR TITLE
Run background catabalancer calls really in the background

### DIFF
--- a/main.go
+++ b/main.go
@@ -238,8 +238,8 @@ func main() {
 		}
 
 		// Without this, we've run into issues with exceeding our open connection limit
-		nodeStatsDB.SetMaxOpenConns(50)
-		nodeStatsDB.SetMaxIdleConns(50)
+		nodeStatsDB.SetMaxOpenConns(2)
+		nodeStatsDB.SetMaxIdleConns(2)
 		nodeStatsDB.SetConnMaxLifetime(time.Hour)
 	} else if catabalancerEnabled {
 		glog.Infof("Catabalancer failed to start, NodeStatsConnectionString was not set")


### PR DESCRIPTION
I think to be safe we should execute these background calls in a separate goroutine, I don't want the risk of slow DB calls slowing down the real responses. I want to see the impact of the DB calls on the execution times, I'm not sure what size DB is appropriate at the moment.