### PR TITLE
Cache node stats db results

### DIFF
--- a/balancer/catabalancer/catalyst_balancer.go
+++ b/balancer/catabalancer/catalyst_balancer.go
@@ -117,13 +117,13 @@ func (n *NodeUpdateEvent) GetIngestStreams() []string {
 	return []string{}
 }
 
-func NewBalancer(nodeName string, metricTimeout time.Duration, ingestStreamTimeout time.Duration, nodeStatsDB *sql.DB) *CataBalancer {
+func NewBalancer(nodeName string, metricTimeout time.Duration, ingestStreamTimeout time.Duration, nodeStatsDB *sql.DB, cacheExpiry time.Duration) *CataBalancer {
 	return &CataBalancer{
 		NodeName:            nodeName,
 		metricTimeout:       metricTimeout,
 		ingestStreamTimeout: ingestStreamTimeout,
 		nodeStatsDB:         nodeStatsDB,
-		nodeStatsCache:      cache.New(500*time.Millisecond, 10*time.Minute),
+		nodeStatsCache:      cache.New(cacheExpiry, 10*time.Minute),
 	}
 }
 

--- a/config/cli.go
+++ b/config/cli.go
@@ -90,6 +90,7 @@ type Cli struct {
 	CataBalancer                    string
 	CataBalancerMetricTimeout       time.Duration
 	CataBalancerIngestStreamTimeout time.Duration
+	CataBalancerCacheExpiry         time.Duration
 	SerfQueueSize                   int
 	SerfEventBuffer                 int
 	SerfMaxQueueDepth               int

--- a/main.go
+++ b/main.go
@@ -84,6 +84,7 @@ func main() {
 	fs.StringVar(&cli.CataBalancer, "catabalancer", "", "Enable catabalancer load balancer")
 	fs.DurationVar(&cli.CataBalancerMetricTimeout, "catabalancer-metric-timeout", 20*time.Second, "Catabalancer timeout for node metrics")
 	fs.DurationVar(&cli.CataBalancerIngestStreamTimeout, "catabalancer-ingest-stream-timeout", 20*time.Minute, "Catabalancer timeout for ingest stream metrics")
+	fs.DurationVar(&cli.CataBalancerCacheExpiry, "catabalancer-cache-expiry", 500*time.Millisecond, "Catabalancer expiry for node stats cache")
 	config.CommaSliceFlag(fs, &cli.BlockedJWTs, "gate-blocked-jwts", []string{}, "List of blocked JWTs for token gating")
 
 	// mist-api-connector parameters
@@ -272,7 +273,7 @@ func main() {
 	} else {
 		bal = mist_balancer.NewRemoteBalancer(mistBalancerConfig)
 		if catabalancerEnabled && nodeStatsDB != nil {
-			cataBalancer := catabalancer.NewBalancer(cli.NodeName, cli.CataBalancerMetricTimeout, cli.CataBalancerIngestStreamTimeout, nodeStatsDB)
+			cataBalancer := catabalancer.NewBalancer(cli.NodeName, cli.CataBalancerMetricTimeout, cli.CataBalancerIngestStreamTimeout, nodeStatsDB, cli.CataBalancerCacheExpiry)
 			// Temporary combined balancer to test cataBalancer logic alongside existing mist balancer
 			bal = balancer.NewCombinedBalancer(cataBalancer, bal, cli.CataBalancer)
 		}


### PR DESCRIPTION
Background load balancer calls were seen taking multiple hours in prod (only on the regions with higher request rate) due to the relatively small number of connections available: https://github.com/livepeer/catalyst-api/blob/f0d8c83827abe68af240afa1a8dcfc894ec7c259/main.go#L241 so cache the results for a short time (500ms currently)