### PR TITLE
DB query coalescing - block other requests while refreshing the cache

### DIFF
--- a/balancer/catabalancer/catalyst_balancer_test.go
+++ b/balancer/catabalancer/catalyst_balancer_test.go
@@ -2,7 +2,6 @@ package catabalancer
 
 import (
 	"context"
-	"database/sql"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -11,6 +10,7 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 )
 
 var CPUOverloadedNode = ScoredNode{
@@ -42,17 +42,6 @@ var BandwidthOverloadedNode = ScoredNode{
 
 var mediaTags = map[string]string{"node": "media", "dtsc": "dtsc://nodedtsc"}
 
-func mockDB(t *testing.T) *sql.DB {
-	db, mock, err := sqlmock.New()
-	require.NoError(t, err)
-	for i := 0; i < 10; i++ {
-		mock.ExpectQuery("SELECT stats FROM node_stats").
-			WillReturnRows(sqlmock.NewRows([]string{"stats"}).AddRow("{}"))
-
-	}
-	return db
-}
-
 func setNodeMetrics(t *testing.T, mock sqlmock.Sqlmock, nodeStats []NodeUpdateEvent) {
 	rows := sqlmock.NewRows([]string{"stats"})
 	for _, s := range nodeStats {
@@ -65,7 +54,11 @@ func setNodeMetrics(t *testing.T, mock sqlmock.Sqlmock, nodeStats []NodeUpdateEv
 }
 
 func TestItReturnsItselfWhenNoOtherNodesPresent(t *testing.T) {
-	c := NewBalancer("me", time.Second, time.Second, mockDB(t), 0)
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	mock.ExpectQuery("SELECT stats FROM node_stats").
+		WillReturnRows(sqlmock.NewRows([]string{"stats"}).AddRow("{}"))
+	c := NewBalancer("me", time.Second, time.Second, db, 0)
 	nodeName, prefix, err := c.GetBestNode(context.Background(), nil, "playbackID", "", "", "", false)
 	require.NoError(t, err)
 	require.Equal(t, "me", nodeName)
@@ -363,15 +356,24 @@ func TestMistUtilLoadSource(t *testing.T) {
 	nodeStats.SetStreams([]string{"stream"}, []string{"ingest"})
 	setNodeMetrics(t, mock, []NodeUpdateEvent{nodeStats})
 
-	source, err := c.MistUtilLoadSource(context.Background(), "ingest", "", "")
+	// simulate two calls in parallel, due to caching and request coalescing there will still only be one
+	// db call set up above with setNodeMetrics()
+	eg := errgroup.Group{}
+	eg.Go(func() error {
+		source, err := c.MistUtilLoadSource(context.Background(), "ingest", "", "")
+		require.NoError(t, err)
+		require.Equal(t, "dtsc://node", source)
+		return nil
+	})
+	_, err = c.MistUtilLoadSource(context.Background(), "ingest", "", "")
 	require.NoError(t, err)
-	require.Equal(t, "dtsc://node", source)
+	require.NoError(t, eg.Wait())
 
 	time.Sleep(2 * time.Millisecond)
 	err = c.UpdateMembers(context.Background(), []cluster.Member{})
 	require.NoError(t, err)
 	setNodeMetrics(t, mock, []NodeUpdateEvent{})
-	source, err = c.MistUtilLoadSource(context.Background(), "ingest", "", "")
+	source, err := c.MistUtilLoadSource(context.Background(), "ingest", "", "")
 	require.EqualError(t, err, "catabalancer no node found for ingest stream: ingest stale: false")
 	require.Empty(t, source)
 }
@@ -391,7 +393,7 @@ func TestStreamTimeout(t *testing.T) {
 	nodeStats := NodeUpdateEvent{NodeID: "node", NodeMetrics: NodeMetrics{Timestamp: time.Now()}}
 	nodeStats.SetStreams([]string{"video+stream"}, []string{"video+ingest"})
 	setNodeMetrics(t, mock, []NodeUpdateEvent{nodeStats})
-	s, err := c.refreshNodes()
+	s, err := c.refreshNodes(context.Background())
 	require.NoError(t, err)
 	setNodeMetrics(t, mock, []NodeUpdateEvent{nodeStats})
 

--- a/balancer/catabalancer/catalyst_balancer_test.go
+++ b/balancer/catabalancer/catalyst_balancer_test.go
@@ -458,3 +458,42 @@ func TestSimulate(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+func TestItCanMarshalAndUnMarshalStreamIDs(t *testing.T) {
+	n := NodeUpdateEvent{}
+	n.SetStreams([]string{"noningest1", "noningest2"}, []string{"ingest1", "ingest2"})
+	jsonBytes, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var n2 NodeUpdateEvent
+	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
+
+	require.Equal(t, []string{"noningest1", "noningest2"}, n2.GetStreams())
+	require.Equal(t, []string{"ingest1", "ingest2"}, n2.GetIngestStreams())
+}
+
+func TestItCanMarshalAndUnMarshalStreamIDsWithNoIngestStreams(t *testing.T) {
+	n := NodeUpdateEvent{}
+	n.SetStreams([]string{"noningest1", "noningest2"}, []string{})
+	jsonBytes, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var n2 NodeUpdateEvent
+	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
+
+	require.Equal(t, []string{"noningest1", "noningest2"}, n2.GetStreams())
+	require.Equal(t, []string{}, n2.GetIngestStreams())
+}
+
+func TestItCanMarshalAndUnMarshalStreamIDsWithNoNonIngestStreams(t *testing.T) {
+	n := NodeUpdateEvent{}
+	n.SetStreams([]string{}, []string{"ingest1", "ingest2"})
+	jsonBytes, err := json.Marshal(n)
+	require.NoError(t, err)
+
+	var n2 NodeUpdateEvent
+	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
+
+	require.Equal(t, []string{}, n2.GetStreams())
+	require.Equal(t, []string{"ingest1", "ingest2"}, n2.GetIngestStreams())
+}

--- a/events/events.go
+++ b/events/events.go
@@ -1,20 +1,13 @@
 package events
 
 import (
-	"database/sql"
 	"encoding/json"
 	"fmt"
-	"time"
-
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
-	"github.com/livepeer/catalyst-api/clients"
-	"github.com/livepeer/catalyst-api/log"
 )
 
 const streamEventResource = "stream"
 const nukeEventResource = "nuke"
 const stopSessionsEventResource = "stopSessions"
-const nodeUpdateEventResource = "nodeUpdate"
 
 type Event interface{}
 
@@ -65,80 +58,6 @@ func Unmarshal(payload []byte) (Event, error) {
 			return nil, err
 		}
 		return event, nil
-	case nodeUpdateEventResource:
-		event := &catabalancer.NodeUpdateEvent{}
-		err := json.Unmarshal(payload, event)
-		if err != nil {
-			return nil, err
-		}
-		return event, nil
 	}
 	return nil, fmt.Errorf("unable to unmarshal event, unknown resource '%s'", generic.Resource)
-}
-
-func StartMetricSending(nodeName string, latitude float64, longitude float64, mist clients.MistAPIClient, nodeStatsDB *sql.DB) {
-	ticker := time.NewTicker(catabalancer.UpdateNodeStatsEvery)
-	go func() {
-		for range ticker.C {
-			sysusage, err := catabalancer.GetSystemUsage()
-			if err != nil {
-				log.LogNoRequestID("catabalancer failed to get sys usage", "err", err)
-				continue
-			}
-
-			event := catabalancer.NodeUpdateEvent{
-				Resource: nodeUpdateEventResource,
-				NodeID:   nodeName,
-				NodeMetrics: catabalancer.NodeMetrics{
-					CPUUsagePercentage:       sysusage.CPUUsagePercentage,
-					RAMUsagePercentage:       sysusage.RAMUsagePercentage,
-					BandwidthUsagePercentage: sysusage.BWUsagePercentage,
-					LoadAvg:                  sysusage.LoadAvg.Load5Min,
-					GeoLatitude:              latitude,
-					GeoLongitude:             longitude,
-					Timestamp:                time.Now(),
-				},
-			}
-
-			if mist != nil {
-				mistState, err := mist.GetState()
-				if err != nil {
-					log.LogNoRequestID("catabalancer failed to get mist state", "err", err)
-					continue
-				}
-
-				var nonIngestStreams, ingestStreams []string
-				for streamID := range mistState.ActiveStreams {
-					if mistState.IsIngestStream(streamID) {
-						ingestStreams = append(ingestStreams, streamID)
-					} else {
-						nonIngestStreams = append(nonIngestStreams, streamID)
-					}
-				}
-				event.SetStreams(nonIngestStreams, ingestStreams)
-			}
-
-			payload, err := json.Marshal(event)
-			if err != nil {
-				log.LogNoRequestID("catabalancer failed to marhsal node update", "err", err)
-				continue
-			}
-
-			insertStatement := `insert into "node_stats"(
-                            "node_id",
-                            "stats"
-                            ) values($1, $2)
-							ON CONFLICT (node_id)
-							DO UPDATE SET stats = EXCLUDED.stats;`
-			_, err = nodeStatsDB.Exec(
-				insertStatement,
-				nodeName,
-				payload,
-			)
-			if err != nil {
-				log.LogNoRequestID("error writing postgres node stats", "err", err)
-				continue
-			}
-		}
-	}()
 }

--- a/events/events_test.go
+++ b/events/events_test.go
@@ -1,10 +1,8 @@
 package events
 
 import (
-	"encoding/json"
 	"testing"
 
-	"github.com/livepeer/catalyst-api/balancer/catabalancer"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,43 +45,4 @@ func TestItFailsBadShapes(t *testing.T) {
 		_, err := Unmarshal(payload)
 		require.Error(t, err)
 	}
-}
-
-func TestItCanMarshalAndUnMarshalStreamIDs(t *testing.T) {
-	n := catabalancer.NodeUpdateEvent{}
-	n.SetStreams([]string{"noningest1", "noningest2"}, []string{"ingest1", "ingest2"})
-	jsonBytes, err := json.Marshal(n)
-	require.NoError(t, err)
-
-	var n2 catabalancer.NodeUpdateEvent
-	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
-
-	require.Equal(t, []string{"noningest1", "noningest2"}, n2.GetStreams())
-	require.Equal(t, []string{"ingest1", "ingest2"}, n2.GetIngestStreams())
-}
-
-func TestItCanMarshalAndUnMarshalStreamIDsWithNoIngestStreams(t *testing.T) {
-	n := catabalancer.NodeUpdateEvent{}
-	n.SetStreams([]string{"noningest1", "noningest2"}, []string{})
-	jsonBytes, err := json.Marshal(n)
-	require.NoError(t, err)
-
-	var n2 catabalancer.NodeUpdateEvent
-	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
-
-	require.Equal(t, []string{"noningest1", "noningest2"}, n2.GetStreams())
-	require.Equal(t, []string{}, n2.GetIngestStreams())
-}
-
-func TestItCanMarshalAndUnMarshalStreamIDsWithNoNonIngestStreams(t *testing.T) {
-	n := catabalancer.NodeUpdateEvent{}
-	n.SetStreams([]string{}, []string{"ingest1", "ingest2"})
-	jsonBytes, err := json.Marshal(n)
-	require.NoError(t, err)
-
-	var n2 catabalancer.NodeUpdateEvent
-	require.NoError(t, json.Unmarshal(jsonBytes, &n2))
-
-	require.Equal(t, []string{}, n2.GetStreams())
-	require.Equal(t, []string{"ingest1", "ingest2"}, n2.GetIngestStreams())
 }

--- a/main.go
+++ b/main.go
@@ -28,7 +28,6 @@ import (
 	"github.com/livepeer/catalyst-api/cluster"
 	"github.com/livepeer/catalyst-api/config"
 	"github.com/livepeer/catalyst-api/crypto"
-	"github.com/livepeer/catalyst-api/events"
 	"github.com/livepeer/catalyst-api/handlers/misttriggers"
 	mistapiconnector "github.com/livepeer/catalyst-api/mapic"
 	"github.com/livepeer/catalyst-api/middleware"
@@ -267,7 +266,7 @@ func main() {
 
 		if catabalancerEnabled && nodeStatsDB != nil {
 			if cli.Tags["node"] == "media" { // don't announce load balancing availability for testing nodes
-				events.StartMetricSending(cli.NodeName, cli.NodeLatitude, cli.NodeLongitude, mist, nodeStatsDB)
+				catabalancer.StartMetricSending(cli.NodeName, cli.NodeLatitude, cli.NodeLongitude, mist, nodeStatsDB)
 			}
 		}
 	} else {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -46,6 +46,7 @@ type CatalystAPIMetrics struct {
 	SerfEventBufferSize             prometheus.Gauge
 	AccessControlRequestCount       *prometheus.CounterVec
 	AccessControlRequestDurationSec *prometheus.SummaryVec
+	CatabalancerRequestDurationSec  *prometheus.HistogramVec
 
 	JobsInFlight         prometheus.Gauge
 	HTTPRequestsInFlight prometheus.Gauge
@@ -126,6 +127,11 @@ func NewMetrics() *CatalystAPIMetrics {
 			Name: "access_control_request_duration_seconds",
 			Help: "The latency of the access control requests",
 		}, []string{"allowed", "playbackID"}),
+		CatabalancerRequestDurationSec: promauto.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "catabalancer_request_duration",
+			Help:    "Time taken for catabalancer load balancing requests",
+			Buckets: []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10},
+		}, []string{"success", "request_type", "mist_match", "background"}),
 
 		// Clients metrics
 		TranscodingStatusUpdate: ClientMetrics{


### PR DESCRIPTION
I found that even with caching there were still requests to the DB taking 1+ seconds, this would happen when a number of concurrent requests hit a cache expiry. So instead of letting these all make a request to the DB, allow one through while making the other wait behind.